### PR TITLE
fix: set BACKEND_URL on frontend so docker-compose auth proxy works

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -45,6 +45,7 @@ services:
       - ./frontend/public:/app/public
     environment:
       NEXT_PUBLIC_AUTH_URL: http://localhost:3500
+      BACKEND_URL: http://backend:3501
     depends_on:
       - backend
 


### PR DESCRIPTION
## Problem

In `make dev`, all Better Auth requests fail because the frontend's `/api/auth/*` rewrite has no way to reach the backend container.

`frontend/next.config.ts` has:

```ts
destination: `${process.env.BACKEND_URL || "http://localhost:3501"}/api/auth/:path*`
```

The `localhost` fallback is correct for **native** dev (running `bun dev` directly on the host alongside the backend on the same machine). But inside Docker, the frontend container's `localhost:3501` resolves to **itself**, not to the backend service. The frontend doesn't listen on 3501, so the rewrite 404s.

Net effect: sign-up / sign-in / sessions all fail silently from a docker-compose-only environment.

## Fix

Set `BACKEND_URL: http://backend:3501` on the frontend service in `docker-compose.dev.yml`. The Docker bridge already resolves `backend` to the backend service container — no other change needed.

One line.

## Verification

Before: `POST /api/auth/sign-up/email` returns 404.
After: 200 + session cookie + user row in Postgres.