### PR TITLE
Move dev targets to makefiles/ to survive terraform bot

### DIFF
--- a/makefiles/Makefile
+++ b/makefiles/Makefile
@@ -1,0 +1,33 @@
+.PHONY: all dev down clean convex-push convex-env
+
+all: dev
+
+dev:
+	docker compose -f docker-compose.dev.yml up --build -d
+	@echo "Waiting for Convex to be healthy..."
+	@for i in $$(seq 1 120); do \
+		if curl -sf http://127.0.0.1:3210/version > /dev/null 2>&1; then break; fi; \
+		if [ $$i -eq 120 ]; then echo "Convex did not become healthy within 120s"; exit 1; fi; \
+		sleep 1; \
+	done
+	$(MAKE) convex-env
+	$(MAKE) convex-push
+	@echo ""
+	@echo "Ready! Open http://localhost:3500"
+	docker compose -f docker-compose.dev.yml logs -f
+
+convex-env:
+	@cd frontend && npx convex env set CLERK_JWT_ISSUER_DOMAIN "$$(grep CLERK_JWT_ISSUER_DOMAIN .env.local | cut -d= -f2-)" \
+		--url http://127.0.0.1:3210 \
+		--admin-key "$$(grep CONVEX_SELF_HOSTED_ADMIN_KEY .env.local | cut -d= -f2-)"
+
+convex-push:
+	cd frontend && npx convex deploy \
+		--url http://127.0.0.1:3210 \
+		--admin-key "$$(grep CONVEX_SELF_HOSTED_ADMIN_KEY .env.local | cut -d= -f2-)"
+
+down:
+	docker compose -f docker-compose.dev.yml down
+
+clean:
+	docker compose -f docker-compose.dev.yml down -v --rmi local

--- a/makefiles/Makefile
+++ b/makefiles/Makefile
@@ -17,12 +17,17 @@ dev:
 	docker compose -f docker-compose.dev.yml logs -f
 
 convex-env:
+	@test -f frontend/.env.local || { echo "Error: frontend/.env.local not found"; exit 1; }
+	@grep -q CLERK_JWT_ISSUER_DOMAIN frontend/.env.local || { echo "Error: CLERK_JWT_ISSUER_DOMAIN not set in frontend/.env.local"; exit 1; }
+	@grep -q CONVEX_SELF_HOSTED_ADMIN_KEY frontend/.env.local || { echo "Error: CONVEX_SELF_HOSTED_ADMIN_KEY not set in frontend/.env.local"; exit 1; }
 	@cd frontend && npx convex env set CLERK_JWT_ISSUER_DOMAIN "$$(grep CLERK_JWT_ISSUER_DOMAIN .env.local | cut -d= -f2-)" \
 		--url http://127.0.0.1:3210 \
 		--admin-key "$$(grep CONVEX_SELF_HOSTED_ADMIN_KEY .env.local | cut -d= -f2-)"
 
 convex-push:
-	cd frontend && npx convex deploy \
+	@test -f frontend/.env.local || { echo "Error: frontend/.env.local not found"; exit 1; }
+	@grep -q CONVEX_SELF_HOSTED_ADMIN_KEY frontend/.env.local || { echo "Error: CONVEX_SELF_HOSTED_ADMIN_KEY not set in frontend/.env.local"; exit 1; }
+	@cd frontend && npx convex deploy \
 		--url http://127.0.0.1:3210 \
 		--admin-key "$$(grep CONVEX_SELF_HOSTED_ADMIN_KEY .env.local | cut -d= -f2-)"
 


### PR DESCRIPTION
## Summary
- Moves `dev`, `down`, `clean`, `convex-push`, and `convex-env` targets from the root `Makefile` into `makefiles/Makefile`
- The root Makefile already does `include $(wildcard makefiles/*)`, so `make dev` continues to work as before
- Prevents `tinyfish-github-terraform[bot]` from wiping these targets on every run (has happened 4 times: c4eec12, 29e6357, 63f6b0f, 4f3cb52)

## Test plan
- [ ] `make dev` starts all services as before
- [ ] `make down` and `make clean` still work
- [ ] Next terraform bot run no longer breaks dev workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)