### PR TITLE
feat: add playwright recipe runner

### DIFF
--- a/backend/src/dataset-agent/index.ts
+++ b/backend/src/dataset-agent/index.ts
@@ -19,6 +19,9 @@ export {
   evaluateRecipeProductionValidation,
   FakeDatasetRecipeRuntime,
 } from "./recipe-runtime.js";
+export {
+  PlaywrightRecipeRunner,
+} from "./playwright-recipe-runner.js";
 export type {
   DatasetRecipe,
   DatasetRecipeArtifact,
@@ -28,6 +31,12 @@ export type {
   DatasetRecipeRunResult,
   DatasetRecipeRuntime,
 } from "./recipe-types.js";
+export type {
+  DatasetRecipeBrowserFactory,
+  DatasetRecipeBrowserSession,
+  DatasetRecipePageLike,
+  DatasetRecipeScriptContext,
+} from "./playwright-recipe-runner.js";
 
 export function createDatasetAgentRuntime(input: {
   runtime?: string;

--- a/backend/src/dataset-agent/playwright-recipe-runner.ts
+++ b/backend/src/dataset-agent/playwright-recipe-runner.ts
@@ -1,0 +1,284 @@
+import vm from "node:vm";
+
+import { emptyMetrics, normalizeDatasetAgentResult } from "./output.js";
+import { createDatasetRecipeRunResult } from "./recipe-runtime.js";
+import type {
+  DatasetRecipeArtifact,
+  DatasetRecipeRunInput,
+  DatasetRecipeRunResult,
+  DatasetRecipeRuntime,
+} from "./recipe-types.js";
+import type { DatasetAgentEvidence, DatasetAgentRow } from "./types.js";
+
+const DEFAULT_RECIPE_TIMEOUT_MS = 30_000;
+const SCRIPT_COMPILE_TIMEOUT_MS = 1_000;
+const MAX_ARTIFACT_TEXT_CHARS = 20_000;
+
+export interface DatasetRecipePageLike {
+  goto?(url: string): Promise<unknown>;
+  content?(): Promise<string>;
+  screenshot?(input?: { type?: "png"; fullPage?: boolean }): Promise<unknown>;
+  url?(): string;
+}
+
+export interface DatasetRecipeBrowserSession {
+  page: DatasetRecipePageLike;
+  close(): Promise<void>;
+  collectArtifacts?(): Promise<DatasetRecipeArtifact[]>;
+}
+
+export type DatasetRecipeBrowserFactory =
+  () => Promise<DatasetRecipeBrowserSession>;
+
+export interface DatasetRecipeScriptContext {
+  page: DatasetRecipePageLike;
+  input: DatasetRecipeRunInput["runInput"];
+  emitRow(row: Partial<DatasetAgentRow> & {
+    cells: Record<string, unknown>;
+  }): void;
+  addEvidence(evidence: DatasetAgentEvidence): void;
+  log(message: string): void;
+}
+
+export class PlaywrightRecipeRunner implements DatasetRecipeRuntime {
+  private readonly browserFactory: DatasetRecipeBrowserFactory;
+  private readonly timeoutMs: number;
+
+  constructor(input: {
+    browserFactory?: DatasetRecipeBrowserFactory;
+    timeoutMs?: number;
+  } = {}) {
+    this.browserFactory = input.browserFactory ?? createDefaultPlaywrightSession;
+    this.timeoutMs = input.timeoutMs ?? DEFAULT_RECIPE_TIMEOUT_MS;
+  }
+
+  async runRecipe(input: DatasetRecipeRunInput): Promise<DatasetRecipeRunResult> {
+    const startedAtMs = Date.now();
+    const startedAt = new Date(startedAtMs).toISOString();
+    const emittedRows: Array<Partial<DatasetAgentRow> & {
+      cells: Record<string, unknown>;
+    }> = [];
+    const sharedEvidence: DatasetAgentEvidence[] = [];
+    const logs: string[] = [];
+    const artifacts: DatasetRecipeArtifact[] = [];
+    let session: DatasetRecipeBrowserSession | undefined;
+    let failureMessage: string | undefined;
+
+    try {
+      session = await this.browserFactory();
+      await runRecipeScriptWithTimeout({
+        scriptText: input.recipe.scriptText,
+        timeoutMs: this.timeoutMs,
+        context: {
+          page: session.page,
+          input: input.runInput,
+          emitRow(row) {
+            emittedRows.push(row);
+          },
+          addEvidence(evidence) {
+            sharedEvidence.push(evidence);
+          },
+          log(message) {
+            logs.push(message);
+          },
+        },
+      });
+    } catch (error) {
+      failureMessage = error instanceof Error ? error.message : String(error);
+    }
+
+    if (logs.length > 0) {
+      artifacts.push({
+        kind: "stdout",
+        label: "recipe-log",
+        content: logs.join("\n").slice(0, MAX_ARTIFACT_TEXT_CHARS),
+      });
+    }
+    if (failureMessage) {
+      artifacts.push({
+        kind: "stderr",
+        label: "recipe-error",
+        content: failureMessage,
+      });
+    }
+    if (session?.collectArtifacts) {
+      artifacts.push(...await session.collectArtifacts());
+    } else if (session?.page) {
+      artifacts.push(...await collectDefaultPageArtifacts(session.page));
+    }
+
+    await session?.close();
+
+    const normalizedResult = normalizeDatasetAgentResult({
+      rawOutput: {
+        rows: emittedRows.map((row) => ({
+          ...row,
+          evidence: row.evidence?.length ? row.evidence : sharedEvidence,
+        })),
+        validationIssues: failureMessage ? [failureMessage] : [],
+      },
+      runInput: input.runInput,
+      metrics: {
+        ...emptyMetrics(),
+        browserCalls: session ? 1 : 0,
+      },
+    });
+
+    return createDatasetRecipeRunResult({
+      recipe: input.recipe,
+      runInput: input.runInput,
+      result: normalizedResult,
+      runStatus: failureMessage ? "failed" : "succeeded",
+      startedAt,
+      completedAt: new Date().toISOString(),
+      runtimeMs: Date.now() - startedAtMs,
+      artifacts,
+    });
+  }
+}
+
+async function runRecipeScriptWithTimeout(input: {
+  scriptText: string;
+  timeoutMs: number;
+  context: DatasetRecipeScriptContext;
+}): Promise<void> {
+  const runDatasetRecipe = compileRecipeScript(input.scriptText);
+  await timeoutPromise(
+    Promise.resolve(runDatasetRecipe(input.context)),
+    input.timeoutMs
+  );
+}
+
+function compileRecipeScript(scriptText: string): (
+  context: DatasetRecipeScriptContext
+) => unknown {
+  const moduleContainer = { exports: {} as Record<string, unknown> };
+  const sandbox = vm.createContext({
+    module: moduleContainer,
+    exports: moduleContainer.exports,
+    console: {
+      log: (...values: unknown[]) => values.join(" "),
+    },
+    setTimeout,
+    clearTimeout,
+    Promise,
+  });
+  const script = new vm.Script(toCommonJsRecipeScript(scriptText));
+  script.runInContext(sandbox, { timeout: SCRIPT_COMPILE_TIMEOUT_MS });
+  const runDatasetRecipe = moduleContainer.exports.runDatasetRecipe;
+
+  if (typeof runDatasetRecipe !== "function") {
+    throw new Error("Recipe script must export runDatasetRecipe(context).");
+  }
+
+  return runDatasetRecipe as (context: DatasetRecipeScriptContext) => unknown;
+}
+
+function toCommonJsRecipeScript(scriptText: string): string {
+  const commonJsText = scriptText
+    .replace(
+      /export\s+async\s+function\s+runDatasetRecipe\s*\(/,
+      "async function runDatasetRecipe("
+    )
+    .replace(
+      /export\s+function\s+runDatasetRecipe\s*\(/,
+      "function runDatasetRecipe("
+    );
+
+  return [
+    "\"use strict\";",
+    commonJsText,
+    "if (typeof runDatasetRecipe === 'function' && !module.exports.runDatasetRecipe) {",
+    "  module.exports.runDatasetRecipe = runDatasetRecipe;",
+    "}",
+  ].join("\n");
+}
+
+async function timeoutPromise<T>(
+  promise: Promise<T>,
+  timeoutMs: number
+): Promise<T> {
+  let timeoutHandle: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(() => {
+      reject(new Error(`Recipe timed out after ${timeoutMs}ms.`));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
+
+async function collectDefaultPageArtifacts(
+  page: DatasetRecipePageLike
+): Promise<DatasetRecipeArtifact[]> {
+  const artifacts: DatasetRecipeArtifact[] = [];
+
+  if (page.url) {
+    artifacts.push({
+      kind: "url-history",
+      label: "final-url",
+      content: page.url(),
+    });
+  }
+
+  if (page.content) {
+    const content = await page.content();
+    artifacts.push({
+      kind: "dom",
+      label: "final-dom",
+      content: content.slice(0, MAX_ARTIFACT_TEXT_CHARS),
+    });
+  }
+
+  if (page.screenshot) {
+    const screenshot = await page.screenshot({ type: "png", fullPage: true });
+    artifacts.push({
+      kind: "screenshot",
+      label: "final-screenshot",
+      content: screenshotToContent(screenshot),
+    });
+  }
+
+  return artifacts;
+}
+
+function screenshotToContent(value: unknown): string {
+  if (typeof value === "string") {
+    return value.slice(0, MAX_ARTIFACT_TEXT_CHARS);
+  }
+  if (value instanceof Uint8Array) {
+    return Buffer.from(value).toString("base64");
+  }
+  return "";
+}
+
+async function createDefaultPlaywrightSession(): Promise<DatasetRecipeBrowserSession> {
+  const dynamicImport = new Function("specifier", "return import(specifier)") as (
+    specifier: string
+  ) => Promise<Record<string, unknown>>;
+  const playwright = await dynamicImport("playwright");
+  const chromium = playwright.chromium as {
+    launch(input: { headless: boolean }): Promise<{
+      newPage(): Promise<DatasetRecipePageLike>;
+      close(): Promise<void>;
+    }>;
+  } | undefined;
+
+  if (!chromium) {
+    throw new Error("Playwright chromium launcher is unavailable.");
+  }
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+
+  return {
+    page,
+    close: () => browser.close(),
+  };
+}

--- a/backend/test/dataset-agent-playwright-recipe-runner.test.ts
+++ b/backend/test/dataset-agent-playwright-recipe-runner.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  createDatasetRecipe,
+  PlaywrightRecipeRunner,
+} from "../src/dataset-agent/index.js";
+import type {
+  DatasetAgentRunInput,
+  DatasetRecipePageLike,
+} from "../src/dataset-agent/index.js";
+
+const runInput: DatasetAgentRunInput = {
+  prompt: "Find latest blog posts from OpenAI with title and source URL.",
+  promptId: "playwright-recipe-fixture",
+  promptQuality: "good",
+  requiredColumns: ["entity_name", "latest_post_title", "source_url"],
+};
+
+test("Playwright recipe runner executes a generated recipe against a page context", async () => {
+  const page = new StaticFixturePage();
+  const recipe = createDatasetRecipe({
+    recipeId: "playwright-recipe-success",
+    datasetId: "dataset-ai-posts",
+    version: 1,
+    scriptText: `
+      export async function runDatasetRecipe({ page, emitRow, log }) {
+        log("opening fixture page");
+        await page.goto("https://fixture.local/news");
+        const entityName = await page.textContent("h1");
+        const latestPostTitle = await page.textContent("article h2");
+        const sourceUrl = page.url();
+
+        emitRow({
+          cells: {
+            entity_name: entityName,
+            latest_post_title: latestPostTitle,
+            source_url: sourceUrl
+          },
+          sourceUrls: [sourceUrl],
+          evidence: [{
+            columnName: "latest_post_title",
+            sourceUrl,
+            quote: latestPostTitle
+          }],
+          needsReview: false
+        });
+      }
+    `,
+    requestedColumns: runInput.requiredColumns,
+    sourcePrompt: runInput.prompt,
+  });
+  const runner = new PlaywrightRecipeRunner({
+    browserFactory: async () => ({
+      page,
+      close: async () => {
+        page.wasClosed = true;
+      },
+    }),
+    timeoutMs: 1_000,
+  });
+
+  const result = await runner.runRecipe({ recipe, runInput });
+
+  assert.equal(result.runStatus, "succeeded");
+  assert.equal(result.rows.length, 1);
+  assert.equal(result.rows[0]?.cells.entity_name, "OpenAI");
+  assert.equal(result.productionValidation.isValid, true);
+  assert.equal(result.productionValidation.requestedCellCompletenessRatio, 1);
+  assert.equal(result.metrics.browserCalls, 1);
+  assert.equal(page.wasClosed, true);
+  assert.deepEqual(
+    result.artifacts.map((artifact) => artifact.kind),
+    ["stdout", "url-history", "dom", "screenshot"]
+  );
+});
+
+test("Playwright recipe runner captures timeout failures as failed runs", async () => {
+  const page = new StaticFixturePage();
+  const recipe = createDatasetRecipe({
+    recipeId: "playwright-recipe-timeout",
+    datasetId: "dataset-ai-posts",
+    version: 1,
+    scriptText: `
+      export async function runDatasetRecipe() {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+    `,
+    requestedColumns: runInput.requiredColumns,
+    sourcePrompt: runInput.prompt,
+  });
+  const runner = new PlaywrightRecipeRunner({
+    browserFactory: async () => ({
+      page,
+      close: async () => {
+        page.wasClosed = true;
+      },
+    }),
+    timeoutMs: 5,
+  });
+
+  const result = await runner.runRecipe({ recipe, runInput });
+
+  assert.equal(result.runStatus, "failed");
+  assert.equal(result.productionValidation.isValid, false);
+  assert.match(result.validationIssues.join("\n"), /timed out/i);
+  assert.equal(page.wasClosed, true);
+  assert.ok(result.artifacts.some((artifact) => artifact.kind === "stderr"));
+});
+
+class StaticFixturePage implements DatasetRecipePageLike {
+  wasClosed = false;
+  private currentUrl = "";
+
+  async goto(url: string): Promise<void> {
+    this.currentUrl = url;
+  }
+
+  async textContent(selector: string): Promise<string> {
+    if (selector === "h1") {
+      return "OpenAI";
+    }
+    if (selector === "article h2") {
+      return "Release notes";
+    }
+    return "";
+  }
+
+  url(): string {
+    return this.currentUrl;
+  }
+
+  async content(): Promise<string> {
+    return "<html><body><h1>OpenAI</h1><article><h2>Release notes</h2></article></body></html>";
+  }
+
+  async screenshot(): Promise<Uint8Array> {
+    return new Uint8Array([1, 2, 3]);
+  }
+}

--- a/benchmarks/dataset-agent/README.md
+++ b/benchmarks/dataset-agent/README.md
@@ -129,9 +129,11 @@ PR1 proves:
 - a candidate recipe only replaces the active recipe when validation or benchmark
   score improves without a regression
 
-PR2 should add the real Playwright executor, timeout handling, artifact capture,
-and sandbox boundaries. DB persistence and cron should wait until that runner is
-trustworthy.
+PR2 adds `PlaywrightRecipeRunner`, which executes the generated
+`runDatasetRecipe(context)` function with a page context, timeout, row emitter,
+and artifact capture. It can use an injected browser factory for tests or load
+Playwright dynamically at runtime when the package is available. DB persistence
+and cron should wait until sandboxing is stricter than this first runner.
 
 ## How To Plug In An Existing Agent
 


### PR DESCRIPTION
## Summary
- add PlaywrightRecipeRunner for executing generated runDatasetRecipe(context) scripts
- inject a page context, emit rows through the existing dataset-agent output contract, and collect stdout/stderr/DOM/screenshot/final URL artifacts
- enforce an async recipe timeout and return failed recipe runs with validation issues when execution breaks
- add integration-style tests using a static fake page fixture

## Verification
- npm --prefix backend test
- npm --prefix backend run build
- node --check benchmarks/dataset-agent/run-benchmark.mjs
- git diff --check

## Stack
- Base PR: #20, branch codex/recipe-healer-contract
- This PR: PR2 runner/artifacts/timeout slice
- Later PR: persistence, cron, stronger isolation

## Notes
- The default runner dynamically loads Playwright only at runtime; tests use an injected page factory, so no browser binary or env secret is needed.
- No real env files inspected or printed.
- No auto-merge.