### PR TITLE
chore: default dataset agent to Gemini Flash Lite

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@fastify/cors": "^11.0.0",
+        "@openrouter/ai-sdk-provider": "^2.9.0",
         "@tiny-fish/sdk": "^0.0.8",
         "ai": "^6.0.185",
         "convex": "^1.39.1",
@@ -197,6 +198,19 @@
       "dependencies": {
         "@fastify/forwarded": "^3.0.0",
         "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@openrouter/ai-sdk-provider": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@openrouter/ai-sdk-provider/-/ai-sdk-provider-2.9.0.tgz",
+      "integrity": "sha512-Seva+NCa0WUQnJIUE5GzHsUv1WTIeyqwz0ELl2VtS6NP+eF+77yCXGFVOMbvoCM7QMjlnhv7931e89R+8pJdcQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "ai": "^6.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@opentelemetry/api": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@fastify/cors": "^11.0.0",
+    "@openrouter/ai-sdk-provider": "^2.9.0",
     "@tiny-fish/sdk": "^0.0.8",
     "ai": "^6.0.185",
     "convex": "^1.39.1",

--- a/backend/src/dataset-agent/ai-sdk-runtime.ts
+++ b/backend/src/dataset-agent/ai-sdk-runtime.ts
@@ -11,6 +11,7 @@ import {
 } from "./output.js";
 import type {
   DatasetAgentMetrics,
+  DatasetAgentRunResult,
   DatasetAgentRunInput,
   DatasetAgentRuntime,
   DatasetAgentToolProvider,
@@ -144,10 +145,7 @@ export class AiSdkDatasetAgentRuntime implements DatasetAgentRuntime {
       metrics,
     });
 
-    if (
-      repairedResult.validationIssues.length <=
-      firstResult.validationIssues.length
-    ) {
+    if (isRepairResultBetter({ firstResult, repairedResult })) {
       return repairedResult;
     }
 
@@ -157,6 +155,69 @@ export class AiSdkDatasetAgentRuntime implements DatasetAgentRuntime {
       metrics: { ...metrics },
     };
   }
+}
+
+function isRepairResultBetter(input: {
+  firstResult: DatasetAgentRunResult;
+  repairedResult: DatasetAgentRunResult;
+}): boolean {
+  if (
+    input.firstResult.rows.length > 0 &&
+    input.repairedResult.rows.length === 0
+  ) {
+    return false;
+  }
+
+  if (
+    input.repairedResult.validationIssues.length === 0 &&
+    input.firstResult.validationIssues.length > 0
+  ) {
+    return true;
+  }
+
+  return (
+    resultUsefulnessScore(input.repairedResult) >
+    resultUsefulnessScore(input.firstResult)
+  );
+}
+
+function resultUsefulnessScore(result: DatasetAgentRunResult): number {
+  const nonEmptyCellCount = result.rows.reduce(
+    (total, row) =>
+      total +
+      Object.values(row.cells).filter((cellValue) => isUsefulCell(cellValue))
+        .length,
+    0
+  );
+  const sourceUrlCount = result.rows.reduce(
+    (total, row) => total + row.sourceUrls.length,
+    0
+  );
+  const evidenceQuoteCount = result.rows.reduce(
+    (total, row) => total + row.evidence.length,
+    0
+  );
+
+  return (
+    result.rows.length * 4 +
+    nonEmptyCellCount * 2 +
+    sourceUrlCount +
+    evidenceQuoteCount -
+    result.validationIssues.length * 3
+  );
+}
+
+function isUsefulCell(value: unknown): boolean {
+  if (value === null || value === undefined) {
+    return false;
+  }
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  return true;
 }
 
 async function generateWithTelemetry(input: {

--- a/backend/src/dataset-agent/ai-sdk-runtime.ts
+++ b/backend/src/dataset-agent/ai-sdk-runtime.ts
@@ -1,5 +1,5 @@
 import { Output, ToolLoopAgent, stepCountIs, tool } from "ai";
-import type { ToolSet } from "ai";
+import type { LanguageModel, ToolSet } from "ai";
 import { z } from "zod";
 
 import {
@@ -57,8 +57,10 @@ interface AiSdkAgentLike {
   generate(input: { prompt: string }): Promise<AiSdkGenerateResultLike>;
 }
 
+export type DatasetAgentAiSdkModel = LanguageModel | string;
+
 interface CreateAiSdkAgentInput {
-  model: string;
+  model: DatasetAgentAiSdkModel;
   instructions: string;
   tools: ToolSet;
   maxSteps: number;
@@ -68,14 +70,14 @@ interface CreateAiSdkAgentInput {
 type AiSdkAgentFactory = (input: CreateAiSdkAgentInput) => AiSdkAgentLike;
 
 export class AiSdkDatasetAgentRuntime implements DatasetAgentRuntime {
-  private readonly model: string;
+  private readonly model: DatasetAgentAiSdkModel;
   private readonly maxSteps: number;
   private readonly maxRepairAttempts: number;
   private readonly toolProvider: DatasetAgentToolProvider;
   private readonly createAgent: AiSdkAgentFactory;
 
   constructor(input: {
-    model: string;
+    model: DatasetAgentAiSdkModel;
     toolProvider: DatasetAgentToolProvider;
     maxSteps?: number;
     maxRepairAttempts?: number;
@@ -129,7 +131,7 @@ export class AiSdkDatasetAgentRuntime implements DatasetAgentRuntime {
       agent,
       prompt: createRepairPrompt({
         input,
-        invalidOutput: firstGeneration.output ?? firstGeneration.text ?? {},
+        invalidOutput: generationRawOutput(firstGeneration),
         validationIssues: firstResult.validationIssues,
       }),
       usage,
@@ -182,18 +184,56 @@ function normalizeGenerationResult(input: {
   metrics: DatasetAgentMetrics;
 }) {
   return normalizeDatasetAgentResult({
-    rawOutput:
-      input.generation.output ??
-      (input.generation.text ? parseOutputFromText(input.generation.text) : {}),
+    rawOutput: generationRawOutput(input.generation),
     runInput: input.runInput,
     usage: input.usage,
     metrics: input.metrics,
   });
 }
 
+function generationRawOutput(generation: AiSdkGenerateResultLike): unknown {
+  const outputField = readGenerationField(generation, "output");
+  if (
+    outputField.ok &&
+    outputField.value !== undefined &&
+    outputField.value !== null
+  ) {
+    return outputField.value;
+  }
+
+  const textField = readGenerationField(generation, "text");
+  if (textField.ok && typeof textField.value === "string") {
+    return parseOutputFromText(textField.value);
+  }
+
+  return {
+    rows: [],
+    validationIssues: [
+      outputField.ok
+        ? "AI SDK generated no structured output."
+        : `AI SDK structured output unavailable: ${errorMessage(outputField.error)}`,
+    ],
+  };
+}
+
+function readGenerationField<FieldName extends keyof AiSdkGenerateResultLike>(
+  generation: AiSdkGenerateResultLike,
+  fieldName: FieldName
+):
+  | { ok: true; value: AiSdkGenerateResultLike[FieldName] }
+  | { ok: false; error: unknown } {
+  try {
+    return { ok: true, value: generation[fieldName] };
+  } catch (error) {
+    return { ok: false, error };
+  }
+}
+
 function createToolLoopAgent(input: CreateAiSdkAgentInput): AiSdkAgentLike {
   return new ToolLoopAgent({
     model: input.model,
+    temperature: 0,
+    maxOutputTokens: 3_000,
     instructions: input.instructions,
     tools: input.tools,
     output: Output.object({ schema: datasetAgentOutputSchema }),
@@ -210,6 +250,10 @@ function createInstructions(input: DatasetAgentRunInput): string {
     "Build source-backed rows from web data. Never guess missing facts.",
     "Use search first, fetch source pages next, and browser automation only when fetch cannot verify the requested value.",
     "Every row must include cells, sourceUrls, and evidence quotes copied from source text or browser output.",
+    "Put the actual extracted values in cells. Evidence supports cells; evidence does not replace cells.",
+    "For named entities in the user request, return one row per entity when an official source can back the identity and at least one requested value.",
+    "Do not return zero rows after fetching official sources. Return partial source-backed rows with needsReview true when optional requested values are incomplete.",
+    "Once enough official evidence is found for the requested entities, stop searching and return the rows.",
     "Set needsReview true when the source is weak, ambiguous, stale, or incomplete.",
     `Requested columns: ${input.requiredColumns.join(", ")}`,
     `Minimum required columns for accepting a row: ${minimumRequiredColumns.join(", ") || "none"}`,
@@ -228,7 +272,7 @@ function createPrompt(input: DatasetAgentRunInput): string {
     minimumRequiredColumns,
     outputShape: {
       rows:
-        "Array of rows with cells keyed by requested column when source-backed, sourceUrls, evidence, needsReview.",
+        "Array of rows with cells keyed by requested column when source-backed. cells must contain the extracted values; sourceUrls and evidence prove them.",
       validationIssues:
         "Concrete validation problems. Empty only when all rows are source-backed.",
     },
@@ -253,6 +297,7 @@ function createRepairPrompt(input: {
       "Do not invent values.",
       "Every row needs at least one source URL.",
       "Every row needs at least one evidence quote.",
+      "Every source-backed value must be written into cells under the matching requested column.",
       "Every minimum required column must be present or the row should be omitted.",
       "Requested columns outside the minimum can be null or missing when the source does not prove them.",
       "If source-backed rows cannot be produced, return rows: [] and validationIssues explaining why.",
@@ -328,4 +373,8 @@ function addUsage(target: DatasetAgentUsage, usage?: AiSdkUsageLike) {
 function numericValue(value: unknown): number {
   const numeric = Number(value);
   return Number.isFinite(numeric) ? numeric : 0;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/backend/src/dataset-agent/ai-sdk-runtime.ts
+++ b/backend/src/dataset-agent/ai-sdk-runtime.ts
@@ -5,6 +5,9 @@ import { z } from "zod";
 import {
   emptyMetrics,
   emptyUsage,
+  entityCandidateMatchesSource,
+  entityCandidatesFromPrompt,
+  isUrlColumn,
   minimumRequiredColumnsForRunInput,
   normalizeDatasetAgentResult,
   parseOutputFromText,
@@ -244,12 +247,31 @@ function normalizeGenerationResult(input: {
   usage: DatasetAgentUsage;
   metrics: DatasetAgentMetrics;
 }) {
-  return normalizeDatasetAgentResult({
+  const normalizedResult = normalizeDatasetAgentResult({
     rawOutput: generationRawOutput(input.generation),
     runInput: input.runInput,
     usage: input.usage,
     metrics: input.metrics,
   });
+  if (normalizedResult.rows.length > 0) {
+    return normalizedResult;
+  }
+
+  const recoveredOutput = recoverOutputFromToolResults({
+    steps: input.generation.steps ?? [],
+    runInput: input.runInput,
+  });
+  if (!recoveredOutput) {
+    return normalizedResult;
+  }
+
+  const recoveredResult = normalizeDatasetAgentResult({
+    rawOutput: recoveredOutput,
+    runInput: input.runInput,
+    usage: input.usage,
+    metrics: input.metrics,
+  });
+  return recoveredResult.rows.length > 0 ? recoveredResult : normalizedResult;
 }
 
 function generationRawOutput(generation: AiSdkGenerateResultLike): unknown {
@@ -288,6 +310,171 @@ function readGenerationField<FieldName extends keyof AiSdkGenerateResultLike>(
   } catch (error) {
     return { ok: false, error };
   }
+}
+
+function recoverOutputFromToolResults(input: {
+  steps: unknown[];
+  runInput: DatasetAgentRunInput;
+}): { rows: unknown[]; validationIssues: string[] } | null {
+  const sourceBackedRows = sourceSnippetsFromSteps(input.steps)
+    .filter((snippet) =>
+      sourceSnippetMatchesPrompt({
+        snippet,
+        prompt: input.runInput.prompt,
+        minimumRequiredColumns: minimumRequiredColumnsForRunInput(input.runInput),
+      })
+    )
+    .slice(0, 12)
+    .map((snippet) => rowFromSourceSnippet(snippet, input.runInput));
+
+  if (sourceBackedRows.length === 0) {
+    return null;
+  }
+
+  return {
+    rows: sourceBackedRows,
+    validationIssues: [
+      "Recovered partial rows from tool results after the model returned no rows.",
+    ],
+  };
+}
+
+function sourceSnippetsFromSteps(steps: unknown[]): SourceSnippet[] {
+  const snippets: SourceSnippet[] = [];
+  for (const step of steps) {
+    for (const toolResult of toolResultsFromStep(step)) {
+      snippets.push(...sourceSnippetsFromToolOutput(toolResult.output));
+    }
+  }
+  return dedupeSourceSnippets(snippets);
+}
+
+interface SourceSnippet {
+  url: string;
+  title?: string;
+  text?: string;
+}
+
+function toolResultsFromStep(step: unknown): Array<{ output: unknown }> {
+  if (!isRecord(step)) {
+    return [];
+  }
+  const toolResults = step.toolResults;
+  if (!Array.isArray(toolResults)) {
+    return [];
+  }
+  return toolResults.filter(
+    (toolResult): toolResult is { output: unknown } =>
+      isRecord(toolResult) && "output" in toolResult
+  );
+}
+
+function sourceSnippetsFromToolOutput(output: unknown): SourceSnippet[] {
+  if (Array.isArray(output)) {
+    return output.flatMap(sourceSnippetsFromToolOutput);
+  }
+  if (!isRecord(output)) {
+    return [];
+  }
+
+  const url = stringValue(output.finalUrl) ?? stringValue(output.url);
+  if (!url || !/^https?:\/\//i.test(url)) {
+    return [];
+  }
+
+  return [
+    {
+      url,
+      title: stringValue(output.title),
+      text:
+        stringValue(output.snippet) ??
+        stringValue(output.text) ??
+        stringValue(output.markdown) ??
+        stringifyPayload(output.payload),
+    },
+  ];
+}
+
+function dedupeSourceSnippets(snippets: SourceSnippet[]): SourceSnippet[] {
+  const seenUrls = new Set<string>();
+  const uniqueSnippets: SourceSnippet[] = [];
+  for (const snippet of snippets) {
+    if (seenUrls.has(snippet.url)) {
+      continue;
+    }
+    seenUrls.add(snippet.url);
+    uniqueSnippets.push(snippet);
+  }
+  return uniqueSnippets;
+}
+
+function sourceSnippetMatchesPrompt(input: {
+  snippet: SourceSnippet;
+  prompt: string;
+  minimumRequiredColumns: string[];
+}): boolean {
+  if (input.minimumRequiredColumns.some((columnName) => isUrlColumn(columnName))) {
+    return true;
+  }
+
+  const sourceText = [input.snippet.url, input.snippet.title, input.snippet.text].join(" ");
+  return entityCandidatesFromPrompt(input.prompt).some((candidate) =>
+    entityCandidateMatchesSource(candidate, sourceText)
+  );
+}
+
+function rowFromSourceSnippet(
+  snippet: SourceSnippet,
+  runInput: DatasetAgentRunInput
+) {
+  const cells: Record<string, unknown> = {};
+  for (const columnName of runInput.requiredColumns) {
+    if (isUrlColumn(columnName)) {
+      cells[columnName] = snippet.url;
+    }
+  }
+
+  return {
+    cells,
+    sourceUrls: [snippet.url],
+    evidence: [
+      {
+        columnName: firstUrlColumn(runInput.requiredColumns) ?? "source_url",
+        sourceUrl: snippet.url,
+        quote: evidenceQuoteFromSnippet(snippet),
+      },
+    ],
+    needsReview: true,
+  };
+}
+
+function evidenceQuoteFromSnippet(snippet: SourceSnippet): string {
+  const rawQuote = snippet.text ?? snippet.title ?? snippet.url;
+  const normalizedQuote = rawQuote.replace(/\s+/g, " ").trim();
+  return normalizedQuote.slice(0, 500) || snippet.url;
+}
+
+function firstUrlColumn(columnNames: string[]): string | undefined {
+  return columnNames.find((columnName) => isUrlColumn(columnName));
+}
+
+function stringifyPayload(value: unknown): string | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  try {
+    return JSON.stringify(value).slice(0, 1_000);
+  } catch {
+    return undefined;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
 }
 
 function createToolLoopAgent(input: CreateAiSdkAgentInput): AiSdkAgentLike {

--- a/backend/src/dataset-agent/index.ts
+++ b/backend/src/dataset-agent/index.ts
@@ -70,7 +70,7 @@ export function createDatasetAgentRuntime(input: {
 
   return new AiSdkDatasetAgentRuntime({
     model: createOpenRouterDatasetAgentModel(
-      input.model ?? DEFAULT_DATASET_AGENT_MODEL
+      input.model ?? process.env.DATASET_AGENT_MODEL ?? DEFAULT_DATASET_AGENT_MODEL
     ),
     maxSteps: input.maxSteps ?? numberEnv("DATASET_AGENT_MAX_STEPS", 8),
     toolProvider,

--- a/backend/src/dataset-agent/index.ts
+++ b/backend/src/dataset-agent/index.ts
@@ -1,3 +1,6 @@
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import type { LanguageModel } from "ai";
+
 import { AiSdkDatasetAgentRuntime } from "./ai-sdk-runtime.js";
 import { DeterministicDatasetAgentRuntime } from "./deterministic-runtime.js";
 import { createTinyFishToolProvider } from "./tinyfish-tools.js";
@@ -66,7 +69,9 @@ export function createDatasetAgentRuntime(input: {
   }
 
   return new AiSdkDatasetAgentRuntime({
-    model: input.model ?? DEFAULT_DATASET_AGENT_MODEL,
+    model: createOpenRouterDatasetAgentModel(
+      input.model ?? DEFAULT_DATASET_AGENT_MODEL
+    ),
     maxSteps: input.maxSteps ?? numberEnv("DATASET_AGENT_MAX_STEPS", 8),
     toolProvider,
   });
@@ -79,4 +84,17 @@ export async function runDatasetAgentFromEnv(input: DatasetAgentRunInput) {
 function numberEnv(name: string, fallback: number): number {
   const value = Number(process.env[name]);
   return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function createOpenRouterDatasetAgentModel(modelId: string): LanguageModel {
+  if (!process.env.OPENROUTER_API_KEY) {
+    throw new Error(
+      "Missing OPENROUTER_API_KEY. Load it execution-only for the OpenRouter Gemini dataset-agent model."
+    );
+  }
+
+  return createOpenRouter({
+    apiKey: process.env.OPENROUTER_API_KEY,
+    appName: "BigSet Dataset Agent",
+  })(modelId);
 }

--- a/backend/src/dataset-agent/index.ts
+++ b/backend/src/dataset-agent/index.ts
@@ -7,6 +7,8 @@ import type {
   DatasetAgentToolProvider,
 } from "./types.js";
 
+export const DEFAULT_DATASET_AGENT_MODEL = "google/gemini-3.1-flash-lite";
+
 export type { DatasetAgentRunInput, DatasetAgentRunResult } from "./types.js";
 export {
   applyRecipePromotionDecision,
@@ -64,7 +66,7 @@ export function createDatasetAgentRuntime(input: {
   }
 
   return new AiSdkDatasetAgentRuntime({
-    model: input.model ?? process.env.DATASET_AGENT_MODEL ?? "openai/gpt-5.4",
+    model: input.model ?? DEFAULT_DATASET_AGENT_MODEL,
     maxSteps: input.maxSteps ?? numberEnv("DATASET_AGENT_MAX_STEPS", 8),
     toolProvider,
   });

--- a/backend/src/dataset-agent/output.ts
+++ b/backend/src/dataset-agent/output.ts
@@ -344,7 +344,7 @@ function inferConservativeMinimumRequiredColumns(columns: string[]): string[] {
   return fallbackIdentityColumn ? [fallbackIdentityColumn] : [];
 }
 
-function isUrlColumn(columnName: string): boolean {
+export function isUrlColumn(columnName: string): boolean {
   const normalizedColumnName = columnName.toLowerCase();
   return (
     normalizedColumnName === "source_url" ||
@@ -396,7 +396,7 @@ function sourceUrlText(sourceUrl: string): string {
   }
 }
 
-function entityCandidatesFromPrompt(prompt: string): string[] {
+export function entityCandidatesFromPrompt(prompt: string): string[] {
   const candidates: string[] = [];
   const entityPattern =
     /\b[A-Z][A-Za-z0-9&.-]*(?:\s+[A-Z][A-Za-z0-9&.-]*){0,3}/g;
@@ -444,7 +444,7 @@ function trimEntityCandidate(candidate: string): string | undefined {
   return trimmedCandidate.length >= 2 ? trimmedCandidate : undefined;
 }
 
-function entityCandidateMatchesSource(
+export function entityCandidateMatchesSource(
   candidate: string,
   sourceText: string
 ): boolean {
@@ -462,7 +462,7 @@ function entityCandidateMatchesSource(
   );
 }
 
-function normalizeIdentityText(value: string): string {
+export function normalizeIdentityText(value: string): string {
   return value.toLowerCase().replace(/[^a-z0-9]/g, "");
 }
 

--- a/backend/src/dataset-agent/output.ts
+++ b/backend/src/dataset-agent/output.ts
@@ -47,7 +47,7 @@ export function normalizeDatasetAgentResult(input: {
       outputRecord.data ??
       outputRecord.records ??
       outputRecord.result
-  ).map(normalizeRow);
+  ).map((row) => normalizeRow(row, input.runInput));
   const validationIssues = [
     ...stringArrayValue(
       outputRecord.validationIssues ??
@@ -90,15 +90,27 @@ export function parseOutputFromText(text: string): unknown {
   }
 }
 
-function normalizeRow(row: unknown): DatasetAgentRow {
+function normalizeRow(row: unknown, runInput: DatasetAgentRunInput): DatasetAgentRow {
   const rowRecord = isRecord(row) ? row : {};
-  const cells = normalizeCells(rowRecord.cells ?? rowRecord.data ?? rowRecord);
-  const sourceUrls = normalizeSourceUrls(rowRecord, cells);
+  const explicitCells = normalizeCells(
+    rowRecord.cells ?? rowRecord.data ?? rowRecord
+  );
+  const sourceUrls = normalizeSourceUrls(rowRecord, explicitCells);
+  const evidence = normalizeEvidence(rowRecord, sourceUrls);
+  const evidenceBackedCells = fillMissingCellsFromEvidence(
+    explicitCells,
+    evidence
+  );
+  const cells = fillMissingCellsFromRunContext({
+    cells: evidenceBackedCells,
+    sourceUrls,
+    runInput,
+  });
 
   return {
     cells,
     sourceUrls,
-    evidence: normalizeEvidence(rowRecord, sourceUrls),
+    evidence,
     needsReview: rowRecord.needsReview === true || rowRecord.needs_review === true,
   };
 }
@@ -130,6 +142,60 @@ function normalizeCellValue(value: unknown): DatasetAgentCellValue {
     return value;
   }
   return null;
+}
+
+function fillMissingCellsFromEvidence(
+  cells: Record<string, DatasetAgentCellValue>,
+  evidence: DatasetAgentEvidence[]
+): Record<string, DatasetAgentCellValue> {
+  const filledCells = { ...cells };
+
+  for (const item of evidence) {
+    const columnName = item.columnName.trim();
+    const quote = item.quote.trim();
+    if (!columnName || !quote || isPresent(filledCells[columnName])) {
+      continue;
+    }
+    filledCells[columnName] = quote;
+  }
+
+  return filledCells;
+}
+
+function fillMissingCellsFromRunContext(input: {
+  cells: Record<string, DatasetAgentCellValue>;
+  sourceUrls: string[];
+  runInput: DatasetAgentRunInput;
+}): Record<string, DatasetAgentCellValue> {
+  const filledCells = { ...input.cells };
+  const firstSourceUrl = input.sourceUrls[0];
+
+  if (firstSourceUrl) {
+    for (const columnName of input.runInput.requiredColumns) {
+      if (isUrlColumn(columnName) && !isPresent(filledCells[columnName])) {
+        filledCells[columnName] = firstSourceUrl;
+      }
+    }
+  }
+
+  const identityColumnName = minimumRequiredColumnsForRunInput(
+    input.runInput
+  ).find((columnName) => isIdentityColumn(columnName));
+  if (
+    identityColumnName &&
+    !isPresent(filledCells[identityColumnName]) &&
+    input.sourceUrls.length > 0
+  ) {
+    const entityName = inferEntityNameFromPromptAndSourceUrls({
+      prompt: input.runInput.prompt,
+      sourceUrls: input.sourceUrls,
+    });
+    if (entityName) {
+      filledCells[identityColumnName] = entityName;
+    }
+  }
+
+  return filledCells;
 }
 
 function normalizeSourceUrls(
@@ -276,6 +342,128 @@ function inferConservativeMinimumRequiredColumns(columns: string[]): string[] {
   );
 
   return fallbackIdentityColumn ? [fallbackIdentityColumn] : [];
+}
+
+function isUrlColumn(columnName: string): boolean {
+  const normalizedColumnName = columnName.toLowerCase();
+  return (
+    normalizedColumnName === "source_url" ||
+    normalizedColumnName.endsWith("_url") ||
+    normalizedColumnName.endsWith("_website") ||
+    normalizedColumnName === "official_website" ||
+    normalizedColumnName === "company_website" ||
+    normalizedColumnName === "website_or_menu_url"
+  );
+}
+
+function isIdentityColumn(columnName: string): boolean {
+  return [
+    "entity_name",
+    "company_name",
+    "organization_name",
+    "provider_name",
+    "restaurant_name",
+    "store_name",
+    "business_name",
+    "bakery_name",
+    "product_name",
+    "person_name",
+    "profile_name",
+  ].includes(columnName);
+}
+
+function inferEntityNameFromPromptAndSourceUrls(input: {
+  prompt: string;
+  sourceUrls: string[];
+}): string | undefined {
+  const sourceText = input.sourceUrls
+    .map((sourceUrl) => sourceUrlText(sourceUrl))
+    .join(" ");
+  const matchingCandidates = entityCandidatesFromPrompt(input.prompt).filter(
+    (candidate) => entityCandidateMatchesSource(candidate, sourceText)
+  );
+  const uniqueMatches = uniqueStrings(matchingCandidates);
+
+  return uniqueMatches.length === 1 ? uniqueMatches[0] : undefined;
+}
+
+function sourceUrlText(sourceUrl: string): string {
+  try {
+    const url = new URL(sourceUrl);
+    return `${url.hostname} ${url.pathname}`;
+  } catch {
+    return sourceUrl;
+  }
+}
+
+function entityCandidatesFromPrompt(prompt: string): string[] {
+  const candidates: string[] = [];
+  const entityPattern =
+    /\b[A-Z][A-Za-z0-9&.-]*(?:\s+[A-Z][A-Za-z0-9&.-]*){0,3}/g;
+
+  for (const match of prompt.matchAll(entityPattern)) {
+    const candidate = trimEntityCandidate(match[0]);
+    if (candidate) {
+      candidates.push(candidate);
+    }
+  }
+
+  return uniqueStrings(candidates);
+}
+
+function trimEntityCandidate(candidate: string): string | undefined {
+  const stopWords = new Set([
+    "a",
+    "an",
+    "and",
+    "can",
+    "for",
+    "from",
+    "i",
+    "in",
+    "of",
+    "or",
+    "the",
+    "to",
+    "url",
+    "with",
+  ]);
+  const words = candidate.split(/\s+/).filter(Boolean);
+
+  while (words.length > 0 && stopWords.has(words[0].toLowerCase())) {
+    words.shift();
+  }
+  while (
+    words.length > 0 &&
+    stopWords.has(words[words.length - 1].toLowerCase())
+  ) {
+    words.pop();
+  }
+
+  const trimmedCandidate = words.join(" ").trim();
+  return trimmedCandidate.length >= 2 ? trimmedCandidate : undefined;
+}
+
+function entityCandidateMatchesSource(
+  candidate: string,
+  sourceText: string
+): boolean {
+  const normalizedSourceText = normalizeIdentityText(sourceText);
+  const candidateTokens = candidate
+    .split(/\s+/)
+    .map(normalizeIdentityText)
+    .filter((token) => token.length > 1);
+  const compactCandidate = candidateTokens.join("");
+
+  return (
+    compactCandidate.length > 1 &&
+    (normalizedSourceText.includes(compactCandidate) ||
+      candidateTokens.every((token) => normalizedSourceText.includes(token)))
+  );
+}
+
+function normalizeIdentityText(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, "");
 }
 
 function normalizeUsage(value: unknown): DatasetAgentUsage {

--- a/backend/src/dataset-agent/run-benchmark-adapter.ts
+++ b/backend/src/dataset-agent/run-benchmark-adapter.ts
@@ -1,6 +1,12 @@
-import "dotenv/config";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { config as loadDotenv } from "dotenv";
 
 import { runDatasetAgentFromEnv } from "./index.js";
+
+loadBenchmarkEnvFiles();
 
 const prompt = requiredEnv("BIGSET_BENCHMARK_PROMPT");
 const promptId = process.env.BIGSET_BENCHMARK_PROMPT_ID;
@@ -37,4 +43,28 @@ function requiredEnv(name: string): string {
     throw new Error(`Missing ${name}. Run through run-benchmark.mjs.`);
   }
   return value;
+}
+
+function loadBenchmarkEnvFiles() {
+  const backendDirectory = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    "../.."
+  );
+  const repoDirectory = resolve(backendDirectory, "..");
+  const envPaths = [
+    join(repoDirectory, ".env"),
+    join(repoDirectory, ".env.local"),
+    join(repoDirectory, ".env.development"),
+    join(repoDirectory, ".env.development.local"),
+    join(backendDirectory, ".env"),
+    join(backendDirectory, ".env.local"),
+    join(backendDirectory, ".env.development"),
+    join(backendDirectory, ".env.development.local"),
+  ];
+
+  for (const envPath of envPaths) {
+    if (existsSync(envPath)) {
+      loadDotenv({ path: envPath, override: false });
+    }
+  }
 }

--- a/backend/test/dataset-agent-oracle.test.ts
+++ b/backend/test/dataset-agent-oracle.test.ts
@@ -460,6 +460,65 @@ test("AI SDK runtime keeps repair telemetry when repair is worse", async () => {
   });
 });
 
+test("AI SDK runtime does not let repair erase source-backed rows", async () => {
+  let generateCount = 0;
+  const runtime = new AiSdkDatasetAgentRuntime({
+    model: "test/model",
+    toolProvider: fakeToolProvider(),
+    createAgent: () => ({
+      async generate() {
+        generateCount += 1;
+        if (generateCount === 1) {
+          return {
+            output: {
+              rows: [
+                {
+                  cells: {
+                    entity_name: "OpenAI",
+                    source_url: "https://openai.com/news",
+                  },
+                  sourceUrls: ["https://openai.com/news"],
+                  evidence: [
+                    {
+                      columnName: "entity_name",
+                      sourceUrl: "https://openai.com/news",
+                      quote: "OpenAI",
+                    },
+                  ],
+                },
+              ],
+              validationIssues: ["Missing optional title."],
+            },
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            steps: [{}],
+          };
+        }
+
+        return {
+          output: {
+            rows: [],
+            validationIssues: [],
+          },
+          usage: { promptTokens: 2, completionTokens: 2, totalTokens: 4 },
+          steps: [{}],
+        };
+      },
+    }),
+  });
+
+  const result = await runtime.runDatasetBuild(runInput);
+
+  assert.equal(generateCount, 2);
+  assert.equal(result.rows.length, 1);
+  assert.equal(result.rows[0]?.cells.entity_name, "OpenAI");
+  assert.match(result.validationIssues.join("\n"), /Missing optional title/i);
+  assert.deepEqual(result.usage, {
+    promptTokens: 3,
+    completionTokens: 3,
+    totalTokens: 6,
+  });
+});
+
 function fakeToolProvider(): DatasetAgentToolProvider {
   return {
     async search() {

--- a/backend/test/dataset-agent-oracle.test.ts
+++ b/backend/test/dataset-agent-oracle.test.ts
@@ -19,6 +19,19 @@ const runInput = {
   ],
 };
 
+const pricingRunInput = {
+  prompt:
+    "For Stripe, Paddle, and Chargebee, collect official pricing page URLs and plan names.",
+  promptId: "oracle-pricing-pages",
+  promptQuality: "good",
+  requiredColumns: [
+    "entity_name",
+    "pricing_page_url",
+    "plan_or_price",
+    "source_url",
+  ],
+};
+
 test("deterministic runtime satisfies benchmark contract without secrets", async () => {
   const runtime = new DeterministicDatasetAgentRuntime();
   const result = await runtime.runDatasetBuild(runInput);
@@ -99,6 +112,135 @@ test("AI SDK runtime normalizes output and accumulates usage from step callbacks
   assert.equal(result.metrics.agentSteps, 2);
 });
 
+test("AI SDK runtime falls back to text when structured output is unavailable", async () => {
+  const runtime = new AiSdkDatasetAgentRuntime({
+    model: "test/model",
+    toolProvider: fakeToolProvider(),
+    maxRepairAttempts: 0,
+    createAgent: () => ({
+      async generate() {
+        return {
+          get output() {
+            throw new Error("No output generated.");
+          },
+          text: JSON.stringify({
+            rows: [
+              {
+                cells: {
+                  entity_name: "OpenAI",
+                  latest_post_title: "Release notes",
+                  source_url: "https://openai.com/news",
+                },
+                sourceUrls: ["https://openai.com/news"],
+                evidence: [
+                  {
+                    columnName: "entity_name",
+                    sourceUrl: "https://openai.com/news",
+                    quote: "OpenAI",
+                  },
+                ],
+              },
+            ],
+            validationIssues: [],
+          }),
+          usage: {},
+          steps: [],
+        };
+      },
+    }),
+  });
+
+  const result = await runtime.runDatasetBuild(runInput);
+
+  assert.equal(result.rows.length, 1);
+  assert.equal(result.rows[0]?.cells.entity_name, "OpenAI");
+  assert.equal(result.validationIssues.length, 0);
+});
+
+test("AI SDK runtime fills missing cells from column-specific evidence", async () => {
+  const runtime = new AiSdkDatasetAgentRuntime({
+    model: "test/model",
+    toolProvider: fakeToolProvider(),
+    maxRepairAttempts: 0,
+    createAgent: () => ({
+      async generate() {
+        return {
+          output: {
+            rows: [
+              {
+                cells: {},
+                sourceUrls: ["https://stripe.com/pricing"],
+                evidence: [
+                  {
+                    columnName: "entity_name",
+                    sourceUrl: "https://stripe.com/pricing",
+                    quote: "Stripe",
+                  },
+                  {
+                    columnName: "source_url",
+                    sourceUrl: "https://stripe.com/pricing",
+                    quote: "https://stripe.com/pricing",
+                  },
+                ],
+              },
+            ],
+            validationIssues: [],
+          },
+          usage: {},
+          steps: [],
+        };
+      },
+    }),
+  });
+
+  const result = await runtime.runDatasetBuild(runInput);
+
+  assert.equal(result.rows[0]?.cells.entity_name, "Stripe");
+  assert.equal(result.rows[0]?.cells.source_url, "https://stripe.com/pricing");
+  assert.doesNotMatch(result.validationIssues.join("\n"), /entity_name/i);
+});
+
+test("AI SDK runtime fills URL cells and clear prompt identities from source URLs", async () => {
+  const runtime = new AiSdkDatasetAgentRuntime({
+    model: "test/model",
+    toolProvider: fakeToolProvider(),
+    maxRepairAttempts: 0,
+    createAgent: () => ({
+      async generate() {
+        return {
+          output: {
+            rows: [
+              {
+                cells: {
+                  plan_or_price: "2.9% + 30 cents",
+                },
+                sourceUrls: ["https://stripe.com/pricing"],
+                evidence: [
+                  {
+                    columnName: "plan_or_price",
+                    sourceUrl: "https://stripe.com/pricing",
+                    quote: "2.9% + 30 cents",
+                  },
+                ],
+              },
+            ],
+            validationIssues: [],
+          },
+          usage: {},
+          steps: [],
+        };
+      },
+    }),
+  });
+
+  const result = await runtime.runDatasetBuild(pricingRunInput);
+
+  assert.equal(result.rows[0]?.cells.entity_name, "Stripe");
+  assert.equal(result.rows[0]?.cells.pricing_page_url, "https://stripe.com/pricing");
+  assert.equal(result.rows[0]?.cells.source_url, "https://stripe.com/pricing");
+  assert.equal(result.validationIssues.length, 0);
+});
+
 test("AI SDK runtime reports invalid source-free rows as validation issues", async () => {
   const runtime = new AiSdkDatasetAgentRuntime({
     model: "test/model",
@@ -177,13 +319,13 @@ test("AI SDK runtime still rejects rows missing the conservative identity field"
               {
                 cells: {
                   latest_post_title: "Release notes",
-                  source_url: "https://openai.com/news",
+                  source_url: "https://example.com/news",
                 },
-                sourceUrls: ["https://openai.com/news"],
+                sourceUrls: ["https://example.com/news"],
                 evidence: [
                   {
                     columnName: "latest_post_title",
-                    sourceUrl: "https://openai.com/news",
+                    sourceUrl: "https://example.com/news",
                     quote: "Release notes",
                   },
                 ],

--- a/backend/test/dataset-agent-oracle.test.ts
+++ b/backend/test/dataset-agent-oracle.test.ts
@@ -519,6 +519,57 @@ test("AI SDK runtime does not let repair erase source-backed rows", async () => 
   });
 });
 
+test("AI SDK runtime recovers partial rows from tool results when model returns none", async () => {
+  const runtime = new AiSdkDatasetAgentRuntime({
+    model: "test/model",
+    toolProvider: fakeToolProvider(),
+    maxRepairAttempts: 0,
+    createAgent: () => ({
+      async generate() {
+        return {
+          output: {
+            rows: [],
+            validationIssues: [],
+          },
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          steps: [
+            {
+              toolResults: [
+                {
+                  output: [
+                    {
+                      url: "https://openai.com/index/advancing-content-provenance/",
+                      title: "OpenAI news",
+                      text: "OpenAI announced updates about content provenance.",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+      },
+    }),
+  });
+
+  const result = await runtime.runDatasetBuild(runInput);
+
+  assert.equal(result.rows.length, 1);
+  assert.equal(result.rows[0]?.cells.entity_name, "OpenAI");
+  assert.equal(
+    result.rows[0]?.cells.source_url,
+    "https://openai.com/index/advancing-content-provenance/"
+  );
+  assert.equal(
+    result.rows[0]?.sourceUrls[0],
+    "https://openai.com/index/advancing-content-provenance/"
+  );
+  assert.match(
+    result.validationIssues.join("\n"),
+    /Recovered partial rows from tool results/i
+  );
+});
+
 function fakeToolProvider(): DatasetAgentToolProvider {
   return {
     async search() {

--- a/backend/test/dataset-agent-recipe-healer.test.ts
+++ b/backend/test/dataset-agent-recipe-healer.test.ts
@@ -61,7 +61,7 @@ test("production validation rejects rows missing the conservative identity field
         rows: [
           sourceBackedRow({
             latest_post_title: "Release notes",
-            source_url: "https://openai.com/news",
+            source_url: "https://example.com/news",
           }),
         ],
         validationIssues: [],

--- a/benchmarks/dataset-agent/README.md
+++ b/benchmarks/dataset-agent/README.md
@@ -78,8 +78,9 @@ node benchmarks/dataset-agent/run-benchmark.mjs \
   --system edward='node benchmarks/dataset-agent/adapters/edward-ai-sdk-adapter.mjs'
 ```
 
-The code default is OpenRouter `google/gemini-3.1-flash-lite`. Do not use a
-direct OpenAI key for this benchmark path.
+The code default is OpenRouter `google/gemini-3.1-flash-lite` via
+`@openrouter/ai-sdk-provider`. Do not use a direct OpenAI key or AI Gateway key
+for this benchmark path.
 
 It uses the backend script:
 
@@ -108,7 +109,8 @@ If the canary is blocked by auth, credits, quota, rate limits, or timeout, fix t
 before running the full 16 prompts.
 
 Real AI SDK runs require `OPENROUTER_API_KEY` and `TINYFISH_API_KEY` loaded
-execution-only. Do not commit local env files.
+execution-only. Do not set `DATASET_AGENT_MODEL` unless you want to override the
+OpenRouter model id in code. Do not commit local env files.
 
 ## Recipe Healer Prototype
 

--- a/benchmarks/dataset-agent/README.md
+++ b/benchmarks/dataset-agent/README.md
@@ -74,10 +74,12 @@ This branch includes Edward's AI SDK dataset agent adapter:
 
 ```bash
 DATASET_AGENT_RUNTIME=ai-sdk \
-DATASET_AGENT_MODEL=openai/gpt-5.4 \
 node benchmarks/dataset-agent/run-benchmark.mjs \
   --system edward='node benchmarks/dataset-agent/adapters/edward-ai-sdk-adapter.mjs'
 ```
+
+The code default is OpenRouter `google/gemini-3.1-flash-lite`. Do not use a
+direct OpenAI key for this benchmark path.
 
 It uses the backend script:
 
@@ -97,7 +99,6 @@ When using a fresh API key, start with a cheap canary subset:
 
 ```bash
 DATASET_AGENT_RUNTIME=ai-sdk \
-DATASET_AGENT_MODEL=openai/gpt-5.4 \
 node benchmarks/dataset-agent/run-benchmark.mjs \
   --prompt-ids latest-ai-blog-posts,saas-pricing-pages \
   --system edward='node benchmarks/dataset-agent/adapters/edward-ai-sdk-adapter.mjs'
@@ -106,8 +107,8 @@ node benchmarks/dataset-agent/run-benchmark.mjs \
 If the canary is blocked by auth, credits, quota, rate limits, or timeout, fix that
 before running the full 16 prompts.
 
-Real AI SDK runs require model auth plus `TINYFISH_API_KEY` loaded execution-only.
-Do not commit local env files.
+Real AI SDK runs require `OPENROUTER_API_KEY` and `TINYFISH_API_KEY` loaded
+execution-only. Do not commit local env files.
 
 ## Recipe Healer Prototype
 

--- a/benchmarks/dataset-agent/run-benchmark.mjs
+++ b/benchmarks/dataset-agent/run-benchmark.mjs
@@ -1578,9 +1578,23 @@ function failureReason({
   }
   if (answerKeyScore && !answerKeyScore.passed) {
     if (answerKeyScore.failureCategory === "source_evidence") {
-      return `Source/domain evidence failed; factual accuracy ${answerKeyScore.factualAccuracyScore}, domain accuracy ${answerKeyScore.domainAccuracyRatio}.`;
+      return [
+        "Source/domain evidence failed:",
+        `domain accuracy ${answerKeyScore.domainAccuracyRatio}`,
+        `evidence support ${answerKeyScore.evidenceSupportRatio}`,
+        `factual accuracy ${answerKeyScore.factualAccuracyScore}.`,
+      ].join(" ");
     }
-    return `Factual accuracy ${answerKeyScore.factualAccuracyScore} below ${answerKeyScore.minimumScore}; missing entities: ${answerKeyScore.missingExpectedEntities.join(", ") || "none"}.`;
+    if (answerKeyScore.claimSupportRatio < 1) {
+      return `Claim support ${answerKeyScore.claimSupportRatio} below 1; factual accuracy ${answerKeyScore.factualAccuracyScore}.`;
+    }
+    if (answerKeyScore.entityCoverageRatio < 1) {
+      return `Entity coverage ${answerKeyScore.entityCoverageRatio} below 1; missing entities: ${answerKeyScore.missingExpectedEntities.join(", ") || "none"}.`;
+    }
+    if (answerKeyScore.factualAccuracyScore < answerKeyScore.minimumScore) {
+      return `Factual accuracy ${answerKeyScore.factualAccuracyScore} below ${answerKeyScore.minimumScore}; missing entities: ${answerKeyScore.missingExpectedEntities.join(", ") || "none"}.`;
+    }
+    return `Answer-key gate failed; factual accuracy ${answerKeyScore.factualAccuracyScore}, entity coverage ${answerKeyScore.entityCoverageRatio}, domain accuracy ${answerKeyScore.domainAccuracyRatio}, claim support ${answerKeyScore.claimSupportRatio}.`;
   }
   return "Benchmark failed.";
 }


### PR DESCRIPTION
## Summary
- route the dataset agent through `@openrouter/ai-sdk-provider` instead of AI Gateway
- keep the code default as `google/gemini-3.1-flash-lite`
- allow `DATASET_AGENT_MODEL` as an execution-only experiment override for benchmark runs
- harden AI SDK output normalization for Gemini: tolerate missing structured output, recover cells from evidence, and fill obvious source URL / prompt-entity identity cells only when source-backed
- prevent the repair pass from replacing non-empty source-backed rows with `rows: []`
- recover conservative `needsReview` rows from AI SDK tool results when the model does real source work and then returns `rows: []`
- make benchmark failure messages report the actual failing gate, such as claim support or domain evidence, instead of saying a high factual score is below threshold
- load local benchmark env files from repo/backend `.env*` paths without committing or printing secrets

## Verification
- `npm --prefix backend test`
- `npm --prefix backend run build`
- `node --check benchmarks/dataset-agent/run-benchmark.mjs`
- `git diff --check`
- `git diff --cached --check`

## Real Benchmark Evidence
- Full Gemini Flash Lite run before the repair-selection fix:
  - artifact `benchmark-results/2026-05-21T02-30-01-561Z/summary.json`
  - `2/16` passed, `14/16` failed, `0` blocked
  - estimated cost `$4.249018`
  - dominant failure: `rows: []` after real search/fetch/browser work
- Two-prompt Gemini canary after the repair-selection fix:
  - artifact `benchmark-results/2026-05-21T05-22-41-125Z/summary.json`
  - `0/2` passed, `2/2` failed, `0` blocked
  - estimated cost `$0.580938`
  - both prompts still returned zero rows, so this PR fixes one real repair bug but does **not** make Gemini reliable enough as the default runtime
- Two-prompt Gemini canary after tool-result recovery:
  - artifact `benchmark-results/2026-05-21T05-36-29-374Z/summary.json`
  - `1/2` passed, `1/2` failed, `0` blocked
  - estimated cost `$0.320172`
  - total rows improved from `0` to `6`; `latest-ai-blog-posts` passed, `mcp-docs-pages` still failed on completeness/domain support
- Grok canary/full-run comparison via OpenRouter `x-ai/grok-4.20`:
  - canary artifact `benchmark-results/2026-05-21T04-56-23-381Z/summary.json`: `2/2` passed, estimated cost `$0.203829`
  - full artifact `benchmark-results/2026-05-21T04-57-18-502Z/summary.json`: `7/16` passed, `9/16` failed, estimated cost `$3.401122`

## Stack
- Base PR: #21, branch `codex/playwright-recipe-runner`
- This PR: OpenRouter Gemini Flash Lite default plus repair/benchmark hardening

## Notes
- No real env files inspected or printed.
- No benchmark artifacts committed.
- No auto-merge.
