### PR TITLE
Expose self-healing benchmark diagnostics

### DIFF
--- a/benchmarks/dataset-agent/README.md
+++ b/benchmarks/dataset-agent/README.md
@@ -114,6 +114,38 @@ When TinyFish Agent result JSON includes explicit `browser_actions` or
 `actions` arrays are ignored because they are not browser-specific enough to
 replay honestly.
 
+The collection self-healing adapter also prints a compact `diagnostics` object
+to stdout so benchmark artifacts can answer the Playwright readiness question
+without committing raw run folders:
+
+```json
+{
+  "diagnostics": {
+    "selfHealingAction": "generated_initial_recipe",
+    "artifactKinds": ["process-trace", "playwright-candidate-readiness"],
+    "processTrace": {
+      "runtime": "collection",
+      "stepCount": 12,
+      "browserStepCount": 1,
+      "sourceUrlCount": 4
+    },
+    "playwrightCandidateReadiness": {
+      "status": "ready",
+      "browserStepCount": 1,
+      "sourceUrlCount": 4
+    }
+  }
+}
+```
+
+`summary.json` carries the same high-signal fields on each lane result:
+`selfHealingAction`, `selfHealingArtifactKinds`, `processTraceStepCount`,
+`processTraceBrowserStepCount`, `playwrightCandidateStatus`,
+`playwrightCandidateBrowserStepCount`, and
+`playwrightCandidateSourceUrlCount`. Use those fields to verify whether an
+Agent canary actually emitted browser actions before starting a Playwright
+compiler.
+
 ## Verify Self-Healing Stack
 
 Use this before asking someone else to migrate a new collection agent into the

--- a/benchmarks/dataset-agent/adapters/collection-self-healing-adapter.mjs
+++ b/benchmarks/dataset-agent/adapters/collection-self-healing-adapter.mjs
@@ -2,6 +2,8 @@
 import { pathToFileURL } from "node:url";
 import { resolve } from "node:path";
 
+import { selfHealingDiagnosticsFromTick } from "./self-healing-output.mjs";
+
 const prompt = requiredEnv("BIGSET_BENCHMARK_PROMPT");
 const promptId = process.env.BIGSET_BENCHMARK_PROMPT_ID ?? "benchmark-prompt";
 const promptQuality = process.env.BIGSET_BENCHMARK_PROMPT_QUALITY ?? "unknown";
@@ -87,6 +89,7 @@ const service = new SelfHealingPopulateRecipeService({
 });
 const tick = await service.tick({ datasetId: context.datasetId, context });
 const result = diagnosticRunForTick(tick);
+const diagnostics = selfHealingDiagnosticsFromTick({ tick, run: result });
 
 console.log(JSON.stringify({
   rows: result?.rows ?? [],
@@ -95,7 +98,16 @@ console.log(JSON.stringify({
     ...minimumColumnIssues(result?.rows ?? []),
   ],
   usage: result?.usage ?? emptyUsage(),
-  metrics: result?.metrics ?? emptyMetrics(),
+  metrics: {
+    ...(result?.metrics ?? emptyMetrics()),
+    processTraceStepCount: diagnostics.processTrace?.stepCount ?? 0,
+    processTraceBrowserStepCount: diagnostics.processTrace?.browserStepCount ?? 0,
+    playwrightCandidateBrowserStepCount:
+      diagnostics.playwrightCandidateReadiness?.browserStepCount ?? 0,
+    playwrightCandidateSourceUrlCount:
+      diagnostics.playwrightCandidateReadiness?.sourceUrlCount ?? 0,
+  },
+  diagnostics,
 }));
 
 async function loadCollectionRunner() {

--- a/benchmarks/dataset-agent/adapters/self-healing-output.mjs
+++ b/benchmarks/dataset-agent/adapters/self-healing-output.mjs
@@ -1,0 +1,75 @@
+export function selfHealingDiagnosticsFromTick({ tick, run }) {
+  const artifacts = Array.isArray(run?.artifacts) ? run.artifacts : [];
+  const processTrace = processTraceSummaryFromArtifacts(artifacts);
+  const playwrightCandidateReadiness = playwrightReadinessFromArtifacts(artifacts);
+
+  return {
+    selfHealingAction: tick?.action,
+    recipeId: run?.recipeId,
+    artifactKinds: artifacts
+      .map((artifact) => artifact?.kind)
+      .filter((kind) => typeof kind === "string"),
+    processTrace,
+    playwrightCandidateReadiness,
+  };
+}
+
+function processTraceSummaryFromArtifacts(artifacts) {
+  const trace = parsedJsonArtifact(artifacts, "process-trace");
+  if (!trace) {
+    return undefined;
+  }
+  const steps = Array.isArray(trace.steps) ? trace.steps : [];
+  const sourceArtifacts = Array.isArray(trace.sourceArtifacts)
+    ? trace.sourceArtifacts
+    : [];
+  const fetchedUrls = Array.isArray(trace.fetchedUrls) ? trace.fetchedUrls : [];
+  const searchQueries = Array.isArray(trace.searchQueries)
+    ? trace.searchQueries
+    : [];
+
+  return {
+    runtime: typeof trace.runtime === "string" ? trace.runtime : "unknown",
+    stepCount: steps.length,
+    browserStepCount: steps.filter((step) => step?.kind === "browser").length,
+    sourceUrlCount: new Set([
+      ...fetchedUrls,
+      ...sourceArtifacts
+        .filter((artifact) => artifact?.status === "succeeded")
+        .map((artifact) => artifact?.url),
+    ].filter((url) => typeof url === "string" && /^https?:\/\//i.test(url))).size,
+    searchQueryCount: searchQueries.length,
+    fetchedUrlCount: fetchedUrls.length,
+  };
+}
+
+function playwrightReadinessFromArtifacts(artifacts) {
+  const readiness = parsedJsonArtifact(artifacts, "playwright-candidate-readiness");
+  if (!readiness) {
+    return undefined;
+  }
+  return {
+    status: readiness.status === "ready" ? "ready" : "not_ready",
+    reasons: Array.isArray(readiness.reasons)
+      ? readiness.reasons.filter((reason) => typeof reason === "string")
+      : [],
+    browserStepCount: numberValue(readiness.browserStepCount),
+    sourceUrlCount: numberValue(readiness.sourceUrlCount),
+  };
+}
+
+function parsedJsonArtifact(artifacts, kind) {
+  const artifact = artifacts.find((candidate) => candidate?.kind === kind);
+  if (!artifact || typeof artifact.content !== "string") {
+    return undefined;
+  }
+  try {
+    return JSON.parse(artifact.content);
+  } catch {
+    return undefined;
+  }
+}
+
+function numberValue(value) {
+  return Number.isFinite(Number(value)) ? Number(value) : 0;
+}

--- a/benchmarks/dataset-agent/run-benchmark.mjs
+++ b/benchmarks/dataset-agent/run-benchmark.mjs
@@ -627,6 +627,18 @@ async function runSystemPrompt(input) {
     needsReviewCount: validation.needsReviewCount,
     validationIssueCount: normalized.validationIssues.length,
     validationIssues: normalized.validationIssues,
+    selfHealingAction: normalized.diagnostics.selfHealingAction,
+    selfHealingArtifactKinds: normalized.diagnostics.artifactKinds,
+    processTraceStepCount: normalized.diagnostics.processTrace?.stepCount,
+    processTraceBrowserStepCount:
+      normalized.diagnostics.processTrace?.browserStepCount,
+    playwrightCandidateStatus:
+      normalized.diagnostics.playwrightCandidateReadiness?.status,
+    playwrightCandidateBrowserStepCount:
+      normalized.diagnostics.playwrightCandidateReadiness?.browserStepCount,
+    playwrightCandidateSourceUrlCount:
+      normalized.diagnostics.playwrightCandidateReadiness?.sourceUrlCount,
+    diagnostics: normalized.diagnostics,
     usage,
     searchCallCount: normalized.metrics.searchCallCount,
     fetchCallCount: normalized.metrics.fetchCallCount,
@@ -930,7 +942,7 @@ function extractLastJsonObject(value) {
   return null;
 }
 
-function normalizePayload(payload) {
+export function normalizePayload(payload) {
   const rows = arrayValue(
     payload?.rows ??
       payload?.data ??
@@ -943,10 +955,12 @@ function normalizePayload(payload) {
   );
   const metrics = payload?.metrics ?? payload?.benchmarkMetrics ?? {};
   const usage = normalizeUsage(payload?.usage ?? metrics.usage ?? metrics);
+  const diagnostics = objectValue(payload?.diagnostics);
 
   return {
     rows,
     validationIssues,
+    diagnostics,
     usage,
     metrics: {
       searchCallCount: numberValue(metrics.searchCallCount ?? metrics.searchCalls),
@@ -1679,6 +1693,13 @@ function capabilityDiagnosticReason(validationIssues) {
 
 function arrayValue(value) {
   return Array.isArray(value) ? value : [];
+}
+
+function objectValue(value) {
+  if (!value || Array.isArray(value) || typeof value !== "object") {
+    return {};
+  }
+  return value;
 }
 
 function stringArrayValue(value) {

--- a/benchmarks/dataset-agent/run-benchmark.test.mjs
+++ b/benchmarks/dataset-agent/run-benchmark.test.mjs
@@ -4,8 +4,10 @@ import { test } from "node:test";
 import {
   failureReason,
   findInfrastructureBlockerReason,
+  normalizePayload,
   scoreBenchmarkRows,
 } from "./run-benchmark.mjs";
+import { selfHealingDiagnosticsFromTick } from "./adapters/self-healing-output.mjs";
 
 const passingValidation = {
   rowCount: 1,
@@ -176,4 +178,58 @@ test("domain scoring counts product, careers, and docs URL cells", () => {
     assert.equal(score.passed, true, `${item.label} should pass`);
     assert.equal(score.domainAccuracyRatio, 1, `${item.label} domain`);
   }
+});
+
+test("self-healing diagnostics summarize trace and readiness artifacts", () => {
+  const diagnostics = selfHealingDiagnosticsFromTick({
+    tick: { action: "generated_initial_recipe" },
+    run: {
+      recipeId: "recipe-v1",
+      artifacts: [
+        {
+          kind: "process-trace",
+          content: JSON.stringify({
+            runtime: "collection",
+            searchQueries: ["example"],
+            fetchedUrls: ["https://example.com"],
+            sourceArtifacts: [{
+              url: "https://example.com",
+              status: "succeeded",
+            }],
+            steps: [
+              { kind: "search" },
+              { kind: "browser" },
+            ],
+          }),
+        },
+        {
+          kind: "playwright-candidate-readiness",
+          content: JSON.stringify({
+            status: "ready",
+            reasons: [],
+            browserStepCount: 1,
+            sourceUrlCount: 1,
+          }),
+        },
+      ],
+    },
+  });
+  const normalized = normalizePayload({
+    rows: [],
+    validationIssues: [],
+    diagnostics,
+  });
+
+  assert.equal(normalized.diagnostics.selfHealingAction, "generated_initial_recipe");
+  assert.deepEqual(normalized.diagnostics.artifactKinds, [
+    "process-trace",
+    "playwright-candidate-readiness",
+  ]);
+  assert.equal(normalized.diagnostics.processTrace.runtime, "collection");
+  assert.equal(normalized.diagnostics.processTrace.stepCount, 2);
+  assert.equal(normalized.diagnostics.processTrace.browserStepCount, 1);
+  assert.equal(
+    normalized.diagnostics.playwrightCandidateReadiness.status,
+    "ready"
+  );
 });

--- a/docs/data-collection-agent-migration-plan.md
+++ b/docs/data-collection-agent-migration-plan.md
@@ -191,6 +191,10 @@ The current layer does not yet:
      enabled
    - confirm the canary emits explicit `agent_browser_actions` or equivalent
      fields in the collection report; source outcomes alone are not enough
+   - check `summary.json` for `playwrightCandidateStatus`,
+     `processTraceBrowserStepCount`, and
+     `playwrightCandidateBrowserStepCount` so the canary proves browser-action
+     provenance, not only row/evidence quality
    - full benchmark only after the 2-prompt run is not obviously broken
    - live `--dataset-id` dry-run only after Convex/env prerequisites are ready
    - `--commit` only on a throwaway dataset first


### PR DESCRIPTION
## Summary

Stacked on #56. Adds the narrow verifier surface the self-healing/Playwright handoff needs before any compiler or app-runtime migration:

- collection self-healing benchmark output now includes compact `diagnostics`
- diagnostics summarize self-healing action, artifact kinds, process-trace counts, browser-step counts, and Playwright candidate readiness
- benchmark `summary.json` carries the same high-signal fields per lane result
- added a pure helper for reading self-healing artifacts without committing raw run folders
- docs now say Agent canaries must prove browser-action provenance through these fields, not only row/evidence quality

This does not generate Playwright scripts, infer browser actions, migrate Meteor's runtime, or make collection the default runtime.

## Verification

- `node --test benchmarks/dataset-agent/run-benchmark.test.mjs`
- `node --check benchmarks/dataset-agent/adapters/collection-self-healing-adapter.mjs`
- `node --check benchmarks/dataset-agent/adapters/self-healing-output.mjs`
- `node --check benchmarks/dataset-agent/run-benchmark.mjs`
- no-key collection adapter smoke with `OPENROUTER_API_KEY`/`TINYFISH_API_KEY` unset
- `npm --prefix backend test`
- `npm --prefix backend run build`
- `git diff --check`
- `make verify-self-healing`
