### PR TITLE
feat: add recipe healer contract

### DIFF
--- a/backend/src/dataset-agent/index.ts
+++ b/backend/src/dataset-agent/index.ts
@@ -8,6 +8,26 @@ import type {
 } from "./types.js";
 
 export type { DatasetAgentRunInput, DatasetAgentRunResult } from "./types.js";
+export {
+  applyRecipePromotionDecision,
+  decideRecipePromotion,
+} from "./recipe-healer.js";
+export {
+  createDatasetRecipe,
+  createDatasetRecipeRunResult,
+  emptyRecipeRunResult,
+  evaluateRecipeProductionValidation,
+  FakeDatasetRecipeRuntime,
+} from "./recipe-runtime.js";
+export type {
+  DatasetRecipe,
+  DatasetRecipeArtifact,
+  DatasetRecipeBenchmarkScore,
+  DatasetRecipeProductionValidation,
+  DatasetRecipeRunInput,
+  DatasetRecipeRunResult,
+  DatasetRecipeRuntime,
+} from "./recipe-types.js";
 
 export function createDatasetAgentRuntime(input: {
   runtime?: string;

--- a/backend/src/dataset-agent/recipe-healer.ts
+++ b/backend/src/dataset-agent/recipe-healer.ts
@@ -1,0 +1,125 @@
+import type {
+  DatasetRecipe,
+  DatasetRecipeBenchmarkScore,
+  DatasetRecipeRunResult,
+} from "./recipe-types.js";
+
+export interface DatasetRecipePromotionDecision {
+  shouldPromote: boolean;
+  reasons: string[];
+  rejectionReasons: string[];
+  activeProductionScore?: number;
+  candidateProductionScore: number;
+  activeBenchmarkScore?: number;
+  candidateBenchmarkScore?: number;
+}
+
+export interface DatasetRecipePromotionResult {
+  decision: DatasetRecipePromotionDecision;
+  activeRecipe: DatasetRecipe;
+  retiredRecipe?: DatasetRecipe;
+}
+
+export function decideRecipePromotion(input: {
+  activeRun?: DatasetRecipeRunResult;
+  candidateRun: DatasetRecipeRunResult;
+}): DatasetRecipePromotionDecision {
+  const candidateProductionScore = input.candidateRun.productionValidation.score;
+  const activeProductionScore = input.activeRun?.productionValidation.score;
+  const candidateBenchmarkScore = scoreValue(input.candidateRun.benchmarkScore);
+  const activeBenchmarkScore = scoreValue(input.activeRun?.benchmarkScore);
+  const reasons: string[] = [];
+  const rejectionReasons: string[] = [];
+
+  if (input.candidateRun.runStatus !== "succeeded") {
+    rejectionReasons.push("Candidate run did not succeed.");
+  }
+
+  if (!input.candidateRun.productionValidation.isValid) {
+    rejectionReasons.push(
+      ...input.candidateRun.productionValidation.criticalIssues
+    );
+  }
+
+  if (input.candidateRun.benchmarkScore?.passed === false) {
+    rejectionReasons.push("Candidate benchmark score did not pass.");
+  }
+
+  if (activeProductionScore !== undefined) {
+    if (candidateProductionScore < activeProductionScore) {
+      rejectionReasons.push("Candidate production validation score regressed.");
+    } else if (candidateProductionScore > activeProductionScore) {
+      reasons.push("Candidate production validation score improved.");
+    }
+  } else {
+    reasons.push("No active recipe run exists.");
+  }
+
+  if (
+    activeBenchmarkScore !== undefined &&
+    candidateBenchmarkScore !== undefined
+  ) {
+    if (candidateBenchmarkScore < activeBenchmarkScore) {
+      rejectionReasons.push("Candidate benchmark score regressed.");
+    } else if (candidateBenchmarkScore > activeBenchmarkScore) {
+      reasons.push("Candidate benchmark score improved.");
+    }
+  }
+
+  if (
+    rejectionReasons.length === 0 &&
+    reasons.length === 0 &&
+    activeProductionScore !== undefined
+  ) {
+    rejectionReasons.push("Candidate did not improve validation or benchmark score.");
+  }
+
+  return {
+    shouldPromote: rejectionReasons.length === 0,
+    reasons,
+    rejectionReasons,
+    activeProductionScore,
+    candidateProductionScore,
+    activeBenchmarkScore,
+    candidateBenchmarkScore,
+  };
+}
+
+export function applyRecipePromotionDecision(input: {
+  activeRecipe: DatasetRecipe;
+  candidateRecipe: DatasetRecipe;
+  activeRun?: DatasetRecipeRunResult;
+  candidateRun: DatasetRecipeRunResult;
+}): DatasetRecipePromotionResult {
+  const decision = decideRecipePromotion({
+    activeRun: input.activeRun,
+    candidateRun: input.candidateRun,
+  });
+
+  if (!decision.shouldPromote) {
+    return {
+      decision,
+      activeRecipe: input.activeRecipe,
+    };
+  }
+
+  return {
+    decision,
+    activeRecipe: {
+      ...input.candidateRecipe,
+      status: "active",
+      lastSuccessfulRunAt: input.candidateRun.completedAt,
+      lastValidationScore: input.candidateRun.productionValidation.score,
+    },
+    retiredRecipe: {
+      ...input.activeRecipe,
+      status: "retired",
+    },
+  };
+}
+
+function scoreValue(score?: DatasetRecipeBenchmarkScore): number | undefined {
+  return typeof score?.score === "number" && Number.isFinite(score.score)
+    ? score.score
+    : undefined;
+}

--- a/backend/src/dataset-agent/recipe-runtime.ts
+++ b/backend/src/dataset-agent/recipe-runtime.ts
@@ -1,0 +1,283 @@
+import {
+  emptyMetrics,
+  emptyUsage,
+  minimumRequiredColumnsForRunInput,
+  normalizeDatasetAgentResult,
+} from "./output.js";
+import type {
+  DatasetRecipe,
+  DatasetRecipeArtifact,
+  DatasetRecipeBenchmarkScore,
+  DatasetRecipeProductionValidation,
+  DatasetRecipeRunInput,
+  DatasetRecipeRunResult,
+  DatasetRecipeRuntime,
+  DatasetRecipeRunStatus,
+} from "./recipe-types.js";
+import type {
+  DatasetAgentRunInput,
+  DatasetAgentRunResult,
+  DatasetAgentUsage,
+  DatasetAgentMetrics,
+} from "./types.js";
+
+export interface FakeDatasetRecipeScenario {
+  rawOutput?: unknown;
+  usage?: Partial<DatasetAgentUsage>;
+  metrics?: Partial<DatasetAgentMetrics>;
+  artifacts?: DatasetRecipeArtifact[];
+  benchmarkScore?: DatasetRecipeBenchmarkScore;
+  runStatus?: DatasetRecipeRunStatus;
+  startedAt?: string;
+  completedAt?: string;
+  runtimeMs?: number;
+}
+
+export class FakeDatasetRecipeRuntime implements DatasetRecipeRuntime {
+  private readonly scenariosByRecipeId: Map<string, FakeDatasetRecipeScenario>;
+
+  constructor(scenariosByRecipeId: Record<string, FakeDatasetRecipeScenario>) {
+    this.scenariosByRecipeId = new Map(Object.entries(scenariosByRecipeId));
+  }
+
+  async runRecipe(input: DatasetRecipeRunInput): Promise<DatasetRecipeRunResult> {
+    const scenario = this.scenariosByRecipeId.get(input.recipe.recipeId) ?? {};
+    const startedAt = scenario.startedAt ?? new Date().toISOString();
+    const completedAt = scenario.completedAt ?? startedAt;
+    const normalizedResult = normalizeDatasetAgentResult({
+      rawOutput: scenario.rawOutput ?? { rows: [], validationIssues: [] },
+      runInput: input.runInput,
+      usage: scenario.usage,
+      metrics: scenario.metrics,
+    });
+
+    return createDatasetRecipeRunResult({
+      recipe: input.recipe,
+      runInput: input.runInput,
+      result: normalizedResult,
+      runStatus:
+        scenario.runStatus ??
+        (normalizedResult.validationIssues.length === 0 ? "succeeded" : "failed"),
+      startedAt,
+      completedAt,
+      runtimeMs: scenario.runtimeMs ?? 0,
+      artifacts: scenario.artifacts ?? [],
+      benchmarkScore: scenario.benchmarkScore,
+    });
+  }
+}
+
+export function createDatasetRecipe(input: {
+  recipeId: string;
+  datasetId: string;
+  version: number;
+  scriptText: string;
+  requestedColumns: string[];
+  sourcePrompt: string;
+  minimumRequiredColumns?: string[];
+  status?: DatasetRecipe["status"];
+  createdAt?: string;
+  createdBy?: DatasetRecipe["createdBy"];
+}): DatasetRecipe {
+  const runInput = {
+    prompt: input.sourcePrompt,
+    requiredColumns: input.requestedColumns,
+    minimumRequiredColumns: input.minimumRequiredColumns,
+  };
+
+  return {
+    recipeId: input.recipeId,
+    datasetId: input.datasetId,
+    version: input.version,
+    status: input.status ?? "candidate",
+    scriptText: input.scriptText,
+    requestedColumns: input.requestedColumns,
+    minimumRequiredColumns: minimumRequiredColumnsForRunInput(runInput),
+    sourcePrompt: input.sourcePrompt,
+    createdAt: input.createdAt ?? new Date().toISOString(),
+    createdBy: input.createdBy ?? "agent",
+  };
+}
+
+export function createDatasetRecipeRunResult(input: {
+  recipe: DatasetRecipe;
+  runInput: DatasetAgentRunInput;
+  result: DatasetAgentRunResult;
+  runStatus: DatasetRecipeRunStatus;
+  startedAt: string;
+  completedAt: string;
+  runtimeMs: number;
+  artifacts: DatasetRecipeArtifact[];
+  benchmarkScore?: DatasetRecipeBenchmarkScore;
+}): DatasetRecipeRunResult {
+  return {
+    ...input.result,
+    recipeId: input.recipe.recipeId,
+    recipeVersion: input.recipe.version,
+    runStatus: input.runStatus,
+    startedAt: input.startedAt,
+    completedAt: input.completedAt,
+    runtimeMs: input.runtimeMs,
+    artifacts: input.artifacts,
+    productionValidation: evaluateRecipeProductionValidation({
+      result: input.result,
+      runInput: input.runInput,
+    }),
+    benchmarkScore: input.benchmarkScore,
+  };
+}
+
+export function evaluateRecipeProductionValidation(input: {
+  result: DatasetAgentRunResult;
+  runInput: DatasetAgentRunInput;
+}): DatasetRecipeProductionValidation {
+  const minimumRequiredColumns = minimumRequiredColumnsForRunInput(input.runInput);
+  const requestedColumns = input.runInput.requiredColumns;
+  const rows = input.result.rows;
+  const criticalIssues = new Set(input.result.validationIssues);
+  let presentMinimumCellCount = 0;
+  let presentRequestedCellCount = 0;
+  let rowsWithSourceUrl = 0;
+  let rowsWithEvidence = 0;
+
+  if (rows.length === 0) {
+    criticalIssues.add("No rows returned.");
+  }
+
+  for (const [rowIndex, row] of rows.entries()) {
+    if (row.sourceUrls.length > 0) {
+      rowsWithSourceUrl += 1;
+    } else {
+      criticalIssues.add(`Row ${rowIndex} has no source URL.`);
+    }
+
+    if (row.evidence.length > 0) {
+      rowsWithEvidence += 1;
+    } else {
+      criticalIssues.add(`Row ${rowIndex} has no evidence quote.`);
+    }
+
+    for (const columnName of minimumRequiredColumns) {
+      if (isPresent(row.cells[columnName])) {
+        presentMinimumCellCount += 1;
+      } else {
+        criticalIssues.add(
+          `Row ${rowIndex} missing minimum required column ${columnName}.`
+        );
+      }
+    }
+
+    for (const columnName of requestedColumns) {
+      if (isPresent(row.cells[columnName])) {
+        presentRequestedCellCount += 1;
+      }
+    }
+  }
+
+  const rowCount = rows.length;
+  const minimumRequiredCompletenessRatio = ratio(
+    presentMinimumCellCount,
+    rowCount * minimumRequiredColumns.length
+  );
+  const requestedCellCompletenessRatio = ratio(
+    presentRequestedCellCount,
+    rowCount * requestedColumns.length
+  );
+  const sourceUrlCoverageRatio = coverageRatio(rowsWithSourceUrl, rowCount);
+  const evidenceCoverageRatio = coverageRatio(rowsWithEvidence, rowCount);
+  const score = roundRatio(
+    ratio(rowCount, Math.max(rowCount, 1)) * 0.15 +
+      minimumRequiredCompletenessRatio * 0.35 +
+      sourceUrlCoverageRatio * 0.2 +
+      evidenceCoverageRatio * 0.2 +
+      requestedCellCompletenessRatio * 0.1
+  );
+
+  return {
+    isValid:
+      rowCount > 0 &&
+      criticalIssues.size === 0 &&
+      minimumRequiredCompletenessRatio === 1 &&
+      sourceUrlCoverageRatio === 1 &&
+      evidenceCoverageRatio === 1,
+    score,
+    rowCount,
+    minimumRequiredCompletenessRatio,
+    requestedCellCompletenessRatio,
+    sourceUrlCoverageRatio,
+    evidenceCoverageRatio,
+    criticalIssues: Array.from(criticalIssues),
+    warnings: completenessWarnings({
+      requestedColumns,
+      requestedCellCompletenessRatio,
+    }),
+  };
+}
+
+function completenessWarnings(input: {
+  requestedColumns: string[];
+  requestedCellCompletenessRatio: number;
+}): string[] {
+  if (
+    input.requestedColumns.length === 0 ||
+    input.requestedCellCompletenessRatio === 1
+  ) {
+    return [];
+  }
+
+  return [
+    `Requested-cell completeness ${input.requestedCellCompletenessRatio} below 1.`,
+  ];
+}
+
+function ratio(numerator: number, denominator: number): number {
+  if (denominator <= 0) {
+    return 1;
+  }
+  return roundRatio(numerator / denominator);
+}
+
+function coverageRatio(numerator: number, denominator: number): number {
+  if (denominator <= 0) {
+    return 0;
+  }
+  return ratio(numerator, denominator);
+}
+
+function roundRatio(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+function isPresent(value: unknown): boolean {
+  if (value === null || value === undefined) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  return true;
+}
+
+export function emptyRecipeRunResult(input: {
+  recipe: DatasetRecipe;
+  runInput: DatasetAgentRunInput;
+  validationIssue: string;
+}): DatasetRecipeRunResult {
+  const result = normalizeDatasetAgentResult({
+    rawOutput: {
+      rows: [],
+      validationIssues: [input.validationIssue],
+      usage: emptyUsage(),
+      metrics: emptyMetrics(),
+    },
+    runInput: input.runInput,
+  });
+
+  return createDatasetRecipeRunResult({
+    recipe: input.recipe,
+    runInput: input.runInput,
+    result,
+    runStatus: "failed",
+    startedAt: new Date().toISOString(),
+    completedAt: new Date().toISOString(),
+    runtimeMs: 0,
+    artifacts: [],
+  });
+}

--- a/backend/src/dataset-agent/recipe-types.ts
+++ b/backend/src/dataset-agent/recipe-types.ts
@@ -1,0 +1,83 @@
+import type {
+  DatasetAgentRunInput,
+  DatasetAgentRunResult,
+} from "./types.js";
+
+export type DatasetRecipeStatus =
+  | "active"
+  | "candidate"
+  | "retired"
+  | "rejected";
+
+export type DatasetRecipeRunStatus = "succeeded" | "failed";
+
+export type DatasetRecipeArtifactKind =
+  | "stdout"
+  | "stderr"
+  | "screenshot"
+  | "dom"
+  | "text"
+  | "url-history";
+
+export interface DatasetRecipe {
+  recipeId: string;
+  datasetId: string;
+  version: number;
+  status: DatasetRecipeStatus;
+  scriptText: string;
+  requestedColumns: string[];
+  minimumRequiredColumns: string[];
+  sourcePrompt: string;
+  createdAt: string;
+  createdBy: "agent" | "human" | "system";
+  lastSuccessfulRunAt?: string;
+  lastValidationScore?: number;
+}
+
+export interface DatasetRecipeArtifact {
+  kind: DatasetRecipeArtifactKind;
+  label: string;
+  content?: string;
+  uri?: string;
+  metadata?: Record<string, string | number | boolean | null>;
+}
+
+export interface DatasetRecipeProductionValidation {
+  isValid: boolean;
+  score: number;
+  rowCount: number;
+  minimumRequiredCompletenessRatio: number;
+  requestedCellCompletenessRatio: number;
+  sourceUrlCoverageRatio: number;
+  evidenceCoverageRatio: number;
+  criticalIssues: string[];
+  warnings: string[];
+}
+
+export interface DatasetRecipeBenchmarkScore {
+  score: number;
+  passed: boolean;
+  failureCategory?: string;
+  details?: Record<string, unknown>;
+}
+
+export interface DatasetRecipeRunInput {
+  recipe: DatasetRecipe;
+  runInput: DatasetAgentRunInput;
+}
+
+export interface DatasetRecipeRunResult extends DatasetAgentRunResult {
+  recipeId: string;
+  recipeVersion: number;
+  runStatus: DatasetRecipeRunStatus;
+  startedAt: string;
+  completedAt: string;
+  runtimeMs: number;
+  artifacts: DatasetRecipeArtifact[];
+  productionValidation: DatasetRecipeProductionValidation;
+  benchmarkScore?: DatasetRecipeBenchmarkScore;
+}
+
+export interface DatasetRecipeRuntime {
+  runRecipe(input: DatasetRecipeRunInput): Promise<DatasetRecipeRunResult>;
+}

--- a/backend/test/dataset-agent-recipe-healer.test.ts
+++ b/backend/test/dataset-agent-recipe-healer.test.ts
@@ -1,0 +1,223 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  applyRecipePromotionDecision,
+  createDatasetRecipe,
+  FakeDatasetRecipeRuntime,
+} from "../src/dataset-agent/index.js";
+import type {
+  DatasetAgentRunInput,
+  DatasetRecipeRunResult,
+} from "../src/dataset-agent/index.js";
+
+const runInput: DatasetAgentRunInput = {
+  prompt: "Find latest blog posts from OpenAI with title, date, and URL.",
+  promptId: "recipe-oracle-latest-posts",
+  promptQuality: "good",
+  requiredColumns: ["entity_name", "latest_post_title", "source_url"],
+};
+
+const activeRecipe = createDatasetRecipe({
+  recipeId: "recipe-active",
+  datasetId: "dataset-ai-posts",
+  version: 1,
+  status: "active",
+  scriptText: "export async function runDatasetRecipe() {}",
+  requestedColumns: runInput.requiredColumns,
+  sourcePrompt: runInput.prompt,
+  createdAt: "2026-05-21T00:00:00.000Z",
+});
+
+test("fake recipe runtime returns current dataset-agent contract plus production validation", async () => {
+  const runtime = new FakeDatasetRecipeRuntime({
+    [activeRecipe.recipeId]: {
+      rawOutput: {
+        rows: [
+          sourceBackedRow({
+            entity_name: "OpenAI",
+            source_url: "https://openai.com/news",
+          }),
+        ],
+        validationIssues: [],
+      },
+    },
+  });
+
+  const result = await runtime.runRecipe({ recipe: activeRecipe, runInput });
+
+  assert.equal(result.recipeId, activeRecipe.recipeId);
+  assert.equal(result.rows.length, 1);
+  assert.equal(result.productionValidation.isValid, true);
+  assert.equal(result.productionValidation.minimumRequiredCompletenessRatio, 1);
+  assert.equal(result.productionValidation.requestedCellCompletenessRatio, 0.667);
+  assert.equal(result.productionValidation.warnings.length, 1);
+});
+
+test("production validation rejects rows missing the conservative identity field", async () => {
+  const runtime = new FakeDatasetRecipeRuntime({
+    [activeRecipe.recipeId]: {
+      rawOutput: {
+        rows: [
+          sourceBackedRow({
+            latest_post_title: "Release notes",
+            source_url: "https://openai.com/news",
+          }),
+        ],
+        validationIssues: [],
+      },
+    },
+  });
+
+  const result = await runtime.runRecipe({ recipe: activeRecipe, runInput });
+
+  assert.equal(result.productionValidation.isValid, false);
+  assert.match(
+    result.productionValidation.criticalIssues.join("\n"),
+    /entity_name/i
+  );
+});
+
+test("promotion accepts a valid candidate that improves requested-cell completeness", async () => {
+  const candidateRecipe = createDatasetRecipe({
+    recipeId: "recipe-candidate",
+    datasetId: activeRecipe.datasetId,
+    version: 2,
+    scriptText: "export async function runDatasetRecipe() { return 'better'; }",
+    requestedColumns: runInput.requiredColumns,
+    sourcePrompt: runInput.prompt,
+    createdAt: "2026-05-21T00:01:00.000Z",
+  });
+  const activeRun = await runFakeRecipe(activeRecipe, {
+    entity_name: "OpenAI",
+    source_url: "https://openai.com/news",
+  });
+  const candidateRun = await runFakeRecipe(candidateRecipe, {
+    entity_name: "OpenAI",
+    latest_post_title: "Release notes",
+    source_url: "https://openai.com/news",
+  });
+
+  const promotion = applyRecipePromotionDecision({
+    activeRecipe,
+    candidateRecipe,
+    activeRun,
+    candidateRun,
+  });
+
+  assert.equal(promotion.decision.shouldPromote, true);
+  assert.equal(promotion.activeRecipe.recipeId, candidateRecipe.recipeId);
+  assert.equal(promotion.activeRecipe.status, "active");
+  assert.equal(promotion.retiredRecipe?.status, "retired");
+});
+
+test("promotion rejects a candidate that regresses production validation score", async () => {
+  const candidateRecipe = createDatasetRecipe({
+    recipeId: "recipe-worse",
+    datasetId: activeRecipe.datasetId,
+    version: 2,
+    scriptText: "export async function runDatasetRecipe() { return 'worse'; }",
+    requestedColumns: runInput.requiredColumns,
+    sourcePrompt: runInput.prompt,
+  });
+  const activeRun = await runFakeRecipe(activeRecipe, {
+    entity_name: "OpenAI",
+    latest_post_title: "Release notes",
+    source_url: "https://openai.com/news",
+  });
+  const candidateRun = await runFakeRecipe(candidateRecipe, {
+    entity_name: "OpenAI",
+    source_url: "https://openai.com/news",
+  });
+
+  const promotion = applyRecipePromotionDecision({
+    activeRecipe,
+    candidateRecipe,
+    activeRun,
+    candidateRun,
+  });
+
+  assert.equal(promotion.decision.shouldPromote, false);
+  assert.equal(promotion.activeRecipe.recipeId, activeRecipe.recipeId);
+  assert.match(
+    promotion.decision.rejectionReasons.join("\n"),
+    /production validation score regressed/i
+  );
+});
+
+test("promotion rejects a candidate when benchmark score regresses", async () => {
+  const candidateRecipe = createDatasetRecipe({
+    recipeId: "recipe-benchmark-regression",
+    datasetId: activeRecipe.datasetId,
+    version: 2,
+    scriptText: "export async function runDatasetRecipe() { return 'fuller but wrong'; }",
+    requestedColumns: runInput.requiredColumns,
+    sourcePrompt: runInput.prompt,
+  });
+  const activeRun = await runFakeRecipe(
+    activeRecipe,
+    {
+      entity_name: "OpenAI",
+      source_url: "https://openai.com/news",
+    },
+    { score: 0.8, passed: true }
+  );
+  const candidateRun = await runFakeRecipe(
+    candidateRecipe,
+    {
+      entity_name: "OpenAI",
+      latest_post_title: "Release notes",
+      source_url: "https://openai.com/news",
+    },
+    { score: 0.7, passed: true }
+  );
+
+  const promotion = applyRecipePromotionDecision({
+    activeRecipe,
+    candidateRecipe,
+    activeRun,
+    candidateRun,
+  });
+
+  assert.equal(promotion.decision.shouldPromote, false);
+  assert.match(
+    promotion.decision.rejectionReasons.join("\n"),
+    /benchmark score regressed/i
+  );
+});
+
+async function runFakeRecipe(
+  recipe: typeof activeRecipe,
+  cells: Record<string, string>,
+  benchmarkScore?: DatasetRecipeRunResult["benchmarkScore"]
+): Promise<DatasetRecipeRunResult> {
+  const runtime = new FakeDatasetRecipeRuntime({
+    [recipe.recipeId]: {
+      rawOutput: {
+        rows: [sourceBackedRow(cells)],
+        validationIssues: [],
+      },
+      benchmarkScore,
+      completedAt: "2026-05-21T00:02:00.000Z",
+    },
+  });
+
+  return runtime.runRecipe({ recipe, runInput });
+}
+
+function sourceBackedRow(cells: Record<string, string>) {
+  const sourceUrl = cells.source_url ?? "https://openai.com/news";
+
+  return {
+    cells,
+    sourceUrls: [sourceUrl],
+    evidence: [
+      {
+        columnName: Object.keys(cells)[0] ?? "entity_name",
+        sourceUrl,
+        quote: Object.values(cells)[0] ?? "OpenAI",
+      },
+    ],
+    needsReview: false,
+  };
+}

--- a/benchmarks/dataset-agent/README.md
+++ b/benchmarks/dataset-agent/README.md
@@ -109,6 +109,30 @@ before running the full 16 prompts.
 Real AI SDK runs require model auth plus `TINYFISH_API_KEY` loaded execution-only.
 Do not commit local env files.
 
+## Recipe Healer Prototype
+
+The first self-healing slice is intentionally contract-only.
+
+The recipe runtime treats a generated Playwright script as a runtime artifact,
+not as committed source code. A recipe run still returns the normal dataset-agent
+shape: `rows`, `validationIssues`, `usage`, and `metrics`.
+
+PR1 proves:
+
+- recipe metadata can track dataset id, version, status, requested columns, and
+  minimum required columns
+- fake recipe runs can produce the same output contract as the AI SDK agent
+- production validation is separate from benchmark scoring
+- rows need identity, source URLs, and evidence quotes to be accepted
+- missing requested fields lower completeness but do not automatically reject a
+  row
+- a candidate recipe only replaces the active recipe when validation or benchmark
+  score improves without a regression
+
+PR2 should add the real Playwright executor, timeout handling, artifact capture,
+and sandbox boundaries. DB persistence and cron should wait until that runner is
+trustworthy.
+
 ## How To Plug In An Existing Agent
 
 Do not rewrite the benchmark. Write a thin adapter around the current agent.


### PR DESCRIPTION
## Summary
- add recipe metadata, artifact, production validation, benchmark score, and recipe run result types
- add a fake recipe runtime that returns the existing dataset-agent output contract
- add promotion logic that only promotes candidates when production validation or benchmark score improves without regression
- document the PR1/PR2 split for the recipe healer flow

## Verification
- npm --prefix backend test
- npm --prefix backend run build
- node --check benchmarks/dataset-agent/run-benchmark.mjs
- git diff --check

## Stack
- Base PR: #18, branch codex/live-benchmark
- This PR: PR1 contract/fake-runner/promotion gate
- Next PR: PR2 real Playwright runner plus artifacts and isolation

## Notes
- No real env files inspected or printed.
- No auto-merge.