### PR TITLE
Add self-healing populate cron runner

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -9,7 +9,7 @@ Fastify serves the backend API on :3501. Protected routes use Clerk JWT verifica
 Routes:
 - `GET /health` — public health check
 - `POST /infer-schema` — protected. Accepts `{ prompt: string }`, returns a `DatasetSchema`. Calls `inferSchema()` from the pipeline.
-- `POST /populate` — protected. Accepts a `DatasetContext` (datasetId, name, description, columns). Triggers the populate workflow which clears existing rows, then uses an AI agent to search the web and insert real data.
+- `POST /populate` — protected. Accepts a `DatasetContext` (datasetId, name, description, columns). Runs the self-healing populate layer, validates the active/candidate recipe output, then atomically replaces rows only after validation passes.
 
 To add a new protected route, register it inside the scoped plugin in `src/index.ts` that has `requireAuth` as a preHandler. Use `req.auth.userId` for the authenticated user — never trust user-supplied IDs in the body.
 
@@ -19,13 +19,25 @@ To add a new protected route, register it inside the scoped plugin in `src/index
 
 The pipeline is a pure function (`inferSchema(prompt) → DatasetSchema`). It is called by both Fastify (for the HTTP API) and Mastra (for workflow orchestration).
 
+## Populate And Self-Healing
+
+`src/pipeline/populate-runtime.ts` — direct callable runtime around the Mastra populate agent. It uses in-memory row capture and returns rows, validation issues, usage, metrics, and debug artifacts without writing Convex rows.
+
+`src/pipeline/populate-self-healing.ts` — recipe runtime/service/store layer. It reruns the active recipe, generates the first recipe, repairs failed active recipes, validates candidate output, promotes healthy candidates, and rejects unsafe candidates.
+
+`src/pipeline/populate-self-healing-runner.ts` — shared route/CLI runner. HTTP populate uses a durable filesystem store and `ConvexPopulateDatasetRowWriter`; benchmark/dry-run paths can inject an in-memory store and skip row commits.
+
+`npm --silent run populate:self-heal -- --context context.json` — operator/cron-friendly dry run. It emits one JSON summary to stdout and does not persist recipe history or commit rows.
+
+`npm --silent run populate:self-heal -- --context context.json --commit` — commits validated rows through the atomic Convex replace mutation. Requires `CONVEX_SELF_HOSTED_ADMIN_KEY`, `OPENROUTER_API_KEY`, and `TINYFISH_API_KEY`.
+
 ## Mastra (Workflow Orchestration)
 
 `src/mastra/` — wraps pipelines into Mastra workflows. Runs as a separate Docker service on :4111 with `mastra dev`, which provides a Studio UI for inspecting and testing workflows.
 
 - `src/mastra/index.ts` — registers agents and workflows with the `Mastra` instance
 - `src/mastra/workflows/infer-schema.ts` — `inferSchemaWorkflow`, a single-step workflow wrapping `inferSchema()`
-- `src/mastra/workflows/populate.ts` — `populateWorkflow`, 3-step workflow: clear rows → build prompt → run populate agent
+- `src/mastra/workflows/populate.ts` — legacy Mastra workflow: clear rows → build prompt → run populate agent. HTTP `/populate` no longer uses this destructive pre-clear path.
 - `src/mastra/agents/populate.ts` — `populateAgent`, an AI agent (Claude Sonnet 4.6 via OpenRouter) with 7 tools for database CRUD and web access
 - `src/mastra/tools/dataset-tools.ts` — 5 Convex-backed tools: `insert_row`, `list_rows`, `get_row`, `update_row`, `delete_row`
 - `src/mastra/tools/web-tools.ts` — 2 TinyFish API tools: `search_web`, `fetch_page`

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,8 @@
     "test": "node --import tsx --test test/*.test.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "mastra:dev": "mastra dev"
+    "mastra:dev": "mastra dev",
+    "populate:self-heal": "tsx src/pipeline/populate-self-healing-cli.ts"
   },
   "dependencies": {
     "@clerk/backend": "^3.4.11",

--- a/backend/src/pipeline/populate-runtime-prerequisites.ts
+++ b/backend/src/pipeline/populate-runtime-prerequisites.ts
@@ -2,16 +2,20 @@ export interface PopulateRuntimePrerequisites {
   convexAdminKey?: string;
   openRouterApiKey?: string;
   tinyFishApiKey?: string;
+  shouldCommitRows?: boolean;
 }
 
 export function missingPopulateRuntimePrerequisites(
   input: PopulateRuntimePrerequisites
 ): string[] {
-  const requiredKeys: Array<[string, string | undefined]> = [
-    ["CONVEX_SELF_HOSTED_ADMIN_KEY", input.convexAdminKey],
+  const requiredKeys: Array<[string, string | undefined]> = [];
+  if (input.shouldCommitRows ?? true) {
+    requiredKeys.push(["CONVEX_SELF_HOSTED_ADMIN_KEY", input.convexAdminKey]);
+  }
+  requiredKeys.push(
     ["OPENROUTER_API_KEY", input.openRouterApiKey],
-    ["TINYFISH_API_KEY", input.tinyFishApiKey],
-  ];
+    ["TINYFISH_API_KEY", input.tinyFishApiKey]
+  );
 
   return requiredKeys
     .filter(([, value]) => !value)

--- a/backend/src/pipeline/populate-self-healing-cli.ts
+++ b/backend/src/pipeline/populate-self-healing-cli.ts
@@ -1,0 +1,6 @@
+import { runPopulateSelfHealingCli } from "./populate-self-healing-command.js";
+
+process.exitCode = await runPopulateSelfHealingCli({
+  argv: process.argv.slice(2),
+  env: process.env,
+});

--- a/backend/src/pipeline/populate-self-healing-command.ts
+++ b/backend/src/pipeline/populate-self-healing-command.ts
@@ -1,0 +1,201 @@
+import { readFile } from "node:fs/promises";
+
+import {
+  populateRuntimePrerequisiteError,
+  type PopulateRuntimePrerequisites,
+} from "./populate-runtime-prerequisites.js";
+import { datasetContextSchema, type DatasetContext } from "./populate.js";
+import { InMemoryPopulateRecipeStore } from "./populate-self-healing.js";
+import {
+  runSelfHealingPopulate,
+  type PopulateDatasetRowWriter,
+  type RunSelfHealingPopulateResult,
+} from "./populate-self-healing-runner.js";
+
+export interface PopulateSelfHealingCliOptions {
+  contextPath?: string;
+  shouldReadStdin: boolean;
+  shouldCommitRows: boolean;
+  recipeStoreDirectory?: string;
+  maxRows?: number;
+}
+
+export interface PopulateSelfHealingCliDependencies {
+  argv: string[];
+  env: NodeJS.ProcessEnv;
+  readFileText?: (path: string) => Promise<string>;
+  readStdinText?: () => Promise<string>;
+  writeStdout?: (text: string) => void;
+  writeStderr?: (text: string) => void;
+  runSelfHealing?: typeof runSelfHealingPopulate;
+  createRowWriter?: () => Promise<PopulateDatasetRowWriter>;
+}
+
+export async function runPopulateSelfHealingCli(
+  input: PopulateSelfHealingCliDependencies
+): Promise<number> {
+  const writeStdout = input.writeStdout ?? ((text) => console.log(text));
+  const writeStderr = input.writeStderr ?? ((text) => console.error(text));
+
+  try {
+    const options = parsePopulateSelfHealingCliArgs(input.argv);
+    const prerequisiteError = populateRuntimePrerequisiteError(
+      prerequisitesFromEnv(input.env, options.shouldCommitRows)
+    );
+    if (prerequisiteError) {
+      writeStdout(JSON.stringify({
+        success: false,
+        error: prerequisiteError,
+        dryRun: !options.shouldCommitRows,
+      }));
+      return 1;
+    }
+
+    const context = await readDatasetContext({
+      options,
+      readFileText: input.readFileText ?? ((path) => readFile(path, "utf8")),
+      readStdinText: input.readStdinText ?? readProcessStdin,
+    });
+    const rowWriter = options.shouldCommitRows
+      ? await (input.createRowWriter ?? defaultCreateRowWriter)()
+      : undefined;
+    const result = await (input.runSelfHealing ?? runSelfHealingPopulate)({
+      context,
+      store: options.shouldCommitRows
+        ? undefined
+        : new InMemoryPopulateRecipeStore(),
+      recipeStoreDirectory: options.shouldCommitRows
+        ? options.recipeStoreDirectory ?? input.env.POPULATE_RECIPE_STORE_DIR
+        : undefined,
+      rowWriter,
+      shouldCommitRows: options.shouldCommitRows,
+      runtime: options.maxRows === undefined
+        ? undefined
+        : await runtimeWithMaxRows(options.maxRows),
+    });
+
+    writeStdout(JSON.stringify(summaryForResult(result, !options.shouldCommitRows)));
+    return result.success ? 0 : 2;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    writeStderr(message);
+    writeStdout(JSON.stringify({ success: false, error: message }));
+    return 1;
+  }
+}
+
+export function parsePopulateSelfHealingCliArgs(
+  argv: string[]
+): PopulateSelfHealingCliOptions {
+  const options: PopulateSelfHealingCliOptions = {
+    shouldReadStdin: false,
+    shouldCommitRows: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--context" || arg === "--context-file") {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error(`${arg} requires a file path or "-".`);
+      }
+      options.contextPath = value;
+      options.shouldReadStdin = value === "-";
+      index += 1;
+    } else if (arg === "--stdin") {
+      options.shouldReadStdin = true;
+      options.contextPath = "-";
+    } else if (arg === "--commit") {
+      options.shouldCommitRows = true;
+    } else if (arg === "--recipe-store-dir") {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error("--recipe-store-dir requires a directory path.");
+      }
+      options.recipeStoreDirectory = value;
+      index += 1;
+    } else if (arg === "--max-rows") {
+      const value = argv[index + 1];
+      const parsed = Number(value);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new Error("--max-rows requires a positive integer.");
+      }
+      options.maxRows = parsed;
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!options.contextPath && !options.shouldReadStdin) {
+    throw new Error("Missing --context <file> or --stdin.");
+  }
+  if (!options.shouldCommitRows && options.recipeStoreDirectory) {
+    throw new Error("--recipe-store-dir requires --commit.");
+  }
+  return options;
+}
+
+async function readDatasetContext(input: {
+  options: PopulateSelfHealingCliOptions;
+  readFileText: (path: string) => Promise<string>;
+  readStdinText: () => Promise<string>;
+}): Promise<DatasetContext> {
+  const text = input.options.shouldReadStdin
+    ? await input.readStdinText()
+    : await input.readFileText(input.options.contextPath!);
+  return datasetContextSchema.parse(JSON.parse(text));
+}
+
+function prerequisitesFromEnv(
+  env: NodeJS.ProcessEnv,
+  shouldCommitRows: boolean
+): PopulateRuntimePrerequisites {
+  return {
+    convexAdminKey: env.CONVEX_SELF_HOSTED_ADMIN_KEY,
+    openRouterApiKey: env.OPENROUTER_API_KEY,
+    tinyFishApiKey: env.TINYFISH_API_KEY,
+    shouldCommitRows,
+  };
+}
+
+async function defaultCreateRowWriter(): Promise<PopulateDatasetRowWriter> {
+  const { ConvexPopulateDatasetRowWriter } = await import(
+    "./populate-convex-writer.js"
+  );
+  return new ConvexPopulateDatasetRowWriter();
+}
+
+async function runtimeWithMaxRows(maxRows: number) {
+  const { MastraPopulateRecipeRuntime } = await import(
+    "./populate-self-healing.js"
+  );
+  return new MastraPopulateRecipeRuntime({ maxRows });
+}
+
+function summaryForResult(
+  result: RunSelfHealingPopulateResult,
+  isDryRun: boolean
+) {
+  const diagnosticRun = result.selectedRun ?? result.diagnosticRun;
+  return {
+    success: result.success,
+    dryRun: isDryRun,
+    action: result.action,
+    datasetId: result.datasetId,
+    committedRows: result.committedRows,
+    rowCount: diagnosticRun?.rows.length ?? 0,
+    validationIssues: result.validationIssues,
+    rejectionReasons: result.rejectionReasons,
+    productionValidation: diagnosticRun?.productionValidation,
+    metrics: diagnosticRun?.metrics,
+  };
+}
+
+async function readProcessStdin(): Promise<string> {
+  let text = "";
+  for await (const chunk of process.stdin) {
+    text += String(chunk);
+  }
+  return text;
+}

--- a/backend/test/populate-runtime-prerequisites.test.ts
+++ b/backend/test/populate-runtime-prerequisites.test.ts
@@ -14,6 +14,17 @@ test("populate runtime prerequisite check reports every missing key", () => {
   ]);
 });
 
+test("populate runtime prerequisite check skips Convex admin key for dry runs", () => {
+  assert.deepEqual(
+    missingPopulateRuntimePrerequisites({
+      openRouterApiKey: "openrouter",
+      tinyFishApiKey: "tinyfish",
+      shouldCommitRows: false,
+    }),
+    []
+  );
+});
+
 test("populate runtime prerequisite check passes when all keys are configured", () => {
   const input = {
     convexAdminKey: "convex",

--- a/backend/test/populate-self-healing-command.test.ts
+++ b/backend/test/populate-self-healing-command.test.ts
@@ -1,0 +1,258 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { DatasetContext } from "../src/pipeline/populate.js";
+import type { RunSelfHealingPopulateResult } from "../src/pipeline/populate-self-healing-runner.js";
+import {
+  parsePopulateSelfHealingCliArgs,
+  runPopulateSelfHealingCli,
+} from "../src/pipeline/populate-self-healing-command.js";
+
+const context: DatasetContext = {
+  datasetId: "dataset-ai-posts",
+  datasetName: "AI posts",
+  description: "Find latest blog posts from OpenAI.",
+  columns: [{
+    name: "entity_name",
+    type: "text",
+    description: "Company name.",
+  }],
+};
+
+test("self-healing CLI parses context and dry-run mode", () => {
+  assert.deepEqual(parsePopulateSelfHealingCliArgs([
+    "--context",
+    "context.json",
+    "--max-rows",
+    "3",
+  ]), {
+    contextPath: "context.json",
+    shouldReadStdin: false,
+    shouldCommitRows: false,
+    maxRows: 3,
+  });
+});
+
+test("self-healing CLI dry run does not require Convex admin key or create writer", async () => {
+  const stdout: string[] = [];
+  let runCalls = 0;
+  let writerCalls = 0;
+  const exitCode = await runPopulateSelfHealingCli({
+    argv: ["--context", "context.json"],
+    env: {
+      OPENROUTER_API_KEY: "openrouter",
+      TINYFISH_API_KEY: "tinyfish",
+    },
+    readFileText: async () => JSON.stringify(context),
+    writeStdout: (text) => stdout.push(text),
+    writeStderr: () => undefined,
+    createRowWriter: async () => {
+      writerCalls += 1;
+      throw new Error("writer should not be created");
+    },
+    runSelfHealing: async (input) => {
+      runCalls += 1;
+      assert.equal(input.shouldCommitRows, false);
+      assert.equal(input.rowWriter, undefined);
+      assert.equal(input.recipeStoreDirectory, undefined);
+      assert.ok(input.store);
+      return successfulResult(input.context.datasetId);
+    },
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(runCalls, 1);
+  assert.equal(writerCalls, 0);
+  assert.equal(stdout.length, 1);
+  const output = JSON.parse(stdout[0]!);
+  assert.equal(output.success, true);
+  assert.equal(output.dryRun, true);
+  assert.equal(output.rowCount, 1);
+});
+
+test("self-healing CLI rejects durable recipe store on dry run", async () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  let didReadContext = false;
+  const exitCode = await runPopulateSelfHealingCli({
+    argv: [
+      "--stdin",
+      "--recipe-store-dir",
+      ".bigset/test-recipes",
+    ],
+    env: {
+      OPENROUTER_API_KEY: "openrouter",
+      TINYFISH_API_KEY: "tinyfish",
+    },
+    readStdinText: async () => {
+      didReadContext = true;
+      return JSON.stringify(context);
+    },
+    writeStdout: (text) => stdout.push(text),
+    writeStderr: (text) => stderr.push(text),
+    runSelfHealing: async () => {
+      throw new Error("runtime should not run");
+    },
+  });
+
+  assert.equal(exitCode, 1);
+  assert.equal(didReadContext, false);
+  assert.equal(stdout.length, 1);
+  assert.match(stdout[0]!, /--recipe-store-dir requires --commit/);
+  assert.match(stderr.join("\n"), /--recipe-store-dir requires --commit/);
+});
+
+test("self-healing CLI commit mode preflights missing Convex key before runtime", async () => {
+  const stdout: string[] = [];
+  let runCalls = 0;
+  const exitCode = await runPopulateSelfHealingCli({
+    argv: ["--context", "context.json", "--commit"],
+    env: {
+      OPENROUTER_API_KEY: "openrouter",
+      TINYFISH_API_KEY: "tinyfish",
+    },
+    readFileText: async () => JSON.stringify(context),
+    writeStdout: (text) => stdout.push(text),
+    writeStderr: () => undefined,
+    runSelfHealing: async () => {
+      runCalls += 1;
+      throw new Error("runtime should not run");
+    },
+  });
+
+  assert.equal(exitCode, 1);
+  assert.equal(runCalls, 0);
+  assert.equal(stdout.length, 1);
+  assert.match(stdout[0]!, /CONVEX_SELF_HOSTED_ADMIN_KEY/);
+});
+
+test("self-healing CLI exits 2 when tick rejects candidate", async () => {
+  const stdout: string[] = [];
+  const exitCode = await runPopulateSelfHealingCli({
+    argv: ["--stdin"],
+    env: {
+      OPENROUTER_API_KEY: "openrouter",
+      TINYFISH_API_KEY: "tinyfish",
+    },
+    readStdinText: async () => JSON.stringify(context),
+    writeStdout: (text) => stdout.push(text),
+    writeStderr: () => undefined,
+    runSelfHealing: async (input) => rejectedResult(input.context.datasetId),
+  });
+
+  assert.equal(exitCode, 2);
+  assert.equal(stdout.length, 1);
+  const output = JSON.parse(stdout[0]!);
+  assert.equal(output.success, false);
+  assert.equal(output.action, "candidate_rejected");
+  assert.match(output.validationIssues.join("\n"), /Still no evidence/);
+});
+
+test("self-healing CLI reports malformed context JSON as one stdout object", async () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const exitCode = await runPopulateSelfHealingCli({
+    argv: ["--context", "context.json"],
+    env: {
+      OPENROUTER_API_KEY: "openrouter",
+      TINYFISH_API_KEY: "tinyfish",
+    },
+    readFileText: async () => "{ nope",
+    writeStdout: (text) => stdout.push(text),
+    writeStderr: (text) => stderr.push(text),
+  });
+
+  assert.equal(exitCode, 1);
+  assert.equal(stdout.length, 1);
+  assert.equal(JSON.parse(stdout[0]!).success, false);
+  assert.match(stderr.join("\n"), /JSON/);
+});
+
+function successfulResult(datasetId: string): RunSelfHealingPopulateResult {
+  return {
+    success: true,
+    action: "generated_initial_recipe",
+    datasetId,
+    selectedRun: {
+      ...baseRun(datasetId),
+      rows: [{
+        cells: { entity_name: "OpenAI" },
+        sourceUrls: ["https://openai.com/news"],
+        evidence: [{
+          columnName: "entity_name",
+          sourceUrl: "https://openai.com/news",
+          quote: "OpenAI",
+        }],
+        needsReview: true,
+      }],
+    },
+    rejectionReasons: [],
+    validationIssues: [],
+    tick: {
+      datasetId,
+      action: "generated_initial_recipe",
+      rejectionReasons: [],
+    },
+  };
+}
+
+function rejectedResult(datasetId: string): RunSelfHealingPopulateResult {
+  return {
+    success: false,
+    action: "candidate_rejected",
+    datasetId,
+    diagnosticRun: {
+      ...baseRun(datasetId),
+      runStatus: "failed",
+      validationIssues: ["Still no evidence."],
+      productionValidation: {
+        ...baseRun(datasetId).productionValidation,
+        isValid: false,
+        score: 0,
+        criticalIssues: ["Still no evidence."],
+      },
+    },
+    rejectionReasons: ["Still no evidence."],
+    validationIssues: ["Still no evidence."],
+    tick: {
+      datasetId,
+      action: "candidate_rejected",
+      rejectionReasons: ["Still no evidence."],
+    },
+  };
+}
+
+function baseRun(datasetId: string): RunSelfHealingPopulateResult["selectedRun"] {
+  return {
+    rows: [],
+    validationIssues: [],
+    usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+    metrics: {
+      searchCalls: 0,
+      fetchCalls: 0,
+      browserCalls: 0,
+      agentRuns: 0,
+      agentSteps: 0,
+    },
+    recipeId: `${datasetId}-recipe-v1`,
+    recipeVersion: 1,
+    runStatus: "succeeded",
+    startedAt: "2026-05-22T00:00:00.000Z",
+    completedAt: "2026-05-22T00:00:01.000Z",
+    runtimeMs: 1_000,
+    productionValidation: {
+      isValid: true,
+      score: 1,
+      rowCount: 1,
+      requestedCellCompletenessRatio: 1,
+      sourceUrlCoverageRatio: 1,
+      evidenceCoverageRatio: 1,
+      expectedEntityCoverageRatio: 1,
+      expectedEntities: [],
+      missingExpectedEntities: [],
+      criticalIssues: [],
+      warnings: [],
+    },
+    artifacts: [],
+  };
+}

--- a/frontend/convex/datasetRows.ts
+++ b/frontend/convex/datasetRows.ts
@@ -124,6 +124,11 @@ export const replaceByDataset = internalMutation({
     })),
   },
   handler: async (ctx, args) => {
+    const dataset = await ctx.db.get(args.datasetId);
+    if (!dataset) {
+      throw new Error("Dataset not found");
+    }
+
     const existingRows = await ctx.db
       .query("datasetRows")
       .withIndex("by_dataset", (q) => q.eq("datasetId", args.datasetId))


### PR DESCRIPTION
## Summary
- add an operator/cron CLI for running one self-healing populate tick from dataset context JSON
- default CLI mode is dry-run: isolated in-memory recipe store, no writer, no durable recipe mutations, no Convex admin key required
- --commit mode uses the durable recipe store + atomic Convex row writer, with runtime key preflight before agent work
- reject --recipe-store-dir unless --commit so dry-run cannot accidentally mutate recipe history
- guard atomic replaceByDataset against stale/deleted dataset ids
- update backend handoff docs for current self-healing /populate and CLI behavior

## Verification
- npm --prefix backend test: 37/37 pass
- npm --prefix backend run build: pass
- node --check benchmarks/dataset-agent/adapters/mastra-populate-adapter.mjs: pass
- npm --silent --prefix backend run populate:self-heal -- --stdin: emits one JSON missing OpenRouter/TinyFish summary and exits 1
- npm --silent --prefix backend run populate:self-heal -- --stdin --recipe-store-dir .bigset/test-recipes: fails before stdin/context read with one JSON summary and exits 1

## Review
- critic rejected first plan because dry-run would persist recipe state; fixed by forcing in-memory store for dry-run and durable store only in --commit
- code reviewer found late recipe-store validation; fixed by moving validation into arg parsing before env/context I/O
- direct frontend Convex typecheck remains blocked by missing generated convex files in this worktree; dataset existence guard is code-inspected

## Notes
- stacked on #34
- no auto-merge