### PR TITLE
Docker fixes, dual databases, and Drizzle Studio

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,5 +2,6 @@
 BETTER_AUTH_SECRET=""
 BETTER_AUTH_URL=http://localhost:3501
 CLIENT_ORIGIN=http://localhost:3500
-DATABASE_URL=postgres://bigset:bigset@localhost:5432/bigset
+DATABASE_URL=postgres://bigset:bigset@localhost:5432/bigset_internal
+DATA_DATABASE_URL=postgres://bigset:bigset@localhost:5432/bigset_data
 PORT=3501

--- a/backend/src/data-db.ts
+++ b/backend/src/data-db.ts
@@ -1,0 +1,5 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+
+import { env } from "./env.js";
+
+export const dataDb = drizzle(env.DATA_DATABASE_URL);

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -13,5 +13,6 @@ export const env = {
   BETTER_AUTH_URL: required("BETTER_AUTH_URL"),
   CLIENT_ORIGIN: process.env.CLIENT_ORIGIN || "http://localhost:3500",
   DATABASE_URL: required("DATABASE_URL"),
+  DATA_DATABASE_URL: required("DATA_DATABASE_URL"),
   PORT: Number(process.env.PORT || "3501"),
 };

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,0 +1,3 @@
+-- POSTGRES_DB (bigset_internal) is created automatically by the Postgres image.
+-- This script creates the second database for user datasets.
+CREATE DATABASE bigset_data;

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -33,6 +33,19 @@ services:
       db:
         condition: service_healthy
 
+  studio:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.dev
+    ports:
+      - "4983:4983"
+    environment:
+      DATABASE_URL: postgres://bigset:bigset@db:5432/bigset
+    depends_on:
+      db:
+        condition: service_healthy
+    command: ["npx", "drizzle-kit", "studio", "--host", "0.0.0.0"]
+
   frontend:
     build:
       context: ./frontend
@@ -45,6 +58,7 @@ services:
       - ./frontend/public:/app/public
     environment:
       NEXT_PUBLIC_AUTH_URL: http://localhost:3500
+      BACKEND_URL: http://backend:3501
     depends_on:
       - backend
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,14 +6,15 @@ services:
     environment:
       POSTGRES_USER: bigset
       POSTGRES_PASSWORD: bigset
-      POSTGRES_DB: bigset
+      POSTGRES_DB: bigset_internal
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U bigset -d bigset"]
+      test: ["CMD-SHELL", "pg_isready -U bigset -d bigset_internal"]
       interval: 5s
       timeout: 5s
       retries: 10
     volumes:
       - pgdata:/var/lib/postgresql/data
+      - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql
 
   backend:
     build:
@@ -27,24 +28,38 @@ services:
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-dev-secret-change-me-in-production}
       BETTER_AUTH_URL: http://localhost:3501
       CLIENT_ORIGIN: http://localhost:3500
-      DATABASE_URL: postgres://bigset:bigset@db:5432/bigset
+      DATABASE_URL: postgres://bigset:bigset@db:5432/bigset_internal
+      DATA_DATABASE_URL: postgres://bigset:bigset@db:5432/bigset_data
       PORT: 3501
     depends_on:
       db:
         condition: service_healthy
 
-  studio:
+  studio-internal:
     build:
       context: ./backend
       dockerfile: Dockerfile.dev
     ports:
-      - "4983:4983"
+      - "3600:3600"
     environment:
-      DATABASE_URL: postgres://bigset:bigset@db:5432/bigset
+      DATABASE_URL: postgres://bigset:bigset@db:5432/bigset_internal
     depends_on:
       db:
         condition: service_healthy
-    command: ["npx", "drizzle-kit", "studio", "--host", "0.0.0.0"]
+    command: ["npx", "drizzle-kit", "studio", "--host", "0.0.0.0", "--port", "3600"]
+
+  studio-data:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.dev
+    ports:
+      - "3601:3601"
+    environment:
+      DATABASE_URL: postgres://bigset:bigset@db:5432/bigset_data
+    depends_on:
+      db:
+        condition: service_healthy
+    command: ["npx", "drizzle-kit", "studio", "--host", "0.0.0.0", "--port", "3601"]
 
   frontend:
     build:

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -2,7 +2,7 @@ FROM node:22-alpine
 
 WORKDIR /app
 
-RUN npm install -g bun
+RUN npm install -g bun && chown node:node /app
 
 COPY --chown=node:node package.json bun.lock ./
 USER node


### PR DESCRIPTION
## Summary

- **Fix frontend Dockerfile permissions**: `WORKDIR /app` is created as root, but `USER node` switches before `bun install`. Added `chown node:node /app` so it can create `node_modules`.

- **Fix Docker networking for auth proxy**: Inside Docker, `localhost` means the container itself. Added `BACKEND_URL=http://backend:3501` so the Next.js rewrite proxies auth requests to the backend container correctly.

- **Dual Postgres databases**: Split into `bigset_internal` (auth/app tables) and `bigset_data` (user-created dataset tables) on the same Postgres instance. `db/init.sql` creates the second database on first startup. Backend gets `DATA_DATABASE_URL` env var and a second Drizzle instance (`data-db.ts`).

- **Drizzle Studio x2**: Two studio services for browsing each database during dev:
  - `:3600` — `bigset_internal` (auth tables)
  - `:3601` — `bigset_data` (dataset tables)

## Port map

| Port | Service |
|------|---------|
| 3500 | Frontend (Next.js) |
| 3501 | Backend (Fastify) |
| 3600 | Drizzle Studio — internal |
| 3601 | Drizzle Studio — data |
| 5432 | Postgres |

## Test plan

- [ ] `make dev` — all five services start (db, backend, frontend, studio-internal, studio-data)
- [ ] Sign up at localhost:3500/auth/sign-up — works (no ECONNREFUSED)
- [ ] Open https://local.drizzle.studio?port=3600 — shows auth tables with new user
- [ ] Open https://local.drizzle.studio?port=3601 — connects to empty bigset_data
- [ ] `make down` then `make dev` — data persists
- [ ] `make clean` then `make dev` — fresh start, both databases recreated

🤖 Generated with [Claude Code](https://claude.com/claude-code)