### PR TITLE
Wire populate runtime selection

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,126 +1,15 @@
-import Fastify from "fastify";
-import fastifyCors from "@fastify/cors";
-
 import { env } from "./env.js";
 import clerkAuthPlugin, { requireAuth } from "./clerk-auth.js";
-import { inferSchema } from "./pipeline/schema-inference.js";
-import { datasetContextSchema } from "./pipeline/populate.js";
 import { ConvexPopulateDatasetRowWriter } from "./pipeline/populate-convex-writer.js";
-import { populateRuntimePrerequisiteError } from "./pipeline/populate-runtime-prerequisites.js";
-import { runSelfHealingPopulate } from "./pipeline/populate-self-healing-runner.js";
 import { convex, api } from "./convex.js";
+import { createBigSetServer } from "./server.js";
 
-const fastify = Fastify({ logger: true });
-const populateRowWriter = new ConvexPopulateDatasetRowWriter();
-
-await fastify.register(fastifyCors, {
-  origin: env.CLIENT_ORIGIN,
-  methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-  allowedHeaders: ["Content-Type", "Authorization", "Cookie"],
-  credentials: true,
-  maxAge: 86400,
-});
-
-// Make `fastify.clerk` available and warn on missing CLERK_SECRET_KEY.
-// `requireAuth` (also exported from ./clerk-auth) is the preHandler for
-// protected routes — see the example block below.
-await fastify.register(clerkAuthPlugin);
-
-// ────────────────────────────────────────────────────────────────────────
-//  Public routes
-// ────────────────────────────────────────────────────────────────────────
-
-fastify.get("/health", async () => ({ status: "ok" }));
-
-// ────────────────────────────────────────────────────────────────────────
-//  Protected routes — gated by Clerk JWT verification
-// ────────────────────────────────────────────────────────────────────────
-
-await fastify.register(async (instance) => {
-  instance.addHook("preHandler", requireAuth);
-
-  instance.post("/infer-schema", async (req, reply) => {
-    const body = req.body as { prompt?: string };
-    if (!body?.prompt || typeof body.prompt !== "string" || !body.prompt.trim()) {
-      return reply.code(400).send({ error: "prompt is required" });
-    }
-
-    try {
-      const schema = await inferSchema(body.prompt.trim());
-      return schema;
-    } catch (err) {
-      req.log.error(err, "Schema inference failed");
-      return reply.code(502).send({ error: "Schema inference failed. Please try again." });
-    }
-  });
-
-  instance.post("/populate", async (req, reply) => {
-    const parsed = datasetContextSchema.safeParse(req.body);
-    if (!parsed.success) {
-      return reply.code(400).send({
-        error: "Invalid request",
-        details: parsed.error.flatten().fieldErrors,
-      });
-    }
-
-    try {
-      const dataset = await convex.query(api.datasets.get, { id: parsed.data.datasetId });
-      if (!dataset) {
-        return reply.code(404).send({ error: "Dataset not found" });
-      }
-      const authenticatedUserId = req.auth?.userId;
-      if (!authenticatedUserId) {
-        return reply.code(401).send({ error: "Unauthenticated" });
-      }
-      if (dataset.ownerId !== authenticatedUserId) {
-        return reply.code(403).send({ error: "Not authorized to populate this dataset" });
-      }
-      const prerequisiteError = populateRuntimePrerequisiteError({
-        convexUrl: env.CONVEX_URL,
-        convexAdminKey: env.CONVEX_ADMIN_KEY,
-        openRouterApiKey: env.OPENROUTER_API_KEY,
-        tinyFishApiKey: env.TINYFISH_API_KEY,
-      });
-      if (prerequisiteError) {
-        return reply.code(500).send({
-          error: prerequisiteError,
-        });
-      }
-
-      const result = await runSelfHealingPopulate({
-        context: parsed.data,
-        recipeStoreDirectory: env.POPULATE_RECIPE_STORE_DIR,
-        rowWriter: populateRowWriter,
-        shouldCommitRows: true,
-      });
-
-      req.log.info({
-        action: result.action,
-        datasetId: result.datasetId,
-        committedRows: result.committedRows?.insertedRowCount ?? 0,
-        validationIssues: result.validationIssues.slice(0, 5),
-      }, "Self-healing populate completed");
-
-      if (!result.success) {
-        return reply.code(422).send({
-          error: "Self-healing populate failed validation.",
-          result: responseSafePopulateResult(result),
-        });
-      }
-
-      return {
-        success: true,
-        result: responseSafePopulateResult(result),
-      };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes("validator") || msg.includes("Invalid")) {
-        return reply.code(400).send({ error: "Invalid datasetId" });
-      }
-      req.log.error(err, "Populate failed");
-      return reply.code(502).send({ error: "Failed to populate dataset. Please try again." });
-    }
-  });
+const fastify = await createBigSetServer({
+  env,
+  authPlugin: clerkAuthPlugin,
+  authPreHandler: requireAuth,
+  getDatasetById: (datasetId) => convex.query(api.datasets.get, { id: datasetId }),
+  populateRowWriter: new ConvexPopulateDatasetRowWriter(),
 });
 
 try {
@@ -128,21 +17,4 @@ try {
 } catch (err) {
   fastify.log.error(err);
   process.exit(1);
-}
-
-function responseSafePopulateResult(
-  result: Awaited<ReturnType<typeof runSelfHealingPopulate>>
-) {
-  const diagnosticRun = result.selectedRun ?? result.diagnosticRun;
-  return {
-    action: result.action,
-    datasetId: result.datasetId,
-    success: result.success,
-    committedRows: result.committedRows,
-    rejectionReasons: result.rejectionReasons,
-    validationIssues: result.validationIssues,
-    productionValidation: diagnosticRun?.productionValidation,
-    metrics: diagnosticRun?.metrics,
-    rowCount: diagnosticRun?.rows.length ?? 0,
-  };
 }

--- a/backend/src/pipeline/populate-runtime-selection.ts
+++ b/backend/src/pipeline/populate-runtime-selection.ts
@@ -1,0 +1,54 @@
+import {
+  CollectionPopulateRecipeRuntime,
+  type CollectionPopulatePipelineRunner,
+} from "./populate-collection-runtime.js";
+import {
+  MastraPopulateRecipeRuntime,
+  type PopulateRecipeRuntime,
+} from "./populate-self-healing.js";
+
+export type PopulateAgentRuntimeName = "mastra" | "collection";
+
+export interface CreatePopulateRecipeRuntimeInput {
+  env: NodeJS.ProcessEnv;
+  maxRows?: number;
+  collectionRunner?: CollectionPopulatePipelineRunner;
+}
+
+export function selectedPopulateRuntimeName(
+  env: NodeJS.ProcessEnv
+): PopulateAgentRuntimeName {
+  const rawRuntimeName = (
+    env.POPULATE_AGENT_RUNTIME ??
+    env.DATASET_AGENT_RUNTIME ??
+    "mastra"
+  ).trim().toLowerCase();
+
+  if (rawRuntimeName === "mastra" || rawRuntimeName === "mastra-populate") {
+    return "mastra";
+  }
+  if (rawRuntimeName === "collection") {
+    return "collection";
+  }
+  throw new Error(
+    `Unsupported POPULATE_AGENT_RUNTIME: ${rawRuntimeName || "(empty)"}.`
+  );
+}
+
+export async function createPopulateRecipeRuntime(
+  input: CreatePopulateRecipeRuntimeInput
+): Promise<PopulateRecipeRuntime> {
+  const runtimeName = selectedPopulateRuntimeName(input.env);
+  if (runtimeName === "mastra") {
+    return new MastraPopulateRecipeRuntime({ maxRows: input.maxRows });
+  }
+  if (!input.collectionRunner) {
+    throw new Error(
+      "POPULATE_AGENT_RUNTIME=collection requires a collection pipeline runner."
+    );
+  }
+  return new CollectionPopulateRecipeRuntime({
+    runPipeline: input.collectionRunner,
+    targetRows: input.maxRows,
+  });
+}

--- a/backend/src/pipeline/populate-self-healing-command.ts
+++ b/backend/src/pipeline/populate-self-healing-command.ts
@@ -11,6 +11,10 @@ import {
   type PopulateDatasetRowWriter,
   type RunSelfHealingPopulateResult,
 } from "./populate-self-healing-runner.js";
+import {
+  createPopulateRecipeRuntime,
+  type CreatePopulateRecipeRuntimeInput,
+} from "./populate-runtime-selection.js";
 
 export interface PopulateSelfHealingCliOptions {
   datasetId?: string;
@@ -29,6 +33,9 @@ export interface PopulateSelfHealingCliDependencies {
   writeStdout?: (text: string) => void;
   writeStderr?: (text: string) => void;
   runSelfHealing?: typeof runSelfHealingPopulate;
+  createRuntime?: (
+    input: CreatePopulateRecipeRuntimeInput
+  ) => Promise<Awaited<ReturnType<typeof createPopulateRecipeRuntime>>>;
   loadDatasetContextById?: (datasetId: string) => Promise<DatasetContext>;
   createRowWriter?: () => Promise<PopulateDatasetRowWriter>;
 }
@@ -65,6 +72,10 @@ export async function runPopulateSelfHealingCli(
         input.loadDatasetContextById ??
         ((datasetId) => defaultLoadDatasetContextById(datasetId, input.env)),
     });
+    const runtime = await (input.createRuntime ?? createPopulateRecipeRuntime)({
+      env: input.env,
+      maxRows: options.maxRows,
+    });
     const rowWriter = options.shouldCommitRows
       ? await (input.createRowWriter ?? defaultCreateRowWriter)()
       : undefined;
@@ -78,9 +89,7 @@ export async function runPopulateSelfHealingCli(
         : undefined,
       rowWriter,
       shouldCommitRows: options.shouldCommitRows,
-      runtime: options.maxRows === undefined
-        ? undefined
-        : await runtimeWithMaxRows(options.maxRows),
+      runtime,
     });
 
     writeStdout(JSON.stringify(summaryForResult(result, !options.shouldCommitRows)));
@@ -210,13 +219,6 @@ async function defaultCreateRowWriter(): Promise<PopulateDatasetRowWriter> {
     "./populate-convex-writer.js"
   );
   return new ConvexPopulateDatasetRowWriter();
-}
-
-async function runtimeWithMaxRows(maxRows: number) {
-  const { MastraPopulateRecipeRuntime } = await import(
-    "./populate-self-healing.js"
-  );
-  return new MastraPopulateRecipeRuntime({ maxRows });
 }
 
 function summaryForResult(

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,186 @@
+import Fastify, {
+  type FastifyInstance,
+  type FastifyPluginAsync,
+  type FastifyReply,
+  type FastifyRequest,
+} from "fastify";
+import fastifyCors from "@fastify/cors";
+
+import { inferSchema } from "./pipeline/schema-inference.js";
+import { datasetContextSchema } from "./pipeline/populate.js";
+import { populateRuntimePrerequisiteError } from "./pipeline/populate-runtime-prerequisites.js";
+import {
+  runSelfHealingPopulate,
+  type PopulateDatasetRowWriter,
+} from "./pipeline/populate-self-healing-runner.js";
+import {
+  createPopulateRecipeRuntime,
+  type CreatePopulateRecipeRuntimeInput,
+} from "./pipeline/populate-runtime-selection.js";
+
+export interface BigSetServerEnv {
+  CLIENT_ORIGIN: string;
+  CONVEX_URL: string;
+  CONVEX_ADMIN_KEY?: string;
+  OPENROUTER_API_KEY?: string;
+  TINYFISH_API_KEY?: string;
+  POPULATE_RECIPE_STORE_DIR: string;
+}
+
+export interface BigSetPopulateDataset {
+  ownerId: string;
+}
+
+export interface CreateBigSetServerInput {
+  env: BigSetServerEnv;
+  authPlugin?: FastifyPluginAsync;
+  authPreHandler: (
+    request: FastifyRequest,
+    reply: FastifyReply
+  ) => Promise<void> | void;
+  getDatasetById: (datasetId: string) => Promise<BigSetPopulateDataset | null>;
+  populateRowWriter: PopulateDatasetRowWriter;
+  runtimeEnv?: NodeJS.ProcessEnv;
+  inferSchemaFn?: typeof inferSchema;
+  runSelfHealing?: typeof runSelfHealingPopulate;
+  createRuntime?: (
+    input: CreatePopulateRecipeRuntimeInput
+  ) => Promise<CreatePopulateRecipeRuntimeResult>;
+}
+
+type CreatePopulateRecipeRuntimeResult = Awaited<
+  ReturnType<typeof createPopulateRecipeRuntime>
+>;
+
+export async function createBigSetServer(
+  input: CreateBigSetServerInput
+): Promise<FastifyInstance> {
+  const fastify = Fastify({ logger: true });
+  const inferSchemaForRequest = input.inferSchemaFn ?? inferSchema;
+  const runSelfHealing = input.runSelfHealing ?? runSelfHealingPopulate;
+  const createRuntime = input.createRuntime ?? createPopulateRecipeRuntime;
+
+  await fastify.register(fastifyCors, {
+    origin: input.env.CLIENT_ORIGIN,
+    methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allowedHeaders: ["Content-Type", "Authorization", "Cookie"],
+    credentials: true,
+    maxAge: 86400,
+  });
+
+  if (input.authPlugin) {
+    await fastify.register(input.authPlugin);
+  }
+
+  fastify.get("/health", async () => ({ status: "ok" }));
+
+  await fastify.register(async (instance) => {
+    instance.addHook("preHandler", input.authPreHandler);
+
+    instance.post("/infer-schema", async (req, reply) => {
+      const body = req.body as { prompt?: string };
+      if (!body?.prompt || typeof body.prompt !== "string" || !body.prompt.trim()) {
+        return reply.code(400).send({ error: "prompt is required" });
+      }
+
+      try {
+        const schema = await inferSchemaForRequest(body.prompt.trim());
+        return schema;
+      } catch (err) {
+        req.log.error(err, "Schema inference failed");
+        return reply.code(502).send({ error: "Schema inference failed. Please try again." });
+      }
+    });
+
+    instance.post("/populate", async (req, reply) => {
+      const parsed = datasetContextSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return reply.code(400).send({
+          error: "Invalid request",
+          details: parsed.error.flatten().fieldErrors,
+        });
+      }
+
+      try {
+        const dataset = await input.getDatasetById(parsed.data.datasetId);
+        if (!dataset) {
+          return reply.code(404).send({ error: "Dataset not found" });
+        }
+        const authenticatedUserId = req.auth?.userId;
+        if (!authenticatedUserId) {
+          return reply.code(401).send({ error: "Unauthenticated" });
+        }
+        if (dataset.ownerId !== authenticatedUserId) {
+          return reply.code(403).send({ error: "Not authorized to populate this dataset" });
+        }
+        const prerequisiteError = populateRuntimePrerequisiteError({
+          convexUrl: input.env.CONVEX_URL,
+          convexAdminKey: input.env.CONVEX_ADMIN_KEY,
+          openRouterApiKey: input.env.OPENROUTER_API_KEY,
+          tinyFishApiKey: input.env.TINYFISH_API_KEY,
+        });
+        if (prerequisiteError) {
+          return reply.code(500).send({
+            error: prerequisiteError,
+          });
+        }
+
+        const runtime = await createRuntime({
+          env: input.runtimeEnv ?? process.env,
+        });
+        const result = await runSelfHealing({
+          context: parsed.data,
+          recipeStoreDirectory: input.env.POPULATE_RECIPE_STORE_DIR,
+          rowWriter: input.populateRowWriter,
+          shouldCommitRows: true,
+          runtime,
+        });
+
+        req.log.info({
+          action: result.action,
+          datasetId: result.datasetId,
+          committedRows: result.committedRows?.insertedRowCount ?? 0,
+          validationIssues: result.validationIssues.slice(0, 5),
+        }, "Self-healing populate completed");
+
+        if (!result.success) {
+          return reply.code(422).send({
+            error: "Self-healing populate failed validation.",
+            result: responseSafePopulateResult(result),
+          });
+        }
+
+        return {
+          success: true,
+          result: responseSafePopulateResult(result),
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("validator") || msg.includes("Invalid")) {
+          return reply.code(400).send({ error: "Invalid datasetId" });
+        }
+        req.log.error(err, "Populate failed");
+        return reply.code(502).send({ error: "Failed to populate dataset. Please try again." });
+      }
+    });
+  });
+
+  return fastify;
+}
+
+function responseSafePopulateResult(
+  result: Awaited<ReturnType<typeof runSelfHealingPopulate>>
+) {
+  const diagnosticRun = result.selectedRun ?? result.diagnosticRun;
+  return {
+    action: result.action,
+    datasetId: result.datasetId,
+    success: result.success,
+    committedRows: result.committedRows,
+    rejectionReasons: result.rejectionReasons,
+    validationIssues: result.validationIssues,
+    productionValidation: diagnosticRun?.productionValidation,
+    metrics: diagnosticRun?.metrics,
+    rowCount: diagnosticRun?.rows.length ?? 0,
+  };
+}

--- a/backend/test/populate-runtime-selection.test.ts
+++ b/backend/test/populate-runtime-selection.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  createPopulateRecipeRuntime,
+  selectedPopulateRuntimeName,
+} from "../src/pipeline/populate-runtime-selection.js";
+import { CollectionPopulateRecipeRuntime } from "../src/pipeline/populate-collection-runtime.js";
+import { MastraPopulateRecipeRuntime } from "../src/pipeline/populate-self-healing.js";
+
+test("populate runtime selection defaults to Mastra", async () => {
+  assert.equal(selectedPopulateRuntimeName({}), "mastra");
+  assert.ok(
+    await createPopulateRecipeRuntime({ env: {} }) instanceof
+      MastraPopulateRecipeRuntime
+  );
+});
+
+test("populate runtime selection supports collection when a runner is provided", async () => {
+  assert.equal(
+    selectedPopulateRuntimeName({ POPULATE_AGENT_RUNTIME: "collection" }),
+    "collection"
+  );
+  const runtime = await createPopulateRecipeRuntime({
+    env: { POPULATE_AGENT_RUNTIME: "collection" },
+    collectionRunner: async () => ({
+      rows: [],
+      validationIssues: ["not used"],
+      usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+      metrics: {
+        searchCalls: 0,
+        fetchCalls: 0,
+        browserCalls: 0,
+        agentRuns: 0,
+        agentSteps: 0,
+      },
+    }),
+  });
+
+  assert.ok(runtime instanceof CollectionPopulateRecipeRuntime);
+});
+
+test("populate runtime selection rejects collection without a runner", async () => {
+  await assert.rejects(
+    () => createPopulateRecipeRuntime({
+      env: { POPULATE_AGENT_RUNTIME: "collection" },
+    }),
+    /requires a collection pipeline runner/
+  );
+});

--- a/backend/test/populate-self-healing-command.test.ts
+++ b/backend/test/populate-self-healing-command.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import type { DatasetContext } from "../src/pipeline/populate.js";
+import type { PopulateRecipeRuntime } from "../src/pipeline/populate-self-healing.js";
 import type { RunSelfHealingPopulateResult } from "../src/pipeline/populate-self-healing-runner.js";
 import {
   parsePopulateSelfHealingCliArgs,
@@ -136,6 +137,38 @@ test("self-healing CLI dry run does not require Convex admin key or create write
   assert.equal(output.success, true);
   assert.equal(output.dryRun, true);
   assert.equal(output.rowCount, 1);
+});
+
+test("self-healing CLI passes selected runtime into the runner", async () => {
+  const stdout: string[] = [];
+  const selectedRuntime = fakeRuntime();
+  let createRuntimeCalls = 0;
+  let didUseSelectedRuntime = false;
+  const exitCode = await runPopulateSelfHealingCli({
+    argv: ["--context", "context.json"],
+    env: {
+      OPENROUTER_API_KEY: "openrouter",
+      TINYFISH_API_KEY: "tinyfish",
+      POPULATE_AGENT_RUNTIME: "collection",
+    },
+    readFileText: async () => JSON.stringify(context),
+    writeStdout: (text) => stdout.push(text),
+    writeStderr: () => undefined,
+    createRuntime: async (input) => {
+      createRuntimeCalls += 1;
+      assert.equal(input.env.POPULATE_AGENT_RUNTIME, "collection");
+      return selectedRuntime;
+    },
+    runSelfHealing: async (input) => {
+      didUseSelectedRuntime = input.runtime === selectedRuntime;
+      return successfulResult(input.context.datasetId);
+    },
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(createRuntimeCalls, 1);
+  assert.equal(didUseSelectedRuntime, true);
+  assert.equal(JSON.parse(stdout[0]!).success, true);
 });
 
 test("self-healing CLI dataset-id dry run loads context before running", async () => {
@@ -460,5 +493,13 @@ function baseRun(datasetId: string): RunSelfHealingPopulateResult["selectedRun"]
       warnings: [],
     },
     artifacts: [],
+  };
+}
+
+function fakeRuntime(): PopulateRecipeRuntime {
+  return {
+    async runRecipe() {
+      throw new Error("fake runtime should not execute in CLI unit tests");
+    },
   };
 }

--- a/backend/test/populate-server.test.ts
+++ b/backend/test/populate-server.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { createBigSetServer } from "../src/server.js";
+import type { DatasetContext } from "../src/pipeline/populate.js";
+import type { PopulateRecipeRuntime } from "../src/pipeline/populate-self-healing.js";
+import type { RunSelfHealingPopulateResult } from "../src/pipeline/populate-self-healing-runner.js";
+
+const context: DatasetContext = {
+  datasetId: "dataset-ai-posts",
+  datasetName: "AI posts",
+  description: "Find latest blog posts from OpenAI.",
+  columns: [{
+    name: "entity_name",
+    type: "text",
+    description: "Company name.",
+  }],
+};
+
+test("POST /populate passes selected runtime into self-healing runner", async () => {
+  const selectedRuntime = fakeRuntime();
+  let createRuntimeCalls = 0;
+  let didUseSelectedRuntime = false;
+  const app = await createBigSetServer({
+    env: {
+      CLIENT_ORIGIN: "http://localhost:3500",
+      CONVEX_URL: "http://convex:3210",
+      CONVEX_ADMIN_KEY: "convex-admin",
+      OPENROUTER_API_KEY: "openrouter",
+      TINYFISH_API_KEY: "tinyfish",
+      POPULATE_RECIPE_STORE_DIR: ".bigset/populate-recipes",
+    },
+    runtimeEnv: {
+      POPULATE_AGENT_RUNTIME: "collection",
+    },
+    authPreHandler: async (request) => {
+      request.auth = { userId: "user-1" };
+    },
+    getDatasetById: async (datasetId) => {
+      assert.equal(datasetId, context.datasetId);
+      return { ownerId: "user-1" };
+    },
+    populateRowWriter: {
+      async replaceRows() {
+        return { insertedRowCount: 1 };
+      },
+    },
+    createRuntime: async (input) => {
+      createRuntimeCalls += 1;
+      assert.equal(input.env.POPULATE_AGENT_RUNTIME, "collection");
+      return selectedRuntime;
+    },
+    runSelfHealing: async (input) => {
+      didUseSelectedRuntime = input.runtime === selectedRuntime;
+      assert.equal(input.shouldCommitRows, true);
+      assert.equal(input.recipeStoreDirectory, ".bigset/populate-recipes");
+      assert.ok(input.rowWriter);
+      return successfulResult(input.context.datasetId);
+    },
+  });
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/populate",
+    payload: context,
+  });
+
+  await app.close();
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(createRuntimeCalls, 1);
+  assert.equal(didUseSelectedRuntime, true);
+  assert.equal(response.json().success, true);
+});
+
+function successfulResult(datasetId: string): RunSelfHealingPopulateResult {
+  return {
+    success: true,
+    action: "generated_initial_recipe",
+    datasetId,
+    selectedRun: {
+      rows: [{
+        cells: { entity_name: "OpenAI" },
+        sourceUrls: ["https://openai.com/news"],
+        evidence: [{
+          columnName: "entity_name",
+          sourceUrl: "https://openai.com/news",
+          quote: "OpenAI",
+        }],
+        needsReview: true,
+      }],
+      validationIssues: [],
+      usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+      metrics: {
+        searchCalls: 0,
+        fetchCalls: 0,
+        browserCalls: 0,
+        agentRuns: 0,
+        agentSteps: 0,
+      },
+      recipeId: `${datasetId}-recipe-v1`,
+      recipeVersion: 1,
+      runStatus: "succeeded",
+      startedAt: "2026-05-22T00:00:00.000Z",
+      completedAt: "2026-05-22T00:00:01.000Z",
+      runtimeMs: 1_000,
+      productionValidation: {
+        isValid: true,
+        score: 1,
+        rowCount: 1,
+        requestedCellCompletenessRatio: 1,
+        sourceUrlCoverageRatio: 1,
+        evidenceCoverageRatio: 1,
+        expectedEntityCoverageRatio: 1,
+        expectedEntities: [],
+        missingExpectedEntities: [],
+        criticalIssues: [],
+        warnings: [],
+      },
+      artifacts: [],
+    },
+    rejectionReasons: [],
+    validationIssues: [],
+    tick: {
+      datasetId,
+      action: "generated_initial_recipe",
+      rejectionReasons: [],
+    },
+  };
+}
+
+function fakeRuntime(): PopulateRecipeRuntime {
+  return {
+    async runRecipe() {
+      throw new Error("fake runtime should not execute in route unit tests");
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- adds a populate runtime selector for `POPULATE_AGENT_RUNTIME` / `DATASET_AGENT_RUNTIME`
- wires both HTTP `/populate` and `populate:self-heal` CLI through selected runtime creation
- extracts a testable server factory so the real `/populate` route can prove selected runtime reaches `runSelfHealingPopulate`

## Verification
- `npm --prefix backend test` passed: 54/54
- `npm --prefix backend run build` passed
- `make verify-self-healing` passed: backend tests, backend build, adapter syntax, and no-key benchmark smoke with zero spend

## Notes
- No auto-merge.
- Default runtime remains Mastra.
- `POPULATE_AGENT_RUNTIME=collection` intentionally requires an injected collection pipeline runner until the real collection pipeline is ported in a later PR.
- Next PR should add the self-healing-wrapped collection benchmark lane.
