### PR TITLE
Bound collection Agent runtime defaults

### DIFF
--- a/backend/BigSet_Data_Collection_Agent/src/integrations/tinyfish-agent.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/integrations/tinyfish-agent.ts
@@ -37,6 +37,10 @@ export interface TinyfishAgentJob {
   goal: string;
 }
 
+export interface TinyfishAgentRunOptions {
+  pollTimeoutMs?: number;
+}
+
 function runToResult(run: Run): TinyfishAgentRunResult {
   const errorMessage =
     run.error?.message ??
@@ -114,8 +118,10 @@ export async function queueTinyfishAgent(
 /** Poll `runs.get` until the run reaches a terminal status or times out. */
 export async function pollTinyfishAgentUntilDone(
   runId: string,
+  options: TinyfishAgentRunOptions = {},
 ): Promise<TinyfishAgentRunResult> {
   const startedAt = Date.now();
+  const pollTimeoutMs = options.pollTimeoutMs ?? config.agentPollTimeoutMs;
   let lastStatus = RunStatus.PENDING;
 
   while (true) {
@@ -134,7 +140,7 @@ export async function pollTinyfishAgentUntilDone(
       return runToResult(run);
     }
 
-    if (Date.now() - startedAt >= config.agentPollTimeoutMs) {
+    if (Date.now() - startedAt >= pollTimeoutMs) {
       await cancelTinyfishAgentRun(runId);
 
       try {
@@ -146,7 +152,7 @@ export async function pollTinyfishAgentUntilDone(
               ...result,
               error:
                 result.error ??
-                `Agent run cancelled after ${config.agentPollTimeoutMs}ms (was ${lastStatus})`,
+                `Agent run cancelled after ${pollTimeoutMs}ms (was ${lastStatus})`,
             };
           }
           return result;
@@ -159,7 +165,7 @@ export async function pollTinyfishAgentUntilDone(
         run_id: runId,
         status: "TIMEOUT",
         result: null,
-        error: `Agent run timed out after ${config.agentPollTimeoutMs}ms (last status: ${lastStatus}); cancel requested`,
+        error: `Agent run timed out after ${pollTimeoutMs}ms (last status: ${lastStatus}); cancel requested`,
       };
     }
 
@@ -173,6 +179,7 @@ export async function pollTinyfishAgentUntilDone(
 export async function runTinyfishAgent(
   url: string,
   goal: string,
+  options: TinyfishAgentRunOptions = {},
 ): Promise<TinyfishAgentRunResult> {
   const queued = await queueTinyfishAgent(url, goal);
   if (queued.error || !queued.run_id) {
@@ -183,7 +190,7 @@ export async function runTinyfishAgent(
       error: queued.error ?? "Failed to queue agent run",
     };
   }
-  return pollTinyfishAgentUntilDone(queued.run_id);
+  return pollTinyfishAgentUntilDone(queued.run_id, options);
 }
 
 /**
@@ -191,6 +198,7 @@ export async function runTinyfishAgent(
  */
 export async function runTinyfishAgentsBatch(
   jobs: TinyfishAgentJob[],
+  options: TinyfishAgentRunOptions = {},
 ): Promise<TinyfishAgentRunResult[]> {
   if (jobs.length === 0) return [];
 
@@ -224,7 +232,7 @@ export async function runTinyfishAgentsBatch(
     pollTargets,
     config.agentPollConcurrency,
     async ({ index, run_id }) => {
-      results[index] = await pollTinyfishAgentUntilDone(run_id);
+      results[index] = await pollTinyfishAgentUntilDone(run_id, options);
     },
   );
 

--- a/backend/BigSet_Data_Collection_Agent/src/orchestrator/acquisition.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/orchestrator/acquisition.ts
@@ -87,6 +87,7 @@ export async function runAcquisitionPhase(options: {
   knownEntityKeys?: string[];
   enableTriage?: boolean;
   enableTinyfishAgent?: boolean;
+  agentPollTimeoutMs?: number;
   memory?: WorkflowMemory;
   forceAgent?: boolean;
   /** Fetch outbound links from high-value pages (repair). */
@@ -222,6 +223,7 @@ export async function runAcquisitionPhase(options: {
     enableTinyfishAgent:
       options.enableTinyfishAgent ??
       (options.forceAgent ? true : config.enableTinyfishAgent),
+    agentPollTimeoutMs: options.agentPollTimeoutMs,
     memory: options.memory,
     log: options.log,
   });

--- a/backend/BigSet_Data_Collection_Agent/src/orchestrator/pipeline.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/orchestrator/pipeline.ts
@@ -63,6 +63,8 @@ export interface PipelineOptions {
   refreshInPlace?: boolean;
   /** When refreshing, re-fetch URLs already seen in the source run. */
   refetchUrls?: boolean;
+  /** Per-run TinyFish Agent poll timeout. Defaults to vendored config. */
+  agentPollTimeoutMs?: number;
   /** Override pipeline logging (benchmark adapters should log to stderr). */
   onLog?: (stage: string, message: string) => void;
   /** Set when invoked from the dataset-agent benchmark harness. */
@@ -262,6 +264,7 @@ async function executeRunPipeline(
     pageIndexStart: pageIndex,
     enableTriage,
     enableTinyfishAgent,
+    agentPollTimeoutMs: options.agentPollTimeoutMs,
     memory: useMemory ? memory : undefined,
     log,
   });
@@ -366,6 +369,7 @@ async function executeRunPipeline(
         allFailedUrls,
         enableTriage,
         enableTinyfishAgent,
+        agentPollTimeoutMs: options.agentPollTimeoutMs,
         targetRowCap,
         log,
       },

--- a/backend/BigSet_Data_Collection_Agent/src/orchestrator/process-pages.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/orchestrator/process-pages.ts
@@ -71,6 +71,7 @@ export async function processFetchedPages(options: {
   knownEntityKeys?: string[];
   enableTriage?: boolean;
   enableTinyfishAgent?: boolean;
+  agentPollTimeoutMs?: number;
   memory?: WorkflowMemory;
   log: (stage: string, message: string) => void;
 }): Promise<ProcessPagesResult> {
@@ -319,7 +320,9 @@ export async function processFetchedPages(options: {
       queueJobIndices.push(index);
     }
 
-    const agentRunResults = await runTinyfishAgentsBatch(queueJobs);
+    const agentRunResults = await runTinyfishAgentsBatch(queueJobs, {
+      pollTimeoutMs: options.agentPollTimeoutMs,
+    });
 
     const jobsToExtract = queueJobIndices.map((jobIndex, batchIndex) => ({
       job: jobsWithGoals[jobIndex]!,

--- a/backend/BigSet_Data_Collection_Agent/src/orchestrator/repair-loop.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/orchestrator/repair-loop.ts
@@ -41,6 +41,7 @@ export interface RepairLoopContext {
   allFailedUrls: string[];
   enableTriage: boolean;
   enableTinyfishAgent: boolean;
+  agentPollTimeoutMs?: number;
   targetRowCap: number;
   log: (stage: string, message: string) => void;
 }
@@ -162,6 +163,7 @@ export async function runRepairLoops(options: {
       knownEntityKeys: entityKeysFromRecords(ctx.spec, recordsBeforeLoop),
       enableTriage: ctx.enableTriage,
       enableTinyfishAgent: ctx.enableTinyfishAgent,
+      agentPollTimeoutMs: ctx.agentPollTimeoutMs,
       memory: ctx.memory,
       forceAgent: preferAgent,
       enableLinkFollow: config.enableRepairLinkFollow,

--- a/backend/src/pipeline/collection-agent-runner.ts
+++ b/backend/src/pipeline/collection-agent-runner.ts
@@ -24,6 +24,7 @@ interface CollectionPipelineOptions {
   enableRepair?: boolean;
   enableTriage?: boolean;
   enableTinyfishAgent?: boolean;
+  agentPollTimeoutMs?: number;
   benchmark?: {
     promptId?: string;
     promptQuality?: string;
@@ -97,7 +98,6 @@ export const runCollectionPopulatePipeline: CollectionPopulatePipelineRunner =
   async (input) => {
     const outputDir = await mkdtemp(join(tmpdir(), "bigset-collection-"));
     const enableTinyfishAgent = boolEnv("COLLECTION_AGENT_ENABLE_AGENT", false);
-    applyCollectionAgentRuntimeDefaults({ enableTinyfishAgent });
     const pipeline = await loadCollectionPipelineModule();
     const result = await pipeline.runPipeline({
       prompt: input.prompt,
@@ -107,6 +107,9 @@ export const runCollectionPopulatePipeline: CollectionPopulatePipelineRunner =
       enableRepair: boolEnv("COLLECTION_AGENT_ENABLE_REPAIR", false),
       enableTriage: boolEnv("COLLECTION_AGENT_ENABLE_TRIAGE", true),
       enableTinyfishAgent,
+      agentPollTimeoutMs: enableTinyfishAgent
+        ? collectionAgentPollTimeoutMs()
+        : undefined,
       benchmark: benchmarkContextFromInput(input),
       onLog: (stage, message) => {
         console.error(`[collection:${stage}] ${message}`);
@@ -312,21 +315,6 @@ function boolEnv(name: string, fallback: boolean): boolean {
   return ["1", "true", "yes", "on"].includes(raw.toLowerCase());
 }
 
-function applyCollectionAgentRuntimeDefaults(input: {
-  enableTinyfishAgent: boolean;
-}): void {
-  if (!input.enableTinyfishAgent || process.env.AGENT_POLL_TIMEOUT_MS) {
-    return;
-  }
-
-  process.env.AGENT_POLL_TIMEOUT_MS = String(
-    intEnv(
-      "COLLECTION_AGENT_POLL_TIMEOUT_MS",
-      DEFAULT_COLLECTION_AGENT_POLL_TIMEOUT_MS
-    )
-  );
-}
-
 function intEnv(name: string, fallback: number): number {
   const raw = process.env[name];
   if (raw === undefined || raw === "") {
@@ -337,4 +325,24 @@ function intEnv(name: string, fallback: number): number {
     throw new Error(`Invalid ${name}: expected positive integer, got "${raw}"`);
   }
   return value;
+}
+
+function optionalIntEnv(name: string): number | undefined {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") {
+    return undefined;
+  }
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`Invalid ${name}: expected positive integer, got "${raw}"`);
+  }
+  return value;
+}
+
+function collectionAgentPollTimeoutMs(): number {
+  return optionalIntEnv("AGENT_POLL_TIMEOUT_MS") ??
+    intEnv(
+      "COLLECTION_AGENT_POLL_TIMEOUT_MS",
+      DEFAULT_COLLECTION_AGENT_POLL_TIMEOUT_MS
+    );
 }

--- a/backend/src/pipeline/collection-agent-runner.ts
+++ b/backend/src/pipeline/collection-agent-runner.ts
@@ -91,9 +91,13 @@ interface CollectionRecordQuality {
   needs_review?: boolean;
 }
 
+const DEFAULT_COLLECTION_AGENT_POLL_TIMEOUT_MS = 480_000;
+
 export const runCollectionPopulatePipeline: CollectionPopulatePipelineRunner =
   async (input) => {
     const outputDir = await mkdtemp(join(tmpdir(), "bigset-collection-"));
+    const enableTinyfishAgent = boolEnv("COLLECTION_AGENT_ENABLE_AGENT", false);
+    applyCollectionAgentRuntimeDefaults({ enableTinyfishAgent });
     const pipeline = await loadCollectionPipelineModule();
     const result = await pipeline.runPipeline({
       prompt: input.prompt,
@@ -102,7 +106,7 @@ export const runCollectionPopulatePipeline: CollectionPopulatePipelineRunner =
       memoryDir: join(outputDir, "memory"),
       enableRepair: boolEnv("COLLECTION_AGENT_ENABLE_REPAIR", false),
       enableTriage: boolEnv("COLLECTION_AGENT_ENABLE_TRIAGE", true),
-      enableTinyfishAgent: boolEnv("COLLECTION_AGENT_ENABLE_AGENT", true),
+      enableTinyfishAgent,
       benchmark: benchmarkContextFromInput(input),
       onLog: (stage, message) => {
         console.error(`[collection:${stage}] ${message}`);
@@ -306,4 +310,31 @@ function boolEnv(name: string, fallback: boolean): boolean {
     return fallback;
   }
   return ["1", "true", "yes", "on"].includes(raw.toLowerCase());
+}
+
+function applyCollectionAgentRuntimeDefaults(input: {
+  enableTinyfishAgent: boolean;
+}): void {
+  if (!input.enableTinyfishAgent || process.env.AGENT_POLL_TIMEOUT_MS) {
+    return;
+  }
+
+  process.env.AGENT_POLL_TIMEOUT_MS = String(
+    intEnv(
+      "COLLECTION_AGENT_POLL_TIMEOUT_MS",
+      DEFAULT_COLLECTION_AGENT_POLL_TIMEOUT_MS
+    )
+  );
+}
+
+function intEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") {
+    return fallback;
+  }
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`Invalid ${name}: expected positive integer, got "${raw}"`);
+  }
+  return value;
 }

--- a/backend/test/collection-agent-runner.test.ts
+++ b/backend/test/collection-agent-runner.test.ts
@@ -14,7 +14,7 @@ test("collection agent runner maps vendored pipeline output into populate runtim
   delete process.env.COLLECTION_AGENT_ENABLE_AGENT;
   delete process.env.COLLECTION_AGENT_POLL_TIMEOUT_MS;
   process.env.COLLECTION_AGENT_PIPELINE_MODULE = fakeCollectionPipelineModuleUrl({
-    expectedAgentEnabled: false,
+    expectedCalls: [{ agentEnabled: false }],
   });
   try {
     const result = await runCollectionPopulatePipeline(collectionPipelineInput());
@@ -41,7 +41,7 @@ test("collection agent runner maps vendored pipeline output into populate runtim
   }
 });
 
-test("collection agent runner requires explicit Agent opt-in and caps poll timeout", async () => {
+test("collection agent runner requires explicit Agent opt-in and caps poll timeout per warm process call", async () => {
   const previousEnv = snapshotEnv([
     "AGENT_POLL_TIMEOUT_MS",
     "COLLECTION_AGENT_ENABLE_AGENT",
@@ -49,16 +49,35 @@ test("collection agent runner requires explicit Agent opt-in and caps poll timeo
     "COLLECTION_AGENT_POLL_TIMEOUT_MS",
   ]);
   delete process.env.AGENT_POLL_TIMEOUT_MS;
-  process.env.COLLECTION_AGENT_ENABLE_AGENT = "true";
-  process.env.COLLECTION_AGENT_POLL_TIMEOUT_MS = "12345";
+  delete process.env.COLLECTION_AGENT_ENABLE_AGENT;
+  delete process.env.COLLECTION_AGENT_POLL_TIMEOUT_MS;
   process.env.COLLECTION_AGENT_PIPELINE_MODULE = fakeCollectionPipelineModuleUrl({
-    expectedAgentEnabled: true,
-    expectedPollTimeoutMs: "12345",
+    expectedModuleLoadPollTimeoutMs: null,
+    expectedCalls: [
+      { agentEnabled: false },
+      { agentEnabled: true, pollTimeoutMs: 12345 },
+      { agentEnabled: true, pollTimeoutMs: 23456 },
+    ],
   });
 
   try {
-    const result = await runCollectionPopulatePipeline(collectionPipelineInput());
-    assert.equal(result.rows.length, 1);
+    assert.equal(
+      (await runCollectionPopulatePipeline(collectionPipelineInput())).rows.length,
+      1
+    );
+
+    process.env.COLLECTION_AGENT_ENABLE_AGENT = "true";
+    process.env.COLLECTION_AGENT_POLL_TIMEOUT_MS = "12345";
+    assert.equal(
+      (await runCollectionPopulatePipeline(collectionPipelineInput())).rows.length,
+      1
+    );
+
+    process.env.COLLECTION_AGENT_POLL_TIMEOUT_MS = "23456";
+    assert.equal(
+      (await runCollectionPopulatePipeline(collectionPipelineInput())).rows.length,
+      1
+    );
   } finally {
     restoreEnv(previousEnv);
   }
@@ -92,15 +111,30 @@ function collectionPipelineInput() {
 }
 
 function fakeCollectionPipelineModuleUrl(input: {
-  expectedAgentEnabled: boolean;
-  expectedPollTimeoutMs?: string;
+  expectedModuleLoadPollTimeoutMs?: string | null;
+  expectedCalls: Array<{
+    agentEnabled: boolean;
+    pollTimeoutMs?: number;
+  }>;
 }): string {
   const source = `
+    const moduleLoadPollTimeoutMs = process.env.AGENT_POLL_TIMEOUT_MS ?? null;
+    const expectedModuleLoadPollTimeoutMs = ${JSON.stringify(input.expectedModuleLoadPollTimeoutMs ?? null)};
+    const expectedCalls = ${JSON.stringify(input.expectedCalls)};
+    let callIndex = 0;
+
     export async function runPipeline(options) {
-      if (options.enableTinyfishAgent !== ${JSON.stringify(input.expectedAgentEnabled)}) {
+      if (moduleLoadPollTimeoutMs !== expectedModuleLoadPollTimeoutMs) {
+        throw new Error("unexpected module-load poll timeout");
+      }
+      const expected = expectedCalls[callIndex++];
+      if (!expected) {
+        throw new Error("unexpected extra pipeline call");
+      }
+      if (options.enableTinyfishAgent !== expected.agentEnabled) {
         throw new Error("unexpected TinyFish Agent setting");
       }
-      if (${JSON.stringify(input.expectedPollTimeoutMs ?? null)} !== null && process.env.AGENT_POLL_TIMEOUT_MS !== ${JSON.stringify(input.expectedPollTimeoutMs ?? null)}) {
+      if ((options.agentPollTimeoutMs ?? null) !== (expected.pollTimeoutMs ?? null)) {
         throw new Error("bounded agent poll timeout missing");
       }
       if (!options.prompt.includes("Durable recipe instructions")) {

--- a/backend/test/collection-agent-runner.test.ts
+++ b/backend/test/collection-agent-runner.test.ts
@@ -4,33 +4,20 @@ import { test } from "node:test";
 import { runCollectionPopulatePipeline } from "../src/pipeline/collection-agent-runner.js";
 
 test("collection agent runner maps vendored pipeline output into populate runtime result", async () => {
-  const previousModule = process.env.COLLECTION_AGENT_PIPELINE_MODULE;
-  process.env.COLLECTION_AGENT_PIPELINE_MODULE = fakeCollectionPipelineModuleUrl();
+  const previousEnv = snapshotEnv([
+    "AGENT_POLL_TIMEOUT_MS",
+    "COLLECTION_AGENT_ENABLE_AGENT",
+    "COLLECTION_AGENT_PIPELINE_MODULE",
+    "COLLECTION_AGENT_POLL_TIMEOUT_MS",
+  ]);
+  delete process.env.AGENT_POLL_TIMEOUT_MS;
+  delete process.env.COLLECTION_AGENT_ENABLE_AGENT;
+  delete process.env.COLLECTION_AGENT_POLL_TIMEOUT_MS;
+  process.env.COLLECTION_AGENT_PIPELINE_MODULE = fakeCollectionPipelineModuleUrl({
+    expectedAgentEnabled: false,
+  });
   try {
-    const result = await runCollectionPopulatePipeline({
-      datasetId: "dataset-ai-posts",
-      datasetName: "AI posts",
-      description: "Find latest AI blog posts.",
-      columns: [
-        { name: "entity_name", type: "text" },
-        { name: "source_url", type: "url" },
-        { name: "evidence_quote", type: "text" },
-      ],
-      requiredColumns: ["entity_name", "source_url", "evidence_quote"],
-      prompt: [
-        "Dataset: AI posts",
-        "Task: Find latest AI blog posts.",
-        "",
-        "Durable recipe instructions:",
-        "Prefer official source pages.",
-      ].join("\n"),
-      recipeInstructions: "Prefer official source pages.",
-      targetRows: 3,
-      promptId: "latest-ai-blog-posts",
-      promptQuality: "easy",
-      persona: "technical operator",
-      expectedStress: "Latest dated source pages.",
-    });
+    const result = await runCollectionPopulatePipeline(collectionPipelineInput());
 
     assert.equal(result.rows.length, 1);
     assert.equal(result.rows[0]?.cells.entity_name, "OpenAI");
@@ -50,17 +37,72 @@ test("collection agent runner maps vendored pipeline output into populate runtim
     assert.equal(result.metrics.agentRuns, 3);
     assert.equal(result.metrics.agentSteps, 3);
   } finally {
-    if (previousModule === undefined) {
-      delete process.env.COLLECTION_AGENT_PIPELINE_MODULE;
-    } else {
-      process.env.COLLECTION_AGENT_PIPELINE_MODULE = previousModule;
-    }
+    restoreEnv(previousEnv);
   }
 });
 
-function fakeCollectionPipelineModuleUrl(): string {
+test("collection agent runner requires explicit Agent opt-in and caps poll timeout", async () => {
+  const previousEnv = snapshotEnv([
+    "AGENT_POLL_TIMEOUT_MS",
+    "COLLECTION_AGENT_ENABLE_AGENT",
+    "COLLECTION_AGENT_PIPELINE_MODULE",
+    "COLLECTION_AGENT_POLL_TIMEOUT_MS",
+  ]);
+  delete process.env.AGENT_POLL_TIMEOUT_MS;
+  process.env.COLLECTION_AGENT_ENABLE_AGENT = "true";
+  process.env.COLLECTION_AGENT_POLL_TIMEOUT_MS = "12345";
+  process.env.COLLECTION_AGENT_PIPELINE_MODULE = fakeCollectionPipelineModuleUrl({
+    expectedAgentEnabled: true,
+    expectedPollTimeoutMs: "12345",
+  });
+
+  try {
+    const result = await runCollectionPopulatePipeline(collectionPipelineInput());
+    assert.equal(result.rows.length, 1);
+  } finally {
+    restoreEnv(previousEnv);
+  }
+});
+
+function collectionPipelineInput() {
+  return {
+    datasetId: "dataset-ai-posts",
+    datasetName: "AI posts",
+    description: "Find latest AI blog posts.",
+    columns: [
+      { name: "entity_name", type: "text" as const },
+      { name: "source_url", type: "url" as const },
+      { name: "evidence_quote", type: "text" as const },
+    ],
+    requiredColumns: ["entity_name", "source_url", "evidence_quote"],
+    prompt: [
+      "Dataset: AI posts",
+      "Task: Find latest AI blog posts.",
+      "",
+      "Durable recipe instructions:",
+      "Prefer official source pages.",
+    ].join("\n"),
+    recipeInstructions: "Prefer official source pages.",
+    targetRows: 3,
+    promptId: "latest-ai-blog-posts",
+    promptQuality: "easy",
+    persona: "technical operator",
+    expectedStress: "Latest dated source pages.",
+  };
+}
+
+function fakeCollectionPipelineModuleUrl(input: {
+  expectedAgentEnabled: boolean;
+  expectedPollTimeoutMs?: string;
+}): string {
   const source = `
     export async function runPipeline(options) {
+      if (options.enableTinyfishAgent !== ${JSON.stringify(input.expectedAgentEnabled)}) {
+        throw new Error("unexpected TinyFish Agent setting");
+      }
+      if (${JSON.stringify(input.expectedPollTimeoutMs ?? null)} !== null && process.env.AGENT_POLL_TIMEOUT_MS !== ${JSON.stringify(input.expectedPollTimeoutMs ?? null)}) {
+        throw new Error("bounded agent poll timeout missing");
+      }
       if (!options.prompt.includes("Durable recipe instructions")) {
         throw new Error("recipe instructions missing from prompt");
       }
@@ -139,4 +181,18 @@ function fakeCollectionPipelineModuleUrl(): string {
     }
   `;
   return `data:text/javascript,${encodeURIComponent(source)}`;
+}
+
+function snapshotEnv(names: string[]): Map<string, string | undefined> {
+  return new Map(names.map((name) => [name, process.env[name]]));
+}
+
+function restoreEnv(snapshot: Map<string, string | undefined>): void {
+  for (const [name, value] of snapshot) {
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  }
 }

--- a/benchmarks/dataset-agent/README.md
+++ b/benchmarks/dataset-agent/README.md
@@ -42,6 +42,10 @@ Real collection benchmark runs require `OPENROUTER_API_KEY`,
 module must export `runCollectionPopulatePipeline(input)` or a default runner
 that accepts `CollectionPopulatePipelineInput` and returns a
 `PopulateRuntimeResult`. The pipeline module must export `runPipeline(options)`.
+The BigSet runner keeps TinyFish Agent/browser calls off by default so the
+benchmark stays cheap and bounded. Set `COLLECTION_AGENT_ENABLE_AGENT=true` to
+opt in; Agent polling is capped by `AGENT_POLL_TIMEOUT_MS`, or by
+`COLLECTION_AGENT_POLL_TIMEOUT_MS` when the generic timeout is unset.
 
 App and CLI collection-runtime runs use the same runner shape, but load it from
 `POPULATE_COLLECTION_RUNNER_MODULE` when `POPULATE_AGENT_RUNTIME=collection`.

--- a/docs/data-collection-agent-migration-plan.md
+++ b/docs/data-collection-agent-migration-plan.md
@@ -238,6 +238,12 @@ POPULATE_COLLECTION_RUNNER_MODULE=./backend/src/pipeline/collection-agent-runner
 COLLECTION_AGENT_PIPELINE_MODULE=./backend/BigSet_Data_Collection_Agent/src/orchestrator/pipeline.ts
 ```
 
+The BigSet runner keeps TinyFish Agent/browser calls disabled unless
+`COLLECTION_AGENT_ENABLE_AGENT=true`. This makes cron and benchmark reruns cheap
+and repeatable first. Agent-enabled runs should also set
+`COLLECTION_AGENT_POLL_TIMEOUT_MS` or `AGENT_POLL_TIMEOUT_MS` so a browser run
+cannot outlive the benchmark/job budget.
+
 Do not switch the default runtime from Mastra to collection until the
 self-healing-wrapped collection benchmark has better evidence than the current
 Mastra lane.


### PR DESCRIPTION
## Summary

- make the BigSet collection runner keep TinyFish Agent/browser calls off unless `COLLECTION_AGENT_ENABLE_AGENT=true`
- add a bounded per-run Agent poll timeout for opt-in Agent runs via `COLLECTION_AGENT_POLL_TIMEOUT_MS` when `AGENT_POLL_TIMEOUT_MS` is unset
- thread the timeout through the vendored collection pipeline, acquisition, repair, page processing, and TinyFish polling path instead of relying on import-time env mutation
- extend collection runner tests to prove default no-Agent behavior and explicit Agent opt-in timeout behavior
- document the runtime default so cron and benchmark runs stay cheap/repeatable by default

## Verification

- `npm --prefix backend test -- test/collection-agent-runner.test.ts` (repo script ran all backend tests: `58/58` pass)
- `npm --prefix backend run build`
- `make verify-self-healing`
- critic subagent review: aligned as infra hardening; do not frame as quality/default-ready work
- code-reviewer requested changes on warm-process timeout caching; fixed by passing timeout as an explicit per-run option and adding a warm-module test

## Real Benchmark Evidence

With keys loaded execution-only and no `COLLECTION_AGENT_ENABLE_AGENT` set:

- `COLLECTION_AGENT_PIPELINE_MODULE=./backend/BigSet_Data_Collection_Agent/src/orchestrator/pipeline.ts`
- `BIGSET_COLLECTION_BENCHMARK_RUNNER_MODULE=./backend/src/pipeline/collection-agent-runner.ts`
- 2-prompt default run: `0/2` passed, `2` failed, `0` blocked, `7` rows, `12` evidence quotes, `0` browser/Agent runs, cost `$0.009562`

Conclusion: this PR fixes budget/runtime behavior, not source-quality. The collection lane no longer accidentally hits the long TinyFish Agent path by default, but source/domain/evidence quality is still the next problem.

## Notes

No merge. This stacks after PR #43.
