### PR TITLE
fix: chown /app before USER node so bun install can write node_modules

### DIFF
--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -2,7 +2,7 @@ FROM node:22-alpine
 
 WORKDIR /app
 
-RUN npm install -g bun
+RUN npm install -g bun && chown node:node /app
 
 COPY --chown=node:node package.json bun.lock ./
 USER node


### PR DESCRIPTION
## Problem

A fresh `make dev` fails on the frontend image build with:

```
#18 [frontend 5/6] RUN bun install
#18 0.200 bun install v1.3.14 (0d9b296a)
#18 0.208 EACCES: Permission denied: could not create the "node_modules" directory (mkdir)
#18 ERROR: process "/bin/sh -c bun install" did not complete successfully: exit code: 1
```

## Cause

`frontend/Dockerfile.dev` does:

```dockerfile
WORKDIR /app
RUN npm install -g bun
COPY --chown=node:node package.json bun.lock ./
USER node
RUN bun install
```

`WORKDIR /app` creates `/app` owned by root. `USER node` drops privileges before `bun install`, but `/app` itself is still root-owned, so `bun` cannot create `node_modules` inside it. `COPY --chown=node:node` only fixes the copied files, not the parent directory.

## Fix

Chown `/app` to `node` in the same `RUN` that installs bun:

```dockerfile
RUN npm install -g bun && chown node:node /app
```

One-line change. No new layers.

## Verification

`make dev` succeeds on a fresh clone; frontend starts and `Ready in 600ms` shows in logs.