### PR TITLE
feat: add self-healing recipe service

### DIFF
--- a/backend/src/dataset-agent/index.ts
+++ b/backend/src/dataset-agent/index.ts
@@ -27,6 +27,9 @@ export {
   InMemoryDatasetRecipeStore,
 } from "./recipe-store.js";
 export {
+  AiSdkDatasetRecipeAuthor,
+} from "./recipe-author.js";
+export {
   SelfHealingRecipeService,
 } from "./self-healing-recipe-service.js";
 export type {

--- a/backend/src/dataset-agent/index.ts
+++ b/backend/src/dataset-agent/index.ts
@@ -22,6 +22,13 @@ export {
 export {
   PlaywrightRecipeRunner,
 } from "./playwright-recipe-runner.js";
+export {
+  FileSystemDatasetRecipeStore,
+  InMemoryDatasetRecipeStore,
+} from "./recipe-store.js";
+export {
+  SelfHealingRecipeService,
+} from "./self-healing-recipe-service.js";
 export type {
   DatasetRecipe,
   DatasetRecipeArtifact,
@@ -31,6 +38,19 @@ export type {
   DatasetRecipeRunResult,
   DatasetRecipeRuntime,
 } from "./recipe-types.js";
+export type {
+  DatasetRecipeStore,
+  DatasetRecipeStoreSnapshot,
+  StoredDatasetRecipeRunRecord,
+} from "./recipe-store.js";
+export type {
+  DatasetRecipeAuthor,
+  DatasetRecipeAuthorGenerateInput,
+  DatasetRecipeAuthorRepairInput,
+  DatasetRecipeBenchmarkScorer,
+  SelfHealingRecipeAction,
+  SelfHealingRecipeTickResult,
+} from "./self-healing-recipe-service.js";
 export type {
   DatasetRecipeBrowserFactory,
   DatasetRecipeBrowserSession,

--- a/backend/src/dataset-agent/playwright-recipe-runner.ts
+++ b/backend/src/dataset-agent/playwright-recipe-runner.ts
@@ -137,6 +137,17 @@ export class PlaywrightRecipeRunner implements DatasetRecipeRuntime {
   }
 }
 
+export function validateDatasetRecipeScript(scriptText: string): void {
+  try {
+    compileRecipeScript(scriptText);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Recipe script must export runDatasetRecipe(context): ${message}`
+    );
+  }
+}
+
 async function runRecipeScriptWithTimeout(input: {
   scriptText: string;
   timeoutMs: number;

--- a/backend/src/dataset-agent/recipe-author.ts
+++ b/backend/src/dataset-agent/recipe-author.ts
@@ -1,0 +1,246 @@
+import { Output, ToolLoopAgent, stepCountIs } from "ai";
+import { z } from "zod";
+
+import { minimumRequiredColumnsForRunInput } from "./output.js";
+import { createDatasetRecipe } from "./recipe-runtime.js";
+import { validateDatasetRecipeScript } from "./playwright-recipe-runner.js";
+import type {
+  DatasetRecipeAuthor,
+  DatasetRecipeAuthorGenerateInput,
+  DatasetRecipeAuthorRepairInput,
+} from "./self-healing-recipe-service.js";
+import type { DatasetRecipeArtifact } from "./recipe-types.js";
+
+const MAX_REPAIR_ARTIFACT_CHARS = 8_000;
+
+const recipeScriptOutputSchema = z.object({
+  scriptText: z.string().min(1),
+  notes: z.array(z.string()).default([]),
+});
+
+interface RecipeAuthorGenerateResultLike {
+  output?: unknown;
+  text?: string;
+}
+
+interface RecipeAuthorAgentLike {
+  generate(input: { prompt: string }): Promise<RecipeAuthorGenerateResultLike>;
+}
+
+interface CreateRecipeAuthorAgentInput {
+  model: string;
+  instructions: string;
+}
+
+type RecipeAuthorAgentFactory = (
+  input: CreateRecipeAuthorAgentInput
+) => RecipeAuthorAgentLike;
+
+export class AiSdkDatasetRecipeAuthor implements DatasetRecipeAuthor {
+  private readonly model: string;
+  private readonly createAgent: RecipeAuthorAgentFactory;
+  private readonly now: () => string;
+
+  constructor(input: {
+    model: string;
+    createAgent?: RecipeAuthorAgentFactory;
+    now?: () => string;
+  }) {
+    this.model = input.model;
+    this.createAgent = input.createAgent ?? createRecipeAuthorAgent;
+    this.now = input.now ?? (() => new Date().toISOString());
+  }
+
+  async generateRecipe(
+    input: DatasetRecipeAuthorGenerateInput
+  ): Promise<ReturnType<typeof createDatasetRecipe>> {
+    const minimumRequiredColumns = minimumRequiredColumnsForRunInput(
+      input.runInput
+    );
+    const scriptText = await this.generateScript({
+      prompt: createGenerateRecipePrompt(input),
+    });
+
+    return createDatasetRecipe({
+      recipeId: recipeIdForVersion(input.datasetId, input.nextVersion),
+      datasetId: input.datasetId,
+      version: input.nextVersion,
+      scriptText,
+      requestedColumns: input.runInput.requiredColumns,
+      minimumRequiredColumns,
+      sourcePrompt: input.runInput.prompt,
+      createdAt: this.now(),
+      createdBy: "agent",
+    });
+  }
+
+  async repairRecipe(
+    input: DatasetRecipeAuthorRepairInput
+  ): Promise<ReturnType<typeof createDatasetRecipe>> {
+    const minimumRequiredColumns = minimumRequiredColumnsForRunInput(
+      input.runInput
+    );
+    const scriptText = await this.generateScript({
+      prompt: createRepairRecipePrompt(input),
+    });
+
+    return createDatasetRecipe({
+      recipeId: recipeIdForVersion(input.datasetId, input.nextVersion),
+      datasetId: input.datasetId,
+      version: input.nextVersion,
+      scriptText,
+      requestedColumns: input.runInput.requiredColumns,
+      minimumRequiredColumns,
+      sourcePrompt: input.runInput.prompt,
+      createdAt: this.now(),
+      createdBy: "agent",
+    });
+  }
+
+  private async generateScript(input: { prompt: string }): Promise<string> {
+    const agent = this.createAgent({
+      model: this.model,
+      instructions: createRecipeAuthorInstructions(),
+    });
+    const generation = await agent.generate({ prompt: input.prompt });
+    const parsed = parseRecipeScriptOutput(generation);
+    validateDatasetRecipeScript(parsed.scriptText);
+    return parsed.scriptText;
+  }
+}
+
+function createRecipeAuthorAgent(
+  input: CreateRecipeAuthorAgentInput
+): RecipeAuthorAgentLike {
+  return new ToolLoopAgent({
+    model: input.model,
+    instructions: input.instructions,
+    tools: {},
+    output: Output.object({ schema: recipeScriptOutputSchema }),
+    stopWhen: stepCountIs(1),
+  }) as unknown as RecipeAuthorAgentLike;
+}
+
+function createRecipeAuthorInstructions(): string {
+  return [
+    "You write BigSet dataset recipes.",
+    "Return a JSON object with scriptText and notes.",
+    "scriptText must be executable plain JavaScript source.",
+    "scriptText must export async function runDatasetRecipe(context).",
+    "Do not use TypeScript annotations, import modules, read files, access process, use eval, or write network code outside the provided page object.",
+    "Use context.page for browser work, context.emitRow for rows, context.addEvidence for shared evidence, and context.log for diagnostics.",
+    "Every emitted row must include cells, sourceUrls, evidence, and needsReview.",
+    "Never invent missing values. Use null or omit unproven optional fields.",
+  ].join("\n");
+}
+
+function createGenerateRecipePrompt(
+  input: DatasetRecipeAuthorGenerateInput
+): string {
+  return JSON.stringify({
+    task: "Generate the first durable browser recipe for this dataset.",
+    datasetId: input.datasetId,
+    nextVersion: input.nextVersion,
+    userRequest: input.runInput.prompt,
+    promptId: input.runInput.promptId,
+    promptQuality: input.runInput.promptQuality,
+    requestedColumns: input.runInput.requiredColumns,
+    minimumRequiredColumns: minimumRequiredColumnsForRunInput(input.runInput),
+    requiredExport: "export async function runDatasetRecipe(context)",
+    contextApi: recipeContextApi(),
+  });
+}
+
+function createRepairRecipePrompt(input: DatasetRecipeAuthorRepairInput): string {
+  return JSON.stringify({
+    task: "Repair a failed durable browser recipe for this dataset.",
+    datasetId: input.datasetId,
+    nextVersion: input.nextVersion,
+    userRequest: input.runInput.prompt,
+    requestedColumns: input.runInput.requiredColumns,
+    minimumRequiredColumns: minimumRequiredColumnsForRunInput(input.runInput),
+    activeRecipe: {
+      recipeId: input.activeRecipe.recipeId,
+      version: input.activeRecipe.version,
+      scriptText: input.activeRecipe.scriptText,
+    },
+    failedRun: {
+      runStatus: input.failedRun.runStatus,
+      validationIssues: input.failedRun.validationIssues,
+      productionValidation: input.failedRun.productionValidation,
+      artifacts: summarizeArtifacts(input.failedRun.artifacts),
+    },
+    repairRules: [
+      "Fix the failure cause. Do not only silence errors.",
+      "Preserve good source/evidence behavior from the active recipe when possible.",
+      "Return a full replacement scriptText, not a patch.",
+      "The repaired script must still export runDatasetRecipe(context).",
+    ],
+    contextApi: recipeContextApi(),
+  });
+}
+
+function recipeContextApi(): Record<string, string> {
+  return {
+    "context.page": "Playwright-like page. Use goto, locator, textContent, content, evaluate, url when available.",
+    "context.input": "Dataset request with prompt, promptId, promptQuality, requiredColumns, minimumRequiredColumns.",
+    "context.emitRow(row)": "Emit one dataset row with cells, sourceUrls, evidence, needsReview.",
+    "context.addEvidence(evidence)": "Attach shared evidence with columnName, sourceUrl, quote.",
+    "context.log(message)": "Record recipe diagnostics for repair artifacts.",
+  };
+}
+
+function summarizeArtifacts(
+  artifacts: DatasetRecipeArtifact[]
+): Array<Pick<DatasetRecipeArtifact, "kind" | "label" | "content" | "uri">> {
+  return artifacts.map((artifact) => ({
+    kind: artifact.kind,
+    label: artifact.label,
+    content: artifact.content?.slice(0, MAX_REPAIR_ARTIFACT_CHARS),
+    uri: artifact.uri,
+  }));
+}
+
+function parseRecipeScriptOutput(
+  generation: RecipeAuthorGenerateResultLike
+): { scriptText: string; notes: string[] } {
+  const payload = generation.output ?? parseJsonText(generation.text);
+  const parsed = recipeScriptOutputSchema.safeParse(payload);
+  if (!parsed.success) {
+    throw new Error(
+      `Recipe author returned invalid script output: ${parsed.error.message}`
+    );
+  }
+
+  return {
+    scriptText: stripMarkdownFence(parsed.data.scriptText.trim()),
+    notes: parsed.data.notes,
+  };
+}
+
+function parseJsonText(text: string | undefined): unknown {
+  if (!text?.trim()) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return {};
+  }
+}
+
+function stripMarkdownFence(scriptText: string): string {
+  const match = scriptText.match(
+    /^```(?:ts|tsx|js|jsx|typescript|javascript)?\s*([\s\S]*?)\s*```$/i
+  );
+  return match?.[1]?.trim() ?? scriptText;
+}
+
+function recipeIdForVersion(datasetId: string, version: number): string {
+  return `${safeRecipeIdSegment(datasetId)}-recipe-v${version}`;
+}
+
+function safeRecipeIdSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, "_");
+}

--- a/backend/src/dataset-agent/recipe-store.ts
+++ b/backend/src/dataset-agent/recipe-store.ts
@@ -1,0 +1,190 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import type {
+  DatasetRecipe,
+  DatasetRecipeBenchmarkScore,
+  DatasetRecipeProductionValidation,
+  DatasetRecipeRunResult,
+  DatasetRecipeRunStatus,
+} from "./recipe-types.js";
+
+export interface StoredDatasetRecipeRunRecord {
+  recipeId: string;
+  recipeVersion: number;
+  runStatus: DatasetRecipeRunStatus;
+  completedAt: string;
+  productionValidation: DatasetRecipeProductionValidation;
+  benchmarkScore?: DatasetRecipeBenchmarkScore;
+  artifactCount: number;
+  runResultUri?: string;
+}
+
+export interface DatasetRecipeStoreSnapshot {
+  datasetId: string;
+  recipes: DatasetRecipe[];
+  runRecords: StoredDatasetRecipeRunRecord[];
+}
+
+export interface DatasetRecipeStore {
+  loadSnapshot(datasetId: string): Promise<DatasetRecipeStoreSnapshot>;
+  saveRecipe(recipe: DatasetRecipe): Promise<void>;
+  saveRunResult(
+    datasetId: string,
+    runResult: DatasetRecipeRunResult
+  ): Promise<void>;
+  getActiveRecipe(datasetId: string): Promise<DatasetRecipe | undefined>;
+}
+
+export class InMemoryDatasetRecipeStore implements DatasetRecipeStore {
+  private readonly snapshotsByDatasetId = new Map<
+    string,
+    DatasetRecipeStoreSnapshot
+  >();
+
+  async loadSnapshot(datasetId: string): Promise<DatasetRecipeStoreSnapshot> {
+    return this.snapshotFor(datasetId);
+  }
+
+  async saveRecipe(recipe: DatasetRecipe): Promise<void> {
+    const snapshot = this.snapshotFor(recipe.datasetId);
+    const recipeIndex = snapshot.recipes.findIndex(
+      (storedRecipe) => storedRecipe.recipeId === recipe.recipeId
+    );
+    if (recipeIndex >= 0) {
+      snapshot.recipes[recipeIndex] = recipe;
+    } else {
+      snapshot.recipes.push(recipe);
+    }
+    snapshot.recipes.sort((left, right) => left.version - right.version);
+  }
+
+  async saveRunResult(
+    datasetId: string,
+    runResult: DatasetRecipeRunResult
+  ): Promise<void> {
+    const snapshot = this.snapshotFor(datasetId);
+    snapshot.runRecords.push(runRecordFromResult(runResult));
+  }
+
+  async getActiveRecipe(datasetId: string): Promise<DatasetRecipe | undefined> {
+    const snapshot = this.snapshotFor(datasetId);
+    return snapshot.recipes
+      .filter((recipe) => recipe.status === "active")
+      .sort((left, right) => right.version - left.version)[0];
+  }
+
+  private snapshotFor(datasetId: string): DatasetRecipeStoreSnapshot {
+    let snapshot = this.snapshotsByDatasetId.get(datasetId);
+    if (!snapshot) {
+      snapshot = { datasetId, recipes: [], runRecords: [] };
+      this.snapshotsByDatasetId.set(datasetId, snapshot);
+    }
+    return snapshot;
+  }
+}
+
+export class FileSystemDatasetRecipeStore implements DatasetRecipeStore {
+  constructor(private readonly rootDirectory: string) {}
+
+  async loadSnapshot(datasetId: string): Promise<DatasetRecipeStoreSnapshot> {
+    const manifestPath = this.manifestPath(datasetId);
+    try {
+      const manifestText = await readFile(manifestPath, "utf8");
+      const parsed = JSON.parse(manifestText) as DatasetRecipeStoreSnapshot;
+      return {
+        datasetId: parsed.datasetId,
+        recipes: parsed.recipes ?? [],
+        runRecords: parsed.runRecords ?? [],
+      };
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return { datasetId, recipes: [], runRecords: [] };
+      }
+      throw error;
+    }
+  }
+
+  async saveRecipe(recipe: DatasetRecipe): Promise<void> {
+    const snapshot = await this.loadSnapshot(recipe.datasetId);
+    const recipeIndex = snapshot.recipes.findIndex(
+      (storedRecipe) => storedRecipe.recipeId === recipe.recipeId
+    );
+    if (recipeIndex >= 0) {
+      snapshot.recipes[recipeIndex] = recipe;
+    } else {
+      snapshot.recipes.push(recipe);
+    }
+    snapshot.recipes.sort((left, right) => left.version - right.version);
+    await this.writeSnapshot(snapshot);
+  }
+
+  async saveRunResult(
+    datasetId: string,
+    runResult: DatasetRecipeRunResult
+  ): Promise<void> {
+    const snapshot = await this.loadSnapshot(datasetId);
+    const runResultUri = join(
+      this.datasetDirectory(datasetId),
+      "runs",
+      `${runResult.completedAt.replace(/[:.]/g, "-")}-${runResult.recipeId}.json`
+    );
+
+    await mkdir(join(this.datasetDirectory(datasetId), "runs"), {
+      recursive: true,
+    });
+    await writeFile(runResultUri, `${JSON.stringify(runResult, null, 2)}\n`);
+    snapshot.runRecords.push({
+      ...runRecordFromResult(runResult),
+      runResultUri,
+    });
+    await this.writeSnapshot(snapshot);
+  }
+
+  async getActiveRecipe(datasetId: string): Promise<DatasetRecipe | undefined> {
+    const snapshot = await this.loadSnapshot(datasetId);
+    return snapshot.recipes
+      .filter((recipe) => recipe.status === "active")
+      .sort((left, right) => right.version - left.version)[0];
+  }
+
+  private async writeSnapshot(
+    snapshot: DatasetRecipeStoreSnapshot
+  ): Promise<void> {
+    await mkdir(this.datasetDirectory(snapshot.datasetId), { recursive: true });
+    await writeFile(
+      this.manifestPath(snapshot.datasetId),
+      `${JSON.stringify(snapshot, null, 2)}\n`
+    );
+  }
+
+  private datasetDirectory(datasetId: string): string {
+    return join(this.rootDirectory, safePathSegment(datasetId));
+  }
+
+  private manifestPath(datasetId: string): string {
+    return join(this.datasetDirectory(datasetId), "manifest.json");
+  }
+}
+
+function runRecordFromResult(
+  runResult: DatasetRecipeRunResult
+): StoredDatasetRecipeRunRecord {
+  return {
+    recipeId: runResult.recipeId,
+    recipeVersion: runResult.recipeVersion,
+    runStatus: runResult.runStatus,
+    completedAt: runResult.completedAt,
+    productionValidation: runResult.productionValidation,
+    benchmarkScore: runResult.benchmarkScore,
+    artifactCount: runResult.artifacts.length,
+  };
+}
+
+function safePathSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/backend/src/dataset-agent/self-healing-recipe-service.ts
+++ b/backend/src/dataset-agent/self-healing-recipe-service.ts
@@ -1,0 +1,224 @@
+import { applyRecipePromotionDecision, decideRecipePromotion } from "./recipe-healer.js";
+import type { DatasetRecipeStore } from "./recipe-store.js";
+import type {
+  DatasetRecipe,
+  DatasetRecipeBenchmarkScore,
+  DatasetRecipeRunResult,
+  DatasetRecipeRuntime,
+} from "./recipe-types.js";
+import type { DatasetAgentRunInput } from "./types.js";
+
+export interface DatasetRecipeAuthorGenerateInput {
+  datasetId: string;
+  runInput: DatasetAgentRunInput;
+  nextVersion: number;
+}
+
+export interface DatasetRecipeAuthorRepairInput
+  extends DatasetRecipeAuthorGenerateInput {
+  activeRecipe: DatasetRecipe;
+  failedRun: DatasetRecipeRunResult;
+}
+
+export interface DatasetRecipeAuthor {
+  generateRecipe(
+    input: DatasetRecipeAuthorGenerateInput
+  ): Promise<DatasetRecipe>;
+  repairRecipe(input: DatasetRecipeAuthorRepairInput): Promise<DatasetRecipe>;
+}
+
+export type DatasetRecipeBenchmarkScorer = (input: {
+  recipe: DatasetRecipe;
+  runInput: DatasetAgentRunInput;
+  runResult: DatasetRecipeRunResult;
+}) => Promise<DatasetRecipeBenchmarkScore | undefined>;
+
+export type SelfHealingRecipeAction =
+  | "active_rerun_succeeded"
+  | "generated_initial_recipe"
+  | "repaired_active_recipe"
+  | "candidate_rejected";
+
+export interface SelfHealingRecipeTickResult {
+  datasetId: string;
+  action: SelfHealingRecipeAction;
+  activeRecipe?: DatasetRecipe;
+  candidateRecipe?: DatasetRecipe;
+  activeRun?: DatasetRecipeRunResult;
+  candidateRun?: DatasetRecipeRunResult;
+  rejectionReasons: string[];
+}
+
+export class SelfHealingRecipeService {
+  constructor(
+    private readonly input: {
+      store: DatasetRecipeStore;
+      runtime: DatasetRecipeRuntime;
+      author: DatasetRecipeAuthor;
+      benchmarkScorer?: DatasetRecipeBenchmarkScorer;
+    }
+  ) {}
+
+  async tick(input: {
+    datasetId: string;
+    runInput: DatasetAgentRunInput;
+  }): Promise<SelfHealingRecipeTickResult> {
+    const activeRecipe = await this.input.store.getActiveRecipe(input.datasetId);
+
+    if (!activeRecipe) {
+      return this.generateInitialRecipe(input);
+    }
+
+    const activeRun = await this.input.runtime.runRecipe({
+      recipe: activeRecipe,
+      runInput: input.runInput,
+    });
+    await this.input.store.saveRunResult(input.datasetId, activeRun);
+
+    if (isHealthyRun(activeRun)) {
+      const updatedActiveRecipe = successfulRecipe(activeRecipe, activeRun);
+      await this.input.store.saveRecipe(updatedActiveRecipe);
+      return {
+        datasetId: input.datasetId,
+        action: "active_rerun_succeeded",
+        activeRecipe: updatedActiveRecipe,
+        activeRun,
+        rejectionReasons: [],
+      };
+    }
+
+    const candidateRecipe = await this.input.author.repairRecipe({
+      datasetId: input.datasetId,
+      runInput: input.runInput,
+      activeRecipe,
+      failedRun: activeRun,
+      nextVersion: await this.nextVersion(input.datasetId),
+    });
+    const candidateRun = await this.runAndMaybeScoreCandidate({
+      recipe: { ...candidateRecipe, status: "candidate" },
+      runInput: input.runInput,
+      datasetId: input.datasetId,
+    });
+    const promotion = applyRecipePromotionDecision({
+      activeRecipe,
+      candidateRecipe,
+      activeRun,
+      candidateRun,
+    });
+
+    if (promotion.decision.shouldPromote) {
+      await this.input.store.saveRecipe(promotion.retiredRecipe!);
+      await this.input.store.saveRecipe(promotion.activeRecipe);
+      return {
+        datasetId: input.datasetId,
+        action: "repaired_active_recipe",
+        activeRecipe: promotion.activeRecipe,
+        candidateRecipe,
+        activeRun,
+        candidateRun,
+        rejectionReasons: [],
+      };
+    }
+
+    await this.input.store.saveRecipe({ ...candidateRecipe, status: "rejected" });
+    return {
+      datasetId: input.datasetId,
+      action: "candidate_rejected",
+      activeRecipe,
+      candidateRecipe: { ...candidateRecipe, status: "rejected" },
+      activeRun,
+      candidateRun,
+      rejectionReasons: promotion.decision.rejectionReasons,
+    };
+  }
+
+  private async generateInitialRecipe(input: {
+    datasetId: string;
+    runInput: DatasetAgentRunInput;
+  }): Promise<SelfHealingRecipeTickResult> {
+    const candidateRecipe = await this.input.author.generateRecipe({
+      datasetId: input.datasetId,
+      runInput: input.runInput,
+      nextVersion: await this.nextVersion(input.datasetId),
+    });
+    const candidateRun = await this.runAndMaybeScoreCandidate({
+      recipe: { ...candidateRecipe, status: "candidate" },
+      runInput: input.runInput,
+      datasetId: input.datasetId,
+    });
+    const decision = decideRecipePromotion({ candidateRun });
+
+    if (decision.shouldPromote) {
+      const activeRecipe = successfulRecipe(candidateRecipe, candidateRun);
+      await this.input.store.saveRecipe(activeRecipe);
+      return {
+        datasetId: input.datasetId,
+        action: "generated_initial_recipe",
+        activeRecipe,
+        candidateRecipe,
+        candidateRun,
+        rejectionReasons: [],
+      };
+    }
+
+    const rejectedRecipe = { ...candidateRecipe, status: "rejected" as const };
+    await this.input.store.saveRecipe(rejectedRecipe);
+    return {
+      datasetId: input.datasetId,
+      action: "candidate_rejected",
+      candidateRecipe: rejectedRecipe,
+      candidateRun,
+      rejectionReasons: decision.rejectionReasons,
+    };
+  }
+
+  private async runAndMaybeScoreCandidate(input: {
+    recipe: DatasetRecipe;
+    runInput: DatasetAgentRunInput;
+    datasetId: string;
+  }): Promise<DatasetRecipeRunResult> {
+    await this.input.store.saveRecipe(input.recipe);
+    const runResult = await this.input.runtime.runRecipe({
+      recipe: input.recipe,
+      runInput: input.runInput,
+    });
+    const benchmarkScore = await this.input.benchmarkScorer?.({
+      recipe: input.recipe,
+      runInput: input.runInput,
+      runResult,
+    });
+    const scoredRunResult = benchmarkScore
+      ? { ...runResult, benchmarkScore }
+      : runResult;
+    await this.input.store.saveRunResult(input.datasetId, scoredRunResult);
+    return scoredRunResult;
+  }
+
+  private async nextVersion(datasetId: string): Promise<number> {
+    const snapshot = await this.input.store.loadSnapshot(datasetId);
+    const latestVersion = snapshot.recipes.reduce(
+      (maxVersion, recipe) => Math.max(maxVersion, recipe.version),
+      0
+    );
+    return latestVersion + 1;
+  }
+}
+
+function isHealthyRun(runResult: DatasetRecipeRunResult): boolean {
+  return (
+    runResult.runStatus === "succeeded" &&
+    runResult.productionValidation.isValid
+  );
+}
+
+function successfulRecipe(
+  recipe: DatasetRecipe,
+  runResult: DatasetRecipeRunResult
+): DatasetRecipe {
+  return {
+    ...recipe,
+    status: "active",
+    lastSuccessfulRunAt: runResult.completedAt,
+    lastValidationScore: runResult.productionValidation.score,
+  };
+}

--- a/backend/test/dataset-agent-recipe-author.test.ts
+++ b/backend/test/dataset-agent-recipe-author.test.ts
@@ -1,0 +1,206 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  AiSdkDatasetRecipeAuthor,
+  PlaywrightRecipeRunner,
+  createDatasetRecipe,
+  createDatasetRecipeRunResult,
+} from "../src/dataset-agent/index.js";
+import type {
+  DatasetAgentRunInput,
+  DatasetRecipeAuthorRepairInput,
+  DatasetRecipeRunResult,
+} from "../src/dataset-agent/index.js";
+
+const runInput: DatasetAgentRunInput = {
+  prompt: "Find latest blog posts from OpenAI with title and source URL.",
+  promptId: "recipe-author-fixture",
+  promptQuality: "good",
+  requiredColumns: ["entity_name", "latest_post_title", "source_url"],
+};
+
+test("AI SDK recipe author generates an executable recipe script", async () => {
+  const prompts: string[] = [];
+  const author = new AiSdkDatasetRecipeAuthor({
+    model: "test-model",
+    now: () => "2026-05-22T00:00:00.000Z",
+    createAgent: () => ({
+      generate: async ({ prompt }) => {
+        prompts.push(prompt);
+        return {
+          output: {
+            scriptText: `
+              export async function runDatasetRecipe({ page, emitRow }) {
+                await page.goto("https://fixture.local/news");
+                const sourceUrl = page.url();
+                emitRow({
+                  cells: {
+                    entity_name: "OpenAI",
+                    latest_post_title: "Release notes",
+                    source_url: sourceUrl
+                  },
+                  sourceUrls: [sourceUrl],
+                  evidence: [{
+                    columnName: "latest_post_title",
+                    sourceUrl,
+                    quote: "Release notes"
+                  }],
+                  needsReview: false
+                });
+              }
+            `,
+            notes: ["fixture recipe"],
+          },
+        };
+      },
+    }),
+  });
+
+  const recipe = await author.generateRecipe({
+    datasetId: "dataset-ai-posts",
+    runInput,
+    nextVersion: 1,
+  });
+  const runResult = await new PlaywrightRecipeRunner({
+    browserFactory: async () => ({
+      page: new StaticFixturePage(),
+      close: async () => {},
+    }),
+  }).runRecipe({ recipe, runInput });
+
+  assert.equal(recipe.recipeId, "dataset-ai-posts-recipe-v1");
+  assert.equal(recipe.createdBy, "agent");
+  assert.match(prompts[0] ?? "", /Generate the first durable browser recipe/);
+  assert.match(prompts[0] ?? "", /latest_post_title/);
+  assert.equal(runResult.runStatus, "succeeded");
+  assert.equal(runResult.productionValidation.isValid, true);
+});
+
+test("AI SDK recipe author includes failed run artifacts when repairing", async () => {
+  let repairPrompt = "";
+  const author = new AiSdkDatasetRecipeAuthor({
+    model: "test-model",
+    now: () => "2026-05-22T00:01:00.000Z",
+    createAgent: () => ({
+      generate: async ({ prompt }) => {
+        repairPrompt = prompt;
+        return {
+          output: {
+            scriptText: `
+              export async function runDatasetRecipe({ emitRow }) {
+                emitRow({
+                  cells: {
+                    entity_name: "OpenAI",
+                    latest_post_title: "Fixed title",
+                    source_url: "https://openai.com/news"
+                  },
+                  sourceUrls: ["https://openai.com/news"],
+                  evidence: [{
+                    columnName: "latest_post_title",
+                    sourceUrl: "https://openai.com/news",
+                    quote: "Fixed title"
+                  }],
+                  needsReview: false
+                });
+              }
+            `,
+          },
+        };
+      },
+    }),
+  });
+  const activeRecipe = createDatasetRecipe({
+    recipeId: "dataset-ai-posts-recipe-v1",
+    datasetId: "dataset-ai-posts",
+    version: 1,
+    status: "active",
+    scriptText: "export async function runDatasetRecipe() { throw new Error('old selector'); }",
+    requestedColumns: runInput.requiredColumns,
+    sourcePrompt: runInput.prompt,
+  });
+  const repairedRecipe = await author.repairRecipe({
+    datasetId: "dataset-ai-posts",
+    runInput,
+    nextVersion: 2,
+    activeRecipe,
+    failedRun: failedRunResult(activeRecipe),
+  });
+
+  assert.equal(repairedRecipe.recipeId, "dataset-ai-posts-recipe-v2");
+  assert.match(repairPrompt, /Repair a failed durable browser recipe/);
+  assert.match(repairPrompt, /Old selector failed/);
+  assert.match(repairPrompt, /recipe stderr/);
+  assert.match(repairPrompt, /old selector/);
+});
+
+test("AI SDK recipe author rejects scripts without runDatasetRecipe export", async () => {
+  const author = new AiSdkDatasetRecipeAuthor({
+    model: "test-model",
+    createAgent: () => ({
+      generate: async () => ({
+        output: {
+          scriptText: "export async function notTheRecipe() {}",
+        },
+      }),
+    }),
+  });
+
+  await assert.rejects(
+    () =>
+      author.generateRecipe({
+        datasetId: "dataset-ai-posts",
+        runInput,
+        nextVersion: 1,
+      }),
+    /runDatasetRecipe/
+  );
+});
+
+function failedRunResult(
+  recipe: DatasetRecipeAuthorRepairInput["activeRecipe"]
+): DatasetRecipeRunResult {
+  return createDatasetRecipeRunResult({
+    recipe,
+    runInput,
+    result: {
+      rows: [],
+      validationIssues: ["Old selector failed."],
+      usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+      metrics: {
+        searchCalls: 0,
+        fetchCalls: 0,
+        browserCalls: 1,
+        agentRuns: 0,
+        agentSteps: 0,
+      },
+    },
+    runStatus: "failed",
+    startedAt: "2026-05-22T00:00:00.000Z",
+    completedAt: "2026-05-22T00:00:01.000Z",
+    runtimeMs: 1_000,
+    artifacts: [
+      {
+        kind: "stderr",
+        label: "recipe stderr",
+        content: "Old selector failed.",
+      },
+    ],
+  });
+}
+
+class StaticFixturePage {
+  private currentUrl = "";
+
+  async goto(url: string): Promise<void> {
+    this.currentUrl = url;
+  }
+
+  url(): string {
+    return this.currentUrl;
+  }
+
+  async content(): Promise<string> {
+    return "<html><body>fixture</body></html>";
+  }
+}

--- a/backend/test/dataset-agent-self-healing-recipe-service.test.ts
+++ b/backend/test/dataset-agent-self-healing-recipe-service.test.ts
@@ -1,0 +1,260 @@
+import assert from "node:assert/strict";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import {
+  createDatasetRecipe,
+  FakeDatasetRecipeRuntime,
+  FileSystemDatasetRecipeStore,
+  InMemoryDatasetRecipeStore,
+  SelfHealingRecipeService,
+} from "../src/dataset-agent/index.js";
+import type {
+  DatasetAgentRunInput,
+  DatasetRecipe,
+  DatasetRecipeAuthor,
+  DatasetRecipeRunResult,
+} from "../src/dataset-agent/index.js";
+
+const runInput: DatasetAgentRunInput = {
+  prompt: "Find latest blog posts from OpenAI with title and source URL.",
+  promptId: "self-healing-fixture",
+  promptQuality: "good",
+  requiredColumns: ["entity_name", "latest_post_title", "source_url"],
+};
+
+test("reruns healthy active recipe without author or benchmark scorer", async () => {
+  const store = new InMemoryDatasetRecipeStore();
+  const activeRecipe = recipe({ recipeId: "healthy-active", status: "active" });
+  await store.saveRecipe(activeRecipe);
+  const author = new FakeRecipeAuthor();
+  let benchmarkCalls = 0;
+  const service = new SelfHealingRecipeService({
+    store,
+    runtime: new FakeDatasetRecipeRuntime({
+      [activeRecipe.recipeId]: validScenario(),
+    }),
+    author,
+    benchmarkScorer: async () => {
+      benchmarkCalls += 1;
+      return { score: 1, passed: true };
+    },
+  });
+
+  const result = await service.tick({ datasetId: activeRecipe.datasetId, runInput });
+
+  assert.equal(result.action, "active_rerun_succeeded");
+  assert.equal(author.generateCalls, 0);
+  assert.equal(author.repairCalls, 0);
+  assert.equal(benchmarkCalls, 0);
+  assert.equal(result.activeRecipe?.status, "active");
+  assert.equal(result.activeRun?.productionValidation.isValid, true);
+});
+
+test("generates and activates first recipe when no active recipe exists", async () => {
+  const store = new InMemoryDatasetRecipeStore();
+  const generatedRecipe = recipe({ recipeId: "generated-v1", version: 1 });
+  const author = new FakeRecipeAuthor({ generatedRecipe });
+  const service = new SelfHealingRecipeService({
+    store,
+    runtime: new FakeDatasetRecipeRuntime({
+      [generatedRecipe.recipeId]: validScenario(),
+    }),
+    author,
+  });
+
+  const result = await service.tick({
+    datasetId: generatedRecipe.datasetId,
+    runInput,
+  });
+  const snapshot = await store.loadSnapshot(generatedRecipe.datasetId);
+
+  assert.equal(result.action, "generated_initial_recipe");
+  assert.equal(result.activeRecipe?.recipeId, generatedRecipe.recipeId);
+  assert.equal(result.activeRecipe?.version, 1);
+  assert.equal(snapshot.recipes[0]?.status, "active");
+  assert.equal(snapshot.runRecords.length, 1);
+});
+
+test("repairs failed active recipe and promotes valid candidate", async () => {
+  const store = new InMemoryDatasetRecipeStore();
+  const activeRecipe = recipe({ recipeId: "broken-active", status: "active" });
+  const repairedRecipe = recipe({ recipeId: "repair-v2", version: 2 });
+  await store.saveRecipe(activeRecipe);
+  const author = new FakeRecipeAuthor({ repairedRecipe });
+  const service = new SelfHealingRecipeService({
+    store,
+    runtime: new FakeDatasetRecipeRuntime({
+      [activeRecipe.recipeId]: invalidScenario("Old selector failed."),
+      [repairedRecipe.recipeId]: validScenario(),
+    }),
+    author,
+  });
+
+  const result = await service.tick({ datasetId: activeRecipe.datasetId, runInput });
+  const snapshot = await store.loadSnapshot(activeRecipe.datasetId);
+
+  assert.equal(result.action, "repaired_active_recipe");
+  assert.equal(author.repairCalls, 1);
+  assert.equal(author.lastRepairInput?.failedRun.artifacts[0]?.kind, "stderr");
+  assert.equal(snapshot.recipes.find((item) => item.recipeId === activeRecipe.recipeId)?.status, "retired");
+  assert.equal(snapshot.recipes.find((item) => item.recipeId === repairedRecipe.recipeId)?.status, "active");
+});
+
+test("keeps active recipe when repaired candidate fails validation", async () => {
+  const store = new InMemoryDatasetRecipeStore();
+  const activeRecipe = recipe({ recipeId: "still-active", status: "active" });
+  const badCandidate = recipe({ recipeId: "bad-repair", version: 2 });
+  await store.saveRecipe(activeRecipe);
+  const service = new SelfHealingRecipeService({
+    store,
+    runtime: new FakeDatasetRecipeRuntime({
+      [activeRecipe.recipeId]: invalidScenario("Active failed."),
+      [badCandidate.recipeId]: invalidScenario("Repair failed."),
+    }),
+    author: new FakeRecipeAuthor({ repairedRecipe: badCandidate }),
+  });
+
+  const result = await service.tick({ datasetId: activeRecipe.datasetId, runInput });
+  const snapshot = await store.loadSnapshot(activeRecipe.datasetId);
+
+  assert.equal(result.action, "candidate_rejected");
+  assert.equal(snapshot.recipes.find((item) => item.recipeId === activeRecipe.recipeId)?.status, "active");
+  assert.equal(snapshot.recipes.find((item) => item.recipeId === badCandidate.recipeId)?.status, "rejected");
+});
+
+test("rejects candidate when benchmark score regresses", async () => {
+  const store = new InMemoryDatasetRecipeStore();
+  const activeRecipe = recipe({ recipeId: "benchmark-active", status: "active" });
+  const candidateRecipe = recipe({ recipeId: "benchmark-candidate", version: 2 });
+  await store.saveRecipe(activeRecipe);
+  const service = new SelfHealingRecipeService({
+    store,
+    runtime: new FakeDatasetRecipeRuntime({
+      [activeRecipe.recipeId]: {
+        ...invalidScenario("Active failed."),
+        benchmarkScore: { score: 0.9, passed: true },
+      },
+      [candidateRecipe.recipeId]: validScenario(),
+    }),
+    author: new FakeRecipeAuthor({ repairedRecipe: candidateRecipe }),
+    benchmarkScorer: async () => ({ score: 0.7, passed: true }),
+  });
+
+  const result = await service.tick({ datasetId: activeRecipe.datasetId, runInput });
+
+  assert.equal(result.action, "candidate_rejected");
+  assert.match(result.rejectionReasons.join("\n"), /benchmark score regressed/i);
+});
+
+test("file store reloads recipe versions and run records", async () => {
+  const rootDirectory = await mkdtemp(join(tmpdir(), "bigset-recipes-"));
+  const store = new FileSystemDatasetRecipeStore(rootDirectory);
+  const generatedRecipe = recipe({ recipeId: "persisted-v1", version: 1 });
+  const service = new SelfHealingRecipeService({
+    store,
+    runtime: new FakeDatasetRecipeRuntime({
+      [generatedRecipe.recipeId]: validScenario(),
+    }),
+    author: new FakeRecipeAuthor({ generatedRecipe }),
+  });
+
+  await service.tick({ datasetId: generatedRecipe.datasetId, runInput });
+
+  const reloadedStore = new FileSystemDatasetRecipeStore(rootDirectory);
+  const snapshot = await reloadedStore.loadSnapshot(generatedRecipe.datasetId);
+
+  assert.equal(snapshot.recipes.length, 1);
+  assert.equal(snapshot.recipes[0]?.status, "active");
+  assert.equal(snapshot.runRecords.length, 1);
+  assert.equal(snapshot.runRecords[0]?.runStatus, "succeeded");
+});
+
+function recipe(input: {
+  recipeId: string;
+  version?: number;
+  status?: DatasetRecipe["status"];
+}): DatasetRecipe {
+  return createDatasetRecipe({
+    recipeId: input.recipeId,
+    datasetId: "dataset-ai-posts",
+    version: input.version ?? 1,
+    status: input.status ?? "candidate",
+    scriptText: "export async function runDatasetRecipe() {}",
+    requestedColumns: runInput.requiredColumns,
+    sourcePrompt: runInput.prompt,
+    createdAt: "2026-05-21T00:00:00.000Z",
+  });
+}
+
+function validScenario() {
+  return {
+    rawOutput: {
+      rows: [
+        {
+          cells: {
+            entity_name: "OpenAI",
+            latest_post_title: "Release notes",
+            source_url: "https://openai.com/news",
+          },
+          sourceUrls: ["https://openai.com/news"],
+          evidence: [
+            {
+              columnName: "latest_post_title",
+              sourceUrl: "https://openai.com/news",
+              quote: "Release notes",
+            },
+          ],
+          needsReview: false,
+        },
+      ],
+      validationIssues: [],
+    },
+    completedAt: "2026-05-21T00:02:00.000Z",
+  };
+}
+
+function invalidScenario(message: string) {
+  return {
+    rawOutput: {
+      rows: [],
+      validationIssues: [message],
+    },
+    artifacts: [
+      {
+        kind: "stderr" as const,
+        label: "stderr",
+        content: message,
+      },
+    ],
+    completedAt: "2026-05-21T00:03:00.000Z",
+  };
+}
+
+class FakeRecipeAuthor implements DatasetRecipeAuthor {
+  generateCalls = 0;
+  repairCalls = 0;
+  lastRepairInput?: Parameters<DatasetRecipeAuthor["repairRecipe"]>[0];
+
+  constructor(
+    private readonly recipes: {
+      generatedRecipe?: DatasetRecipe;
+      repairedRecipe?: DatasetRecipe;
+    } = {}
+  ) {}
+
+  async generateRecipe(): Promise<DatasetRecipe> {
+    this.generateCalls += 1;
+    return this.recipes.generatedRecipe ?? recipe({ recipeId: "generated" });
+  }
+
+  async repairRecipe(
+    input: Parameters<DatasetRecipeAuthor["repairRecipe"]>[0]
+  ): Promise<DatasetRecipe> {
+    this.repairCalls += 1;
+    this.lastRepairInput = input;
+    return this.recipes.repairedRecipe ?? recipe({ recipeId: "repaired", version: 2 });
+  }
+}


### PR DESCRIPTION
## Summary
- add `DatasetRecipeStore` with in-memory and file-backed implementations
- add `SelfHealingRecipeService` to run active recipes cheaply, generate first recipes, repair failed recipes, and promote only validated candidates
- keep benchmark scoring candidate-only so healthy scheduled reruns do not pay benchmark cost
- persist recipe manifests and run-result records for local restart/reload

## Verification
- `npm --prefix backend test`
- `npm --prefix backend run build`
- `git diff --check`

## Stack
- Base PR: #21, branch `codex/playwright-recipe-runner`
- This PR: PR3 self-healing recipe lifecycle service

## Notes
- No DB persistence or platform cron in this slice.
- No generated recipe scripts are committed.
- No real env files inspected or printed.
- No auto-merge.
