### PR TITLE
fix: make benchmark required columns conservative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .env
 .env.local
 Project_BigSet_brief.md
+benchmark-results/

--- a/backend/src/dataset-agent/ai-sdk-runtime.ts
+++ b/backend/src/dataset-agent/ai-sdk-runtime.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import {
   emptyMetrics,
   emptyUsage,
+  minimumRequiredColumnsForRunInput,
   normalizeDatasetAgentResult,
   parseOutputFromText,
 } from "./output.js";
@@ -202,25 +203,32 @@ function createToolLoopAgent(input: CreateAiSdkAgentInput): AiSdkAgentLike {
 }
 
 function createInstructions(input: DatasetAgentRunInput): string {
+  const minimumRequiredColumns = minimumRequiredColumnsForRunInput(input);
+
   return [
     "You are BigSet's dataset collection agent.",
     "Build source-backed rows from web data. Never guess missing facts.",
     "Use search first, fetch source pages next, and browser automation only when fetch cannot verify the requested value.",
     "Every row must include cells, sourceUrls, and evidence quotes copied from source text or browser output.",
     "Set needsReview true when the source is weak, ambiguous, stale, or incomplete.",
-    `Required columns: ${input.requiredColumns.join(", ")}`,
+    `Requested columns: ${input.requiredColumns.join(", ")}`,
+    `Minimum required columns for accepting a row: ${minimumRequiredColumns.join(", ") || "none"}`,
+    "Missing requested columns outside the minimum should be null or omitted, not invented.",
   ].join("\n");
 }
 
 function createPrompt(input: DatasetAgentRunInput): string {
+  const minimumRequiredColumns = minimumRequiredColumnsForRunInput(input);
+
   return JSON.stringify({
     promptId: input.promptId,
     promptQuality: input.promptQuality,
     userRequest: input.prompt,
-    requiredColumns: input.requiredColumns,
+    requestedColumns: input.requiredColumns,
+    minimumRequiredColumns,
     outputShape: {
       rows:
-        "Array of rows with cells keyed by required column, sourceUrls, evidence, needsReview.",
+        "Array of rows with cells keyed by requested column when source-backed, sourceUrls, evidence, needsReview.",
       validationIssues:
         "Concrete validation problems. Empty only when all rows are source-backed.",
     },
@@ -232,17 +240,21 @@ function createRepairPrompt(input: {
   invalidOutput: unknown;
   validationIssues: string[];
 }): string {
+  const minimumRequiredColumns = minimumRequiredColumnsForRunInput(input.input);
+
   return JSON.stringify({
     task: "Repair the previous dataset-agent output. Use tools again if needed. Return only valid source-backed rows.",
     userRequest: input.input.prompt,
-    requiredColumns: input.input.requiredColumns,
+    requestedColumns: input.input.requiredColumns,
+    minimumRequiredColumns,
     validationIssues: input.validationIssues,
     invalidOutput: input.invalidOutput,
     repairRules: [
       "Do not invent values.",
       "Every row needs at least one source URL.",
       "Every row needs at least one evidence quote.",
-      "Every required column must be present or the row should be omitted.",
+      "Every minimum required column must be present or the row should be omitted.",
+      "Requested columns outside the minimum can be null or missing when the source does not prove them.",
       "If source-backed rows cannot be produced, return rows: [] and validationIssues explaining why.",
     ],
   });

--- a/backend/src/dataset-agent/output.ts
+++ b/backend/src/dataset-agent/output.ts
@@ -22,6 +22,19 @@ export function emptyMetrics(): DatasetAgentMetrics {
   };
 }
 
+export function minimumRequiredColumnsForRunInput(
+  input: DatasetAgentRunInput
+): string[] {
+  const configuredMinimumColumns = uniqueStrings(
+    input.minimumRequiredColumns ?? []
+  );
+  if (configuredMinimumColumns.length > 0) {
+    return configuredMinimumColumns;
+  }
+
+  return inferConservativeMinimumRequiredColumns(input.requiredColumns);
+}
+
 export function normalizeDatasetAgentResult(input: {
   rawOutput: unknown;
   runInput: DatasetAgentRunInput;
@@ -43,7 +56,7 @@ export function normalizeDatasetAgentResult(input: {
     ),
     ...validateRows({
       rows,
-      requiredColumns: input.runInput.requiredColumns,
+      minimumRequiredColumns: minimumRequiredColumnsForRunInput(input.runInput),
     }),
   ];
 
@@ -168,7 +181,7 @@ function normalizeEvidence(
 
 function validateRows(input: {
   rows: DatasetAgentRow[];
-  requiredColumns: string[];
+  minimumRequiredColumns: string[];
 }): string[] {
   const issues: string[] = [];
   if (input.rows.length === 0) {
@@ -182,14 +195,87 @@ function validateRows(input: {
     if (row.evidence.length === 0) {
       issues.push(`Row ${rowIndex} has no evidence quote.`);
     }
-    for (const columnName of input.requiredColumns) {
+    for (const columnName of input.minimumRequiredColumns) {
       if (!isPresent(row.cells[columnName])) {
-        issues.push(`Row ${rowIndex} missing required column ${columnName}.`);
+        issues.push(`Row ${rowIndex} missing minimum required column ${columnName}.`);
       }
     }
   }
 
   return issues;
+}
+
+function inferConservativeMinimumRequiredColumns(columns: string[]): string[] {
+  const requestedColumns = uniqueStrings(columns);
+  const identityPriority = [
+    "entity_name",
+    "company_name",
+    "organization_name",
+    "provider_name",
+    "restaurant_name",
+    "store_name",
+    "business_name",
+    "bakery_name",
+    "product_name",
+    "person_name",
+    "profile_name",
+    "docs_title",
+    "latest_item_title",
+    "open_role_title",
+  ];
+  const identityUrlPriority = [
+    "company_domain",
+    "official_website",
+    "official_source_url",
+    "profile_url",
+    "linkedin_url",
+    "product_url",
+    "website_url",
+    "docs_url",
+    "careers_page_url",
+    "quote_page_url",
+    "menu_url",
+    "pricing_page_url",
+  ];
+
+  const prioritizedIdentityColumn = identityPriority.find((columnName) =>
+    requestedColumns.includes(columnName)
+  );
+  if (prioritizedIdentityColumn) {
+    return [prioritizedIdentityColumn];
+  }
+
+  const nameColumn = requestedColumns.find((columnName) =>
+    /(^|_)name$/.test(columnName)
+  );
+  if (nameColumn) {
+    return [nameColumn];
+  }
+
+  const titleColumn = requestedColumns.find((columnName) =>
+    /(^|_)title$/.test(columnName)
+  );
+  if (titleColumn) {
+    return [titleColumn];
+  }
+
+  const identityUrlColumn = identityUrlPriority.find((columnName) =>
+    requestedColumns.includes(columnName)
+  );
+  if (identityUrlColumn) {
+    return [identityUrlColumn];
+  }
+
+  const fallbackIdentityColumn = requestedColumns.find(
+    (columnName) =>
+      columnName !== "source_url" &&
+      !columnName.endsWith("_at") &&
+      !columnName.includes("score") &&
+      !columnName.startsWith("is_") &&
+      !columnName.startsWith("has_")
+  );
+
+  return fallbackIdentityColumn ? [fallbackIdentityColumn] : [];
 }
 
 function normalizeUsage(value: unknown): DatasetAgentUsage {
@@ -270,6 +356,10 @@ function stringArrayValue(value: unknown): string[] {
     return value.filter((item): item is string => typeof item === "string");
   }
   return typeof value === "string" ? [value] : [];
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values.filter((value) => value.length > 0)));
 }
 
 function singleStringArray(value: unknown): string[] {

--- a/backend/src/dataset-agent/run-benchmark-adapter.ts
+++ b/backend/src/dataset-agent/run-benchmark-adapter.ts
@@ -5,19 +5,31 @@ import { runDatasetAgentFromEnv } from "./index.js";
 const prompt = requiredEnv("BIGSET_BENCHMARK_PROMPT");
 const promptId = process.env.BIGSET_BENCHMARK_PROMPT_ID;
 const promptQuality = process.env.BIGSET_BENCHMARK_PROMPT_QUALITY;
-const requiredColumns = requiredEnv("BIGSET_BENCHMARK_REQUIRED_COLUMNS")
-  .split(",")
-  .map((columnName) => columnName.trim())
-  .filter(Boolean);
+const requiredColumns = columnList(requiredEnv("BIGSET_BENCHMARK_REQUIRED_COLUMNS"));
+const minimumRequiredColumns = columnListEnv(
+  "BIGSET_BENCHMARK_MINIMUM_REQUIRED_COLUMNS"
+);
 
 const result = await runDatasetAgentFromEnv({
   prompt,
   promptId,
   promptQuality,
   requiredColumns,
+  minimumRequiredColumns,
 });
 
 console.log(JSON.stringify(result));
+
+function columnListEnv(name: string): string[] {
+  return columnList(process.env[name] ?? "");
+}
+
+function columnList(value: string): string[] {
+  return value
+  .split(",")
+  .map((columnName) => columnName.trim())
+  .filter(Boolean);
+}
 
 function requiredEnv(name: string): string {
   const value = process.env[name];

--- a/backend/src/dataset-agent/types.ts
+++ b/backend/src/dataset-agent/types.ts
@@ -10,7 +10,17 @@ export interface DatasetAgentRunInput {
   prompt: string;
   promptId?: string;
   promptQuality?: string;
+  /**
+   * Columns the caller wants back for scoring/completeness. These are not all
+   * hard row-acceptance requirements.
+   */
   requiredColumns: string[];
+  /**
+   * Tiny identity fields that must be present before a row can be accepted.
+   * When omitted, the runtime infers a conservative identity column from
+   * requiredColumns.
+   */
+  minimumRequiredColumns?: string[];
 }
 
 export interface DatasetAgentEvidence {

--- a/backend/test/dataset-agent-oracle.test.ts
+++ b/backend/test/dataset-agent-oracle.test.ts
@@ -121,8 +121,87 @@ test("AI SDK runtime reports invalid source-free rows as validation issues", asy
 
   assert.match(result.validationIssues.join("\n"), /no source URL/i);
   assert.match(result.validationIssues.join("\n"), /no evidence quote/i);
-  assert.match(result.validationIssues.join("\n"), /latest_post_title/i);
+  assert.doesNotMatch(result.validationIssues.join("\n"), /latest_post_title/i);
   assert.equal(result.metrics.agentRuns, 2);
+});
+
+test("AI SDK runtime treats non-identity requested columns as completeness, not hard requirements", async () => {
+  const runtime = new AiSdkDatasetAgentRuntime({
+    model: "test/model",
+    toolProvider: fakeToolProvider(),
+    createAgent: () => ({
+      async generate() {
+        return {
+          output: {
+            rows: [
+              {
+                cells: {
+                  entity_name: "OpenAI",
+                  source_url: "https://openai.com/news",
+                },
+                sourceUrls: ["https://openai.com/news"],
+                evidence: [
+                  {
+                    columnName: "entity_name",
+                    sourceUrl: "https://openai.com/news",
+                    quote: "OpenAI",
+                  },
+                ],
+              },
+            ],
+            validationIssues: [],
+          },
+          usage: {},
+          steps: [],
+        };
+      },
+    }),
+  });
+
+  const result = await runtime.runDatasetBuild(runInput);
+
+  assert.equal(result.validationIssues.length, 0);
+  assert.equal(result.metrics.agentRuns, 1);
+});
+
+test("AI SDK runtime still rejects rows missing the conservative identity field", async () => {
+  const runtime = new AiSdkDatasetAgentRuntime({
+    model: "test/model",
+    toolProvider: fakeToolProvider(),
+    maxRepairAttempts: 0,
+    createAgent: () => ({
+      async generate() {
+        return {
+          output: {
+            rows: [
+              {
+                cells: {
+                  latest_post_title: "Release notes",
+                  source_url: "https://openai.com/news",
+                },
+                sourceUrls: ["https://openai.com/news"],
+                evidence: [
+                  {
+                    columnName: "latest_post_title",
+                    sourceUrl: "https://openai.com/news",
+                    quote: "Release notes",
+                  },
+                ],
+              },
+            ],
+            validationIssues: [],
+          },
+          usage: {},
+          steps: [],
+        };
+      },
+    }),
+  });
+
+  const result = await runtime.runDatasetBuild(runInput);
+
+  assert.match(result.validationIssues.join("\n"), /entity_name/i);
+  assert.doesNotMatch(result.validationIssues.join("\n"), /latest_post_date/i);
 });
 
 test("AI SDK runtime self-heals once when the first output fails validation", async () => {
@@ -202,7 +281,7 @@ test("AI SDK runtime keeps repair telemetry when repair is worse", async () => {
                 {
                   cells: { entity_name: "OpenAI" },
                   sourceUrls: ["https://openai.com/news"],
-                  evidence: ["OpenAI news"],
+                  evidence: [],
                 },
               ],
               validationIssues: [],
@@ -229,6 +308,7 @@ test("AI SDK runtime keeps repair telemetry when repair is worse", async () => {
   assert.equal(generateCount, 2);
   assert.equal(result.rows.length, 1);
   assert.equal(result.rows[0]?.cells.entity_name, "OpenAI");
+  assert.match(result.validationIssues.join("\n"), /no evidence quote/i);
   assert.equal(result.metrics.agentRuns, 2);
   assert.equal(result.metrics.agentSteps, 2);
   assert.deepEqual(result.usage, {

--- a/benchmarks/dataset-agent/README.md
+++ b/benchmarks/dataset-agent/README.md
@@ -85,6 +85,19 @@ node benchmarks/dataset-agent/run-benchmark.mjs \
   --system edward='node benchmarks/dataset-agent/adapters/edward-ai-sdk-adapter.mjs'
 ```
 
+When using a fresh API key, start with a cheap canary subset:
+
+```bash
+DATASET_AGENT_RUNTIME=ai-sdk \
+DATASET_AGENT_MODEL=openai/gpt-5.4 \
+node benchmarks/dataset-agent/run-benchmark.mjs \
+  --prompt-ids latest-ai-blog-posts,saas-pricing-pages \
+  --system edward='node benchmarks/dataset-agent/adapters/edward-ai-sdk-adapter.mjs'
+```
+
+If the canary is blocked by auth, credits, quota, rate limits, or timeout, fix that
+before running the full 16 prompts.
+
 Real AI SDK runs require model auth plus `TINYFISH_API_KEY` loaded execution-only.
 Do not commit local env files.
 
@@ -149,7 +162,7 @@ Then run:
 node benchmarks/dataset-agent/run-benchmark.mjs \
   --system mengzhe='node benchmarks/dataset-agent/adapters/local-mengzhe-adapter.mjs'
 
-For quick validation, first run with --prompts pointing at a 2-3 prompt subset.
+For quick validation, first run with --prompt-ids on a 2-3 prompt subset.
 Commit only docs or reusable adapter templates. Do not commit local-* adapters,
 env files, logs, reports, screenshots, transcripts, private links, or secrets.
 ```

--- a/benchmarks/dataset-agent/README.md
+++ b/benchmarks/dataset-agent/README.md
@@ -48,7 +48,8 @@ Useful placeholders:
 - `{{promptJson}}`: shell-escaped JSON string for the prompt.
 - `{{prompt}}`: shell-escaped raw prompt text.
 - `{{promptId}}`: shell-escaped prompt id.
-- `{{requiredColumnsJson}}`: shell-escaped JSON array of required columns.
+- `{{requiredColumnsJson}}`: shell-escaped JSON array of requested output columns.
+- `{{minimumRequiredColumnsJson}}`: shell-escaped JSON array of minimum row-identity columns.
 
 The runner also sets env vars for each prompt:
 
@@ -56,9 +57,16 @@ The runner also sets env vars for each prompt:
 - `BIGSET_BENCHMARK_PROMPT_ID`
 - `BIGSET_BENCHMARK_PROMPT_QUALITY`
 - `BIGSET_BENCHMARK_REQUIRED_COLUMNS`
+- `BIGSET_BENCHMARK_MINIMUM_REQUIRED_COLUMNS`
 
 Most adapters should read the env vars instead of using placeholders. Use
 placeholders only when the existing agent already has a CLI that accepts args.
+
+`BIGSET_BENCHMARK_REQUIRED_COLUMNS` is the requested table shape used for
+completeness scoring. It is not a hard row-acceptance list. The hard minimum is
+`BIGSET_BENCHMARK_MINIMUM_REQUIRED_COLUMNS`, which defaults to one conservative
+identity column such as `entity_name`, `provider_name`, or `product_name`.
+Rows still need at least one source URL and evidence quote.
 
 ## Edward AI SDK Agent
 
@@ -221,8 +229,8 @@ The report includes:
 - official-domain accuracy
 - wall-clock latency
 - row count
-- required-cell completeness
-- missing required cells
+- requested-cell completeness
+- missing requested cells
 - source URL count
 - evidence quote count
 - duplicate identity count
@@ -240,7 +248,7 @@ Default pass gate:
 - command exits `0`
 - stdout contains parseable JSON
 - prompt output satisfies the prompt-specific answer key in `run-benchmark.mjs`
-- answerable prompts include rows, source URLs, evidence quotes, required cells,
+- answerable prompts include rows, source URLs, evidence quotes, requested cells,
   expected entities, and official domains
 - underspecified prompts can pass by asking for missing inputs or explicitly
   abstaining instead of inventing facts

--- a/benchmarks/dataset-agent/adapters/template-adapter.mjs
+++ b/benchmarks/dataset-agent/adapters/template-adapter.mjs
@@ -7,11 +7,16 @@ const requiredColumns = requiredEnv("BIGSET_BENCHMARK_REQUIRED_COLUMNS")
   .split(",")
   .map((columnName) => columnName.trim())
   .filter(Boolean);
+const minimumRequiredColumns = (process.env.BIGSET_BENCHMARK_MINIMUM_REQUIRED_COLUMNS ?? "")
+  .split(",")
+  .map((columnName) => columnName.trim())
+  .filter(Boolean);
 
 const agentResult = await runCurrentAgent({
   prompt,
   promptId,
   requiredColumns,
+  minimumRequiredColumns,
 });
 
 console.log(JSON.stringify(toBenchmarkPayload(agentResult)));

--- a/benchmarks/dataset-agent/run-benchmark.mjs
+++ b/benchmarks/dataset-agent/run-benchmark.mjs
@@ -10,7 +10,8 @@ const defaultMinimumFactualAccuracy = 0.75;
 
 async function main() {
   const config = parseArgs(process.argv.slice(2));
-  const prompts = JSON.parse(await readFile(config.promptsPath, "utf8"));
+  const allPrompts = JSON.parse(await readFile(config.promptsPath, "utf8"));
+  const prompts = selectPrompts(allPrompts, config.promptIds);
   const runStartedAt = new Date();
   const runDirectory = config.outDirectory ?? join(
     process.cwd(),
@@ -637,6 +638,7 @@ async function runSystemPrompt(input) {
 function parseArgs(args) {
   const config = {
     promptsPath: defaultPromptsPath,
+    promptIds: null,
     systems: [],
     timeoutMs: 10 * 60 * 1000,
     inputUsdPer1M: 0.05,
@@ -651,6 +653,9 @@ function parseArgs(args) {
     const value = args[index + 1];
     if (arg === "--prompts") {
       config.promptsPath = value;
+      index += 1;
+    } else if (arg === "--prompt-ids") {
+      config.promptIds = parsePromptIds(value);
       index += 1;
     } else if (arg === "--out") {
       config.outDirectory = value;
@@ -688,6 +693,50 @@ function parseArgs(args) {
   }
 
   return config;
+}
+
+function parsePromptIds(value) {
+  const promptIds = value
+    .split(",")
+    .map((promptId) => promptId.trim())
+    .filter(Boolean);
+
+  if (promptIds.length === 0) {
+    throw new Error("--prompt-ids requires at least one prompt id");
+  }
+
+  return promptIds;
+}
+
+function selectPrompts(prompts, promptIds) {
+  if (!promptIds) {
+    return prompts;
+  }
+
+  const promptsById = new Map(prompts.map((promptDefinition) => [
+    promptDefinition.id,
+    promptDefinition,
+  ]));
+  const selectedPrompts = [];
+  const missingPromptIds = [];
+
+  for (const promptId of promptIds) {
+    const promptDefinition = promptsById.get(promptId);
+    if (promptDefinition) {
+      selectedPrompts.push(promptDefinition);
+    } else {
+      missingPromptIds.push(promptId);
+    }
+  }
+
+  if (missingPromptIds.length > 0) {
+    const availablePromptIds = prompts.map((promptDefinition) => promptDefinition.id).join(", ");
+    throw new Error(
+      `Unknown prompt id(s): ${missingPromptIds.join(", ")}. Available ids: ${availablePromptIds}`
+    );
+  }
+
+  return selectedPrompts;
 }
 
 function parseSystem(value) {
@@ -882,6 +931,10 @@ async function rescoreBenchmarkRun({ runDirectory, prompts, config }) {
   const rescoredLaneResults = [];
 
   for (const laneResult of previousSummary.laneResults ?? []) {
+    if (config.promptIds && !config.promptIds.includes(laneResult.promptId)) {
+      continue;
+    }
+
     const promptDefinition = promptsById.get(laneResult.promptId);
     if (!promptDefinition) {
       rescoredLaneResults.push(laneResult);
@@ -1524,6 +1577,11 @@ function printHelpAndExit() {
   console.log(`Usage:
 node benchmarks/dataset-agent/run-benchmark.mjs \\
   --system mengzhe='npm run benchmark -- {{promptJson}}' \\
+  --system edward='node ./my-agent.js --prompt {{promptJson}}'
+
+Run a canary subset before spending credits on all prompts:
+node benchmarks/dataset-agent/run-benchmark.mjs \\
+  --prompt-ids latest-ai-blog-posts,saas-pricing-pages \\
   --system edward='node ./my-agent.js --prompt {{promptJson}}'
 
 Rescore existing artifacts without spending credits:

--- a/benchmarks/dataset-agent/run-benchmark.mjs
+++ b/benchmarks/dataset-agent/run-benchmark.mjs
@@ -519,6 +519,9 @@ await main();
 
 async function runSystemPrompt(input) {
   const startedAt = Date.now();
+  const minimumRequiredColumns = minimumRequiredColumnsForPrompt(
+    input.promptDefinition
+  );
   const command = renderCommand(input.system.command, input.promptDefinition);
   console.error(
     `[${input.system.name}] ${input.promptIndex + 1}/${input.promptCount} ${input.promptDefinition.id}`
@@ -532,6 +535,7 @@ async function runSystemPrompt(input) {
       BIGSET_BENCHMARK_PROMPT_ID: input.promptDefinition.id,
       BIGSET_BENCHMARK_PROMPT_QUALITY: input.promptDefinition.quality,
       BIGSET_BENCHMARK_REQUIRED_COLUMNS: input.promptDefinition.requiredColumns.join(","),
+      BIGSET_BENCHMARK_MINIMUM_REQUIRED_COLUMNS: minimumRequiredColumns.join(","),
     },
   });
   const parsedPayload = parseJsonPayload(execution.stdout);
@@ -582,7 +586,9 @@ async function runSystemPrompt(input) {
     promptQuality: input.promptDefinition.quality,
     promptPersona: input.promptDefinition.persona,
     prompt: input.promptDefinition.prompt,
+    requestedColumns: input.promptDefinition.requiredColumns,
     requiredColumns: input.promptDefinition.requiredColumns,
+    minimumRequiredColumns,
     expectedStress: input.promptDefinition.expectedStress,
     answerKey: answerKeyForPrompt(input.promptDefinition),
     status,
@@ -603,10 +609,13 @@ async function runSystemPrompt(input) {
     rowCount: validation.rowCount,
     nonEmptyCellCount: validation.nonEmptyCellCount,
     totalExpectedCellCount: validation.totalExpectedCellCount,
+    requestedCellCompletenessRatio: validation.requestedCellCompletenessRatio,
     requiredCellCompletenessRatio: validation.requiredCellCompletenessRatio,
     sourceUrlCount: validation.sourceUrlCount,
     evidenceQuoteCount: validation.evidenceQuoteCount,
     duplicateIdentityCount: validation.duplicateIdentityCount,
+    missingRequestedCellCount: validation.missingRequestedCellCount,
+    missingRequestedCells: validation.missingRequestedCells,
     missingRequiredCellCount: validation.missingRequiredCellCount,
     missingRequiredCells: validation.missingRequiredCells,
     needsReviewCount: validation.needsReviewCount,
@@ -633,6 +642,90 @@ async function runSystemPrompt(input) {
         minRequiredCompleteness: input.config.minRequiredCompleteness,
       }),
   };
+}
+
+function minimumRequiredColumnsForPrompt(promptDefinition) {
+  if (Array.isArray(promptDefinition.minimumRequiredColumns)) {
+    return uniqueStrings(promptDefinition.minimumRequiredColumns);
+  }
+  return inferConservativeMinimumRequiredColumns(promptDefinition.requiredColumns ?? []);
+}
+
+function inferConservativeMinimumRequiredColumns(columns) {
+  const requestedColumns = uniqueStrings(columns);
+  const identityPriority = [
+    "entity_name",
+    "company_name",
+    "organization_name",
+    "provider_name",
+    "restaurant_name",
+    "store_name",
+    "business_name",
+    "bakery_name",
+    "product_name",
+    "person_name",
+    "profile_name",
+    "docs_title",
+    "latest_item_title",
+    "open_role_title",
+  ];
+  const identityUrlPriority = [
+    "company_domain",
+    "official_website",
+    "official_source_url",
+    "profile_url",
+    "linkedin_url",
+    "product_url",
+    "website_url",
+    "docs_url",
+    "careers_page_url",
+    "quote_page_url",
+    "menu_url",
+    "pricing_page_url",
+  ];
+
+  const prioritizedIdentityColumn = identityPriority.find((columnName) =>
+    requestedColumns.includes(columnName)
+  );
+  if (prioritizedIdentityColumn) {
+    return [prioritizedIdentityColumn];
+  }
+
+  const nameColumn = requestedColumns.find((columnName) =>
+    /(^|_)name$/.test(columnName)
+  );
+  if (nameColumn) {
+    return [nameColumn];
+  }
+
+  const titleColumn = requestedColumns.find((columnName) =>
+    /(^|_)title$/.test(columnName)
+  );
+  if (titleColumn) {
+    return [titleColumn];
+  }
+
+  const identityUrlColumn = identityUrlPriority.find((columnName) =>
+    requestedColumns.includes(columnName)
+  );
+  if (identityUrlColumn) {
+    return [identityUrlColumn];
+  }
+
+  const fallbackIdentityColumn = requestedColumns.find(
+    (columnName) =>
+      columnName !== "source_url" &&
+      !columnName.endsWith("_at") &&
+      !columnName.includes("score") &&
+      !columnName.startsWith("is_") &&
+      !columnName.startsWith("has_")
+  );
+
+  return fallbackIdentityColumn ? [fallbackIdentityColumn] : [];
+}
+
+function uniqueStrings(values) {
+  return [...new Set(values.filter((value) => typeof value === "string" && value.length > 0))];
 }
 
 function parseArgs(args) {
@@ -752,11 +845,13 @@ function parseSystem(value) {
 }
 
 function renderCommand(command, promptDefinition) {
+  const minimumRequiredColumns = minimumRequiredColumnsForPrompt(promptDefinition);
   return command
     .replaceAll("{{prompt}}", shellEscape(promptDefinition.prompt))
     .replaceAll("{{promptJson}}", shellEscape(JSON.stringify(promptDefinition.prompt)))
     .replaceAll("{{promptId}}", shellEscape(promptDefinition.id))
-    .replaceAll("{{requiredColumnsJson}}", shellEscape(JSON.stringify(promptDefinition.requiredColumns)));
+    .replaceAll("{{requiredColumnsJson}}", shellEscape(JSON.stringify(promptDefinition.requiredColumns)))
+    .replaceAll("{{minimumRequiredColumnsJson}}", shellEscape(JSON.stringify(minimumRequiredColumns)));
 }
 
 function runCommand({ command, timeoutMs, env }) {
@@ -912,10 +1007,13 @@ function evaluateRows({ rows, promptDefinition }) {
     rowCount: rows.length,
     nonEmptyCellCount,
     totalExpectedCellCount,
+    requestedCellCompletenessRatio: requiredCellCompletenessRatio,
     requiredCellCompletenessRatio,
     sourceUrlCount: sourceUrls.size,
     evidenceQuoteCount,
     duplicateIdentityCount,
+    missingRequestedCellCount: missingRequiredCells.length,
+    missingRequestedCells: missingRequiredCells,
     missingRequiredCellCount: missingRequiredCells.length,
     missingRequiredCells,
     needsReviewCount,
@@ -976,7 +1074,9 @@ async function rescoreBenchmarkRun({ runDirectory, prompts, config }) {
 
     rescoredLaneResults.push({
       ...laneResult,
+      requestedColumns: promptDefinition.requiredColumns,
       requiredColumns: promptDefinition.requiredColumns,
+      minimumRequiredColumns: minimumRequiredColumnsForPrompt(promptDefinition),
       expectedStress: promptDefinition.expectedStress,
       answerKey: answerKeyForPrompt(promptDefinition),
       status,
@@ -994,10 +1094,13 @@ async function rescoreBenchmarkRun({ runDirectory, prompts, config }) {
       rowCount: validation.rowCount,
       nonEmptyCellCount: validation.nonEmptyCellCount,
       totalExpectedCellCount: validation.totalExpectedCellCount,
+      requestedCellCompletenessRatio: validation.requestedCellCompletenessRatio,
       requiredCellCompletenessRatio: validation.requiredCellCompletenessRatio,
       sourceUrlCount: validation.sourceUrlCount,
       evidenceQuoteCount: validation.evidenceQuoteCount,
       duplicateIdentityCount: validation.duplicateIdentityCount,
+      missingRequestedCellCount: validation.missingRequestedCellCount,
+      missingRequestedCells: validation.missingRequestedCells,
       missingRequiredCellCount: validation.missingRequiredCellCount,
       missingRequiredCells: validation.missingRequiredCells,
       needsReviewCount: validation.needsReviewCount,
@@ -1292,6 +1395,9 @@ function aggregateResults(results) {
       avgRequiredCellCompletenessRatio: roundRatio(
         sum(eligibleGroup, "requiredCellCompletenessRatio") / Math.max(1, eligibleCount)
       ),
+      avgRequestedCellCompletenessRatio: roundRatio(
+        sum(eligibleGroup, "requestedCellCompletenessRatio") / Math.max(1, eligibleCount)
+      ),
       avgFactualAccuracyScore: roundRatio(
         sum(eligibleGroup, "factualAccuracyScore") / Math.max(1, eligibleCount)
       ),
@@ -1304,6 +1410,7 @@ function aggregateResults(results) {
       totalRows: sum(group, "rowCount"),
       totalEvidenceQuotes: sum(group, "evidenceQuoteCount"),
       totalSourceUrls: sum(group, "sourceUrlCount"),
+      totalMissingRequestedCells: sum(group, "missingRequestedCellCount"),
       totalMissingRequiredCells: sum(group, "missingRequiredCellCount"),
       totalDuplicateIdentities: sum(group, "duplicateIdentityCount"),
       totalPromptTokens: group.reduce((total, result) => total + result.usage.promptTokens, 0),
@@ -1330,26 +1437,26 @@ async function writeMarkdownReport(filePath, summary, prompts) {
     "",
     "## Aggregate",
     "",
-    "| System | Runs | Passed | Failed | Blocked | Pass Rate | Eligible Pass | Avg Accuracy | Avg Latency | Rows | Evidence | Sources | Completeness | Missing Required | Duplicates | Tokens In | Tokens Out | Agent Steps | Est Cost |",
+    "| System | Runs | Passed | Failed | Blocked | Pass Rate | Eligible Pass | Avg Accuracy | Avg Latency | Rows | Evidence | Sources | Completeness | Missing Requested | Duplicates | Tokens In | Tokens Out | Agent Steps | Est Cost |",
     "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
     ...summary.aggregate.map((row) =>
-      `| ${escapeMarkdown(row.system)} | ${row.total} | ${row.passed} | ${row.failed} | ${row.blocked} | ${row.passRate} | ${row.eligiblePassRate} | ${row.avgFactualAccuracyScore} | ${formatDuration(row.avgLatencyMs)} | ${row.totalRows} | ${row.totalEvidenceQuotes} | ${row.totalSourceUrls} | ${row.avgRequiredCellCompletenessRatio} | ${row.totalMissingRequiredCells} | ${row.totalDuplicateIdentities} | ${row.totalPromptTokens} | ${row.totalCompletionTokens} | ${row.agentStepCount} | ${formatUsd(row.estimatedTotalCostUsd)} |`
+      `| ${escapeMarkdown(row.system)} | ${row.total} | ${row.passed} | ${row.failed} | ${row.blocked} | ${row.passRate} | ${row.eligiblePassRate} | ${row.avgFactualAccuracyScore} | ${formatDuration(row.avgLatencyMs)} | ${row.totalRows} | ${row.totalEvidenceQuotes} | ${row.totalSourceUrls} | ${row.avgRequestedCellCompletenessRatio ?? row.avgRequiredCellCompletenessRatio} | ${row.totalMissingRequestedCells ?? row.totalMissingRequiredCells} | ${row.totalDuplicateIdentities} | ${row.totalPromptTokens} | ${row.totalCompletionTokens} | ${row.agentStepCount} | ${formatUsd(row.estimatedTotalCostUsd)} |`
     ),
     "",
     "## Prompt Pack",
     "",
-    "| # | Quality | Persona | Prompt | Required Columns | Stress |",
-    "| ---: | --- | --- | --- | --- | --- |",
+    "| # | Quality | Persona | Prompt | Requested Columns | Minimum Required | Stress |",
+    "| ---: | --- | --- | --- | --- | --- | --- |",
     ...prompts.map((prompt, index) =>
-      `| ${index + 1} | ${prompt.quality} | ${escapeMarkdown(prompt.persona)} | ${escapeMarkdown(prompt.prompt)} | ${prompt.requiredColumns.join(", ")} | ${escapeMarkdown(prompt.expectedStress)} |`
+      `| ${index + 1} | ${prompt.quality} | ${escapeMarkdown(prompt.persona)} | ${escapeMarkdown(prompt.prompt)} | ${prompt.requiredColumns.join(", ")} | ${minimumRequiredColumnsForPrompt(prompt).join(", ")} | ${escapeMarkdown(prompt.expectedStress)} |`
     ),
     "",
     "## Raw Results",
     "",
-    "| System | Prompt | Quality | Status | Category | Accuracy | Entity Coverage | Domain Accuracy | Latency | Rows | Completeness | Evidence | Sources | Missing Required | Duplicates | Tokens In | Tokens Out | Search | Fetch | Browser | Agent Runs | Agent Steps | Est Cost | Issue |",
+    "| System | Prompt | Quality | Status | Category | Accuracy | Entity Coverage | Domain Accuracy | Latency | Rows | Completeness | Evidence | Sources | Missing Requested | Duplicates | Tokens In | Tokens Out | Search | Fetch | Browser | Agent Runs | Agent Steps | Est Cost | Issue |",
     "| --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
     ...summary.laneResults.map((result) =>
-      `| ${escapeMarkdown(result.system)} | ${escapeMarkdown(result.promptId)} | ${result.promptQuality} | ${result.status} | ${escapeMarkdown(result.failureCategory ?? "")} | ${result.factualAccuracyScore ?? 0} | ${result.entityCoverageRatio ?? 0} | ${result.domainAccuracyRatio ?? 0} | ${formatDuration(result.latencyMs)} | ${result.rowCount} | ${result.requiredCellCompletenessRatio} | ${result.evidenceQuoteCount} | ${result.sourceUrlCount} | ${result.missingRequiredCellCount} | ${result.duplicateIdentityCount} | ${result.usage.promptTokens} | ${result.usage.completionTokens} | ${result.searchCallCount} | ${result.fetchCallCount} | ${result.browserCallCount} | ${result.agentRunCount} | ${result.agentStepCount} | ${formatUsd(result.estimatedTotalCostUsd)} | ${escapeMarkdown(result.errorMessage ?? "")} |`
+      `| ${escapeMarkdown(result.system)} | ${escapeMarkdown(result.promptId)} | ${result.promptQuality} | ${result.status} | ${escapeMarkdown(result.failureCategory ?? "")} | ${result.factualAccuracyScore ?? 0} | ${result.entityCoverageRatio ?? 0} | ${result.domainAccuracyRatio ?? 0} | ${formatDuration(result.latencyMs)} | ${result.rowCount} | ${result.requestedCellCompletenessRatio ?? result.requiredCellCompletenessRatio} | ${result.evidenceQuoteCount} | ${result.sourceUrlCount} | ${result.missingRequestedCellCount ?? result.missingRequiredCellCount} | ${result.duplicateIdentityCount} | ${result.usage.promptTokens} | ${result.usage.completionTokens} | ${result.searchCallCount} | ${result.fetchCallCount} | ${result.browserCallCount} | ${result.agentRunCount} | ${result.agentStepCount} | ${formatUsd(result.estimatedTotalCostUsd)} | ${escapeMarkdown(result.errorMessage ?? "")} |`
     ),
     "",
   ];
@@ -1467,7 +1574,7 @@ function failureReason({
   if (validation.sourceUrlCount === 0) return "No source URLs found.";
   if (validation.evidenceQuoteCount === 0) return "No evidence quotes found.";
   if (validation.requiredCellCompletenessRatio < minRequiredCompleteness) {
-    return `Required-cell completeness ${validation.requiredCellCompletenessRatio} below ${minRequiredCompleteness}.`;
+    return `Requested-cell completeness ${validation.requiredCellCompletenessRatio} below ${minRequiredCompleteness}.`;
   }
   if (answerKeyScore && !answerKeyScore.passed) {
     if (answerKeyScore.failureCategory === "source_evidence") {


### PR DESCRIPTION
## Summary
- add `--prompt-ids` to run canonical canary subsets without creating temp prompt files
- split benchmark requested columns from conservative minimum required columns
- make the AI SDK runtime reject rows only when identity/source/evidence is missing, while treating other requested fields as completeness scoring
- document the new minimum-required benchmark env var and ignore local benchmark artifacts

## Verification
- `node --check benchmarks/dataset-agent/run-benchmark.mjs`
- `node --check benchmarks/dataset-agent/adapters/template-adapter.mjs`
- `npm --prefix backend test`
- `npm --prefix backend run build`
- `git diff --check`
- `DATASET_AGENT_RUNTIME=deterministic node benchmarks/dataset-agent/run-benchmark.mjs --prompt-ids latest-ai-blog-posts,saas-pricing-pages --system edward='node benchmarks/dataset-agent/adapters/edward-ai-sdk-adapter.mjs'`

## Notes
- Did not inspect or print real env files.
- No auto-merge.