### PR TITLE
feat: ALLOWED_DEV_ORIGINS env for cross-origin dev mode

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,6 +1,18 @@
 import type { NextConfig } from "next";
 
+// Hosts allowed to load /_next/* dev resources from this dev server.
+// Next.js 16 blocks cross-origin dev requests by default; without this,
+// running `next dev` behind any reverse proxy or non-localhost origin
+// silently breaks HMR and React hydration.
+// Set ALLOWED_DEV_ORIGINS as a comma-separated list, e.g.
+//   ALLOWED_DEV_ORIGINS=bigset.example.com,staging.example.com
+const allowedDevOrigins = (process.env.ALLOWED_DEV_ORIGINS || "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
 const nextConfig: NextConfig = {
+  allowedDevOrigins,
   async rewrites() {
     return [
       {


### PR DESCRIPTION
## Problem

Next.js 16 blocks cross-origin requests to `/_next/*` dev resources by default. When `next dev` runs behind a reverse proxy (or any non-localhost origin), HMR and the dev chunk loader get blocked, which silently breaks React hydration.

Concrete failure mode: page loads, looks fine, but **React never hydrates**. The form on `/auth/sign-up` submits natively as a GET to `/auth/sign-up?` (form action defaults to the page URL, inputs lack `name` attributes so the URL has no query). No POST to `/api/auth/sign-up/email`, no user created, no visible error. Looks like the app is broken.

This is the dev-mode log warning that appears server-side:

```
⚠ Blocked cross-origin request to Next.js dev resource /_next/webpack-hmr from "bigset.example.com".
Cross-origin access to Next.js dev resources is blocked by default for safety.
```

## Fix

Plumb `ALLOWED_DEV_ORIGINS` (comma-separated) through `NextConfig.allowedDevOrigins`. Default stays empty so plain `localhost` dev is unchanged.

```bash
ALLOWED_DEV_ORIGINS=bigset.example.com bun dev
```

Twelve added lines, zero behavior change for current users.

Ref: https://nextjs.org/docs/app/api-reference/config/next-config-js/allowedDevOrigins