### PR TITLE
Surface Agent run provenance diagnostics

### DIFF
--- a/backend/BigSet_Data_Collection_Agent/src/integrations/tinyfish-agent.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/integrations/tinyfish-agent.ts
@@ -25,6 +25,9 @@ export interface TinyfishAgentRunResult {
   status: string;
   result: Record<string, unknown> | null;
   error: string | null;
+  agent_step_count: number | null;
+  has_streaming_url: boolean;
+  result_keys: string[];
 }
 
 export interface QueueTinyfishAgentResult {
@@ -41,16 +44,23 @@ export interface TinyfishAgentRunOptions {
   pollTimeoutMs?: number;
 }
 
-function runToResult(run: Run): TinyfishAgentRunResult {
+export function tinyfishAgentRunResultFromRun(run: Run): TinyfishAgentRunResult {
   const errorMessage =
     run.error?.message ??
     (run.status === RunStatus.FAILED ? "Agent run failed" : null);
+  const result = (run.result as Record<string, unknown> | null) ?? null;
 
   return {
     run_id: run.run_id,
     status: run.status,
-    result: (run.result as Record<string, unknown> | null) ?? null,
+    result,
     error: errorMessage,
+    agent_step_count: typeof run.num_of_steps === "number"
+      ? run.num_of_steps
+      : null,
+    has_streaming_url: typeof run.streaming_url === "string" &&
+      run.streaming_url.length > 0,
+    result_keys: result ? Object.keys(result).sort() : [],
   };
 }
 
@@ -137,7 +147,7 @@ export async function pollTinyfishAgentUntilDone(
     lastStatus = run.status;
 
     if (TERMINAL_STATUSES.has(run.status)) {
-      return runToResult(run);
+      return tinyfishAgentRunResultFromRun(run);
     }
 
     if (Date.now() - startedAt >= pollTimeoutMs) {
@@ -146,7 +156,7 @@ export async function pollTinyfishAgentUntilDone(
       try {
         const finalRun = await getClient().runs.get(runId);
         if (TERMINAL_STATUSES.has(finalRun.status)) {
-          const result = runToResult(finalRun);
+          const result = tinyfishAgentRunResultFromRun(finalRun);
           if (finalRun.status === RunStatus.CANCELLED) {
             return {
               ...result,
@@ -166,6 +176,9 @@ export async function pollTinyfishAgentUntilDone(
         status: "TIMEOUT",
         result: null,
         error: `Agent run timed out after ${pollTimeoutMs}ms (last status: ${lastStatus}); cancel requested`,
+        agent_step_count: null,
+        has_streaming_url: false,
+        result_keys: [],
       };
     }
 
@@ -188,6 +201,9 @@ export async function runTinyfishAgent(
       status: RunStatus.FAILED,
       result: null,
       error: queued.error ?? "Failed to queue agent run",
+      agent_step_count: null,
+      has_streaming_url: false,
+      result_keys: [],
     };
   }
   return pollTinyfishAgentUntilDone(queued.run_id, options);
@@ -222,6 +238,9 @@ export async function runTinyfishAgentsBatch(
         status: RunStatus.FAILED,
         result: null,
         error: item.error ?? "Failed to queue agent run",
+        agent_step_count: null,
+        has_streaming_url: false,
+        result_keys: [],
       };
       continue;
     }

--- a/backend/BigSet_Data_Collection_Agent/src/models/schemas.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/models/schemas.ts
@@ -126,6 +126,10 @@ export const agentRunRecordSchema = z.object({
   goal: z.string(),
   records_extracted: z.number(),
   error: z.string().optional(),
+  agent_step_count: z.number().nullable().optional(),
+  has_streaming_url: z.boolean().optional(),
+  result_keys: z.array(z.string()).optional(),
+  browser_action_diagnostic: z.string().optional(),
   browser_actions: z.array(browserActionReportSchema).optional(),
 });
 
@@ -143,6 +147,9 @@ export const triageSummarySchema = z.object({
   skipped: z.number(),
   records_from_extract: z.number(),
   records_from_agent: z.number(),
+  agent_reported_step_count: z.number().optional(),
+  agent_runs_with_streaming_url: z.number().optional(),
+  agent_runs_with_explicit_browser_actions: z.number().optional(),
 });
 
 export type TriageSummary = z.infer<typeof triageSummarySchema>;

--- a/backend/BigSet_Data_Collection_Agent/src/orchestrator/process-pages.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/orchestrator/process-pages.ts
@@ -5,6 +5,7 @@ import { triagePage } from "../agents/source-triage.js";
 import { derivePromptSourcePolicy } from "../agents/source-policy.js";
 import { config } from "../config.js";
 import { runTinyfishAgentsBatch } from "../integrations/tinyfish-agent.js";
+import type { TinyfishAgentRunResult } from "../integrations/tinyfish-agent.js";
 import type { WorkflowMemory } from "../memory/index.js";
 import { getPrimaryKeyValue } from "../merge/records.js";
 import {
@@ -56,6 +57,55 @@ function emptySummary(): TriageSummary {
     skipped: 0,
     records_from_extract: 0,
     records_from_agent: 0,
+    agent_reported_step_count: 0,
+    agent_runs_with_streaming_url: 0,
+    agent_runs_with_explicit_browser_actions: 0,
+  };
+}
+
+function recordAgentRunProvenance(
+  summary: TriageSummary,
+  run: TinyfishAgentRunResult,
+  browserActionCount: number,
+): void {
+  summary.agent_reported_step_count =
+    (summary.agent_reported_step_count ?? 0) +
+      (run.agent_step_count ?? 0);
+  if (run.has_streaming_url) {
+    summary.agent_runs_with_streaming_url =
+      (summary.agent_runs_with_streaming_url ?? 0) + 1;
+  }
+  if (browserActionCount > 0) {
+    summary.agent_runs_with_explicit_browser_actions =
+      (summary.agent_runs_with_explicit_browser_actions ?? 0) + 1;
+  }
+}
+
+function agentRunProvenanceFields(input: {
+  run: TinyfishAgentRunResult;
+  recordsExtracted: number;
+  browserActionCount: number;
+}): Pick<
+  AgentRunRecord,
+  | "agent_step_count"
+  | "has_streaming_url"
+  | "result_keys"
+  | "browser_action_diagnostic"
+> {
+  const hasReportedBrowserWork = (input.run.agent_step_count ?? 0) > 0;
+  const missingExplicitBrowserActions =
+    hasReportedBrowserWork && input.browserActionCount === 0;
+  const browserActionDiagnostic = missingExplicitBrowserActions
+    ? input.recordsExtracted > 0
+      ? "Agent completed and returned rows, but polled run payload exposed no explicit browser actions."
+      : "Agent completed with reported browser work, but polled run payload exposed no explicit browser actions."
+    : undefined;
+
+  return {
+    agent_step_count: input.run.agent_step_count,
+    has_streaming_url: input.run.has_streaming_url,
+    result_keys: input.run.result_keys,
+    browser_action_diagnostic: browserActionDiagnostic,
   };
 }
 
@@ -392,6 +442,7 @@ export async function processFetchedPages(options: {
         const pageUrl = job.pageUrl;
 
         if (run.error || !run.result) {
+          recordAgentRunProvenance(summary, run, 0);
           summary.agent_failed += 1;
           agentRuns.push({
             url: pageUrl,
@@ -401,6 +452,11 @@ export async function processFetchedPages(options: {
             goal: job.goal,
             records_extracted: 0,
             error: run.error ?? "No result returned",
+            ...agentRunProvenanceFields({
+              run,
+              recordsExtracted: 0,
+              browserActionCount: 0,
+            }),
           });
           options.log(
             options.label,
@@ -413,6 +469,7 @@ export async function processFetchedPages(options: {
           agentResult: run.result,
           pageUrl,
         });
+        recordAgentRunProvenance(summary, run, browserActions.length);
 
         try {
           const agentRecords = await extractFromAgentResult({
@@ -438,6 +495,11 @@ export async function processFetchedPages(options: {
             agent_status: run.status,
             goal: job.goal,
             records_extracted: agentRecords.length,
+            ...agentRunProvenanceFields({
+              run,
+              recordsExtracted: agentRecords.length,
+              browserActionCount: browserActions.length,
+            }),
             browser_actions: browserActions.length > 0
               ? browserActions
               : undefined,
@@ -459,6 +521,11 @@ export async function processFetchedPages(options: {
             goal: job.goal,
             records_extracted: 0,
             error: msg,
+            ...agentRunProvenanceFields({
+              run,
+              recordsExtracted: 0,
+              browserActionCount: browserActions.length,
+            }),
             browser_actions: browserActions.length > 0
               ? browserActions
               : undefined,

--- a/backend/src/pipeline/collection-agent-runner.ts
+++ b/backend/src/pipeline/collection-agent-runner.ts
@@ -95,6 +95,9 @@ interface CollectionPhaseStats {
     agent_dispatched?: number;
     agent_succeeded?: number;
     agent_failed?: number;
+    agent_reported_step_count?: number;
+    agent_runs_with_streaming_url?: number;
+    agent_runs_with_explicit_browser_actions?: number;
   };
 }
 
@@ -393,6 +396,15 @@ function collectionDebugNotes(report: CollectionPipelineResult["report"]): strin
   if (report.repair?.loops && report.repair.loops.length > 0) {
     notes.push(`collection repair loops=${report.repair.loops.length}`);
   }
+  const triage = report.stats?.triage ?? report.initial?.triage;
+  if (
+    numberValue(triage?.agent_reported_step_count) > 0 &&
+    numberValue(triage?.agent_runs_with_explicit_browser_actions) === 0
+  ) {
+    notes.push(
+      `collection Agent reported ${numberValue(triage?.agent_reported_step_count)} step(s), but emitted no explicit browser actions for Playwright replay`
+    );
+  }
   return notes;
 }
 
@@ -608,17 +620,23 @@ function metricsFromReport(report: CollectionPipelineResult["report"]) {
   const agentDispatched =
     numberValue(initialTriage.agent_dispatched) +
       numberValue(repairTriage.agent_dispatched);
+  const reportedAgentSteps =
+    numberValue(initialTriage.agent_reported_step_count) +
+      numberValue(repairTriage.agent_reported_step_count);
+  const fallbackAgentSteps =
+    numberValue(initialTriage.agent_succeeded) +
+      numberValue(initialTriage.agent_failed) +
+      numberValue(repairTriage.agent_succeeded) +
+      numberValue(repairTriage.agent_failed);
 
   return {
     searchCalls: numberValue(stats.search_queries_executed),
     fetchCalls: numberValue(stats.pages_fetched),
     browserCalls: agentDispatched,
     agentRuns: agentDispatched,
-    agentSteps:
-      numberValue(initialTriage.agent_succeeded) +
-      numberValue(initialTriage.agent_failed) +
-      numberValue(repairTriage.agent_succeeded) +
-      numberValue(repairTriage.agent_failed),
+    agentSteps: reportedAgentSteps > 0
+      ? reportedAgentSteps
+      : fallbackAgentSteps,
   };
 }
 

--- a/backend/test/collection-agent-runner.test.ts
+++ b/backend/test/collection-agent-runner.test.ts
@@ -130,6 +130,41 @@ test("collection agent runner maps explicit browser action reports into process 
   }
 });
 
+test("collection agent runner surfaces Agent provenance when actions are missing", async () => {
+  const previousEnv = snapshotEnv([
+    "AGENT_POLL_TIMEOUT_MS",
+    "COLLECTION_AGENT_ENABLE_AGENT",
+    "COLLECTION_AGENT_PIPELINE_MODULE",
+    "COLLECTION_AGENT_POLL_TIMEOUT_MS",
+  ]);
+  delete process.env.AGENT_POLL_TIMEOUT_MS;
+  process.env.COLLECTION_AGENT_ENABLE_AGENT = "true";
+  delete process.env.COLLECTION_AGENT_POLL_TIMEOUT_MS;
+  process.env.COLLECTION_AGENT_PIPELINE_MODULE = fakeCollectionPipelineModuleUrl({
+    expectedCalls: [{ agentEnabled: true, pollTimeoutMs: 480_000 }],
+    agentReportedStepCount: 4,
+    agentRunsWithStreamingUrl: 1,
+    agentRunsWithExplicitBrowserActions: 0,
+  });
+  try {
+    const result = await runCollectionPopulatePipeline(collectionPipelineInput());
+
+    assert.equal(result.metrics.agentSteps, 4);
+    assert.equal(
+      result.debug?.processTrace.notes.some((note) =>
+        /reported 4 step\(s\), but emitted no explicit browser actions/i.test(note)
+      ),
+      true
+    );
+    assert.equal(
+      playwrightCandidateReadinessForRun({ result }).status,
+      "not_ready"
+    );
+  } finally {
+    restoreEnv(previousEnv);
+  }
+});
+
 test("collection agent runner requires explicit Agent opt-in and caps poll timeout per warm process call", async () => {
   const previousEnv = snapshotEnv([
     "AGENT_POLL_TIMEOUT_MS",
@@ -256,6 +291,9 @@ function fakeCollectionPipelineModuleUrl(input: {
   sources?: unknown;
   browserActions?: unknown;
   agentBrowserActions?: unknown;
+  agentReportedStepCount?: number;
+  agentRunsWithStreamingUrl?: number;
+  agentRunsWithExplicitBrowserActions?: number;
 }): string {
   const source = `
     const moduleLoadPollTimeoutMs = process.env.AGENT_POLL_TIMEOUT_MS ?? null;
@@ -311,6 +349,9 @@ function fakeCollectionPipelineModuleUrl(input: {
               agent_dispatched: 1,
               agent_succeeded: 1,
               agent_failed: 0,
+              agent_reported_step_count: ${JSON.stringify(input.agentReportedStepCount)},
+              agent_runs_with_streaming_url: ${JSON.stringify(input.agentRunsWithStreamingUrl)},
+              agent_runs_with_explicit_browser_actions: ${JSON.stringify(input.agentRunsWithExplicitBrowserActions)},
             },
           },
           initial: {
@@ -327,6 +368,9 @@ function fakeCollectionPipelineModuleUrl(input: {
               agent_dispatched: 1,
               agent_succeeded: 1,
               agent_failed: 0,
+              agent_reported_step_count: ${JSON.stringify(input.agentReportedStepCount)},
+              agent_runs_with_streaming_url: ${JSON.stringify(input.agentRunsWithStreamingUrl)},
+              agent_runs_with_explicit_browser_actions: ${JSON.stringify(input.agentRunsWithExplicitBrowserActions)},
             },
           },
           repair: {

--- a/backend/test/collection-browser-actions.test.ts
+++ b/backend/test/collection-browser-actions.test.ts
@@ -71,8 +71,16 @@ test("Agent run records and run reports persist browser action arrays", () => {
     agent_status: "COMPLETED",
     goal: "Submit the form and extract the result.",
     records_extracted: 1,
+    agent_step_count: 3,
+    has_streaming_url: true,
+    result_keys: ["records"],
+    browser_action_diagnostic: "Agent completed and returned rows, but polled run payload exposed no explicit browser actions.",
     browser_actions: browserActions,
   });
+
+  assert.equal(agentRun.agent_step_count, 3);
+  assert.equal(agentRun.has_streaming_url, true);
+  assert.deepEqual(agentRun.result_keys, ["records"]);
 
   assert.deepEqual(
     explicitBrowserActionsFromAgentRuns([agentRun]),
@@ -154,5 +162,23 @@ function phaseStats() {
     pages_fetched: 1,
     pages_failed: 0,
     raw_records_extracted: 1,
+    triage: {
+      pages_triaged: 1,
+      by_status: {
+        requires_form_submission: 1,
+      },
+      extract_now: 0,
+      agent_candidates: 1,
+      agent_dispatched: 1,
+      agent_deferred: 0,
+      agent_succeeded: 1,
+      agent_failed: 0,
+      skipped: 0,
+      records_from_extract: 0,
+      records_from_agent: 1,
+      agent_reported_step_count: 3,
+      agent_runs_with_streaming_url: 1,
+      agent_runs_with_explicit_browser_actions: 1,
+    },
   };
 }

--- a/backend/test/tinyfish-agent-run.test.ts
+++ b/backend/test/tinyfish-agent-run.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { tinyfishAgentRunResultFromRun } from "../BigSet_Data_Collection_Agent/src/integrations/tinyfish-agent.js";
+
+test("TinyFish run normalization keeps safe provenance without streaming URL", () => {
+  const normalized = tinyfishAgentRunResultFromRun({
+    run_id: "run-1",
+    status: "COMPLETED",
+    goal: "Extract rows.",
+    created_at: "2026-05-23T00:00:00Z",
+    started_at: "2026-05-23T00:00:01Z",
+    finished_at: "2026-05-23T00:00:02Z",
+    num_of_steps: 3,
+    result: {
+      records: [],
+    },
+    error: null,
+    streaming_url: "https://agent.tinyfish.ai/private-stream-token",
+    browser_config: {
+      proxy_enabled: true,
+      proxy_country_code: null,
+    },
+  } as never);
+
+  assert.equal(normalized.agent_step_count, 3);
+  assert.equal(normalized.has_streaming_url, true);
+  assert.deepEqual(normalized.result_keys, ["records"]);
+  assert.equal(
+    JSON.stringify(normalized).includes("private-stream-token"),
+    false
+  );
+});

--- a/benchmarks/dataset-agent/README.md
+++ b/benchmarks/dataset-agent/README.md
@@ -146,6 +146,13 @@ without committing raw run folders:
 Agent canary actually emitted browser actions before starting a Playwright
 compiler.
 
+Agent canaries also preserve safe provenance from the TinyFish run payload:
+reported step count, whether a streaming URL existed, and top-level result
+keys. Raw `streaming_url` values are never persisted. If Agent returns rows but
+the polled run payload has no explicit `browser_actions`, diagnostics include
+that distinction so `not_ready` means "no replayable action trace", not "the
+Agent did no browser work."
+
 For browser-action canaries, add `--require-playwright-ready` to make the
 benchmark fail with `failureCategory: "capability_gate"` unless the
 `playwright-candidate-readiness` artifact is `ready`. This gate uses the

--- a/benchmarks/dataset-agent/adapters/self-healing-output.mjs
+++ b/benchmarks/dataset-agent/adapters/self-healing-output.mjs
@@ -27,6 +27,9 @@ function processTraceSummaryFromArtifacts(artifacts) {
   const searchQueries = Array.isArray(trace.searchQueries)
     ? trace.searchQueries
     : [];
+  const notes = Array.isArray(trace.notes)
+    ? trace.notes.filter((note) => typeof note === "string")
+    : [];
 
   return {
     runtime: typeof trace.runtime === "string" ? trace.runtime : "unknown",
@@ -40,6 +43,7 @@ function processTraceSummaryFromArtifacts(artifacts) {
     ].filter((url) => typeof url === "string" && /^https?:\/\//i.test(url))).size,
     searchQueryCount: searchQueries.length,
     fetchedUrlCount: fetchedUrls.length,
+    notes: notes.slice(0, 10),
   };
 }
 

--- a/docs/data-collection-agent-migration-plan.md
+++ b/docs/data-collection-agent-migration-plan.md
@@ -197,6 +197,10 @@ The current layer does not yet:
      provenance, not only row/evidence quality
    - run browser-action canaries with `--require-playwright-ready` so row
      quality cannot hide missing replayable browser-action provenance
+   - inspect Agent run provenance fields (`agent_step_count`,
+     `has_streaming_url`, and `result_keys`) when readiness fails; these fields
+     prove browser work happened without persisting raw streaming URLs or
+     pretending selectors/clicks exist
    - full benchmark only after the 2-prompt run is not obviously broken
    - live `--dataset-id` dry-run only after Convex/env prerequisites are ready
    - `--commit` only on a throwaway dataset first


### PR DESCRIPTION
## Summary

Stacked on #58. Adds safe Agent provenance diagnostics so `not_ready` no longer looks like "Agent did nothing":

- preserves TinyFish run `num_of_steps` as `agent_step_count`
- records whether a streaming URL existed as `has_streaming_url`
- records top-level `result_keys`
- never persists raw `streaming_url`
- adds `browser_action_diagnostic` when Agent returns rows but exposes no explicit browser actions
- propagates aggregate provenance through triage stats and benchmark diagnostics
- uses reported Agent step count for benchmark `agentSteps` when available

This still does not infer selectors/clicks, capture stream logs, or generate Playwright.

## Live Evidence

Agent-enabled `mcp-docs-pages` canary:

- rows: `3`
- normal benchmark status: `ok`
- `agentStepCount`: `20`
- `processTraceBrowserStepCount`: `0`
- `playwrightCandidateStatus`: `not_ready`
- diagnostic note: `collection Agent reported 20 step(s), but emitted no explicit browser actions for Playwright replay`
- raw `agent_runs_initial.json` contains:
  - `agent_step_count: 20`
  - `has_streaming_url: true`
  - `result_keys: ["records"]`
  - `browser_action_diagnostic`
  - no raw `streaming_url`
  - no `browser_actions`

So the current truth is: TinyFish Agent did browser work and returned rows, but the polled run payload still does not expose replayable browser actions.

## Verification

- `node --import ./backend/node_modules/tsx/dist/esm/index.mjs --test backend/test/tinyfish-agent-run.test.ts backend/test/collection-browser-actions.test.ts backend/test/collection-agent-runner.test.ts benchmarks/dataset-agent/run-benchmark.test.mjs`
- `node --check benchmarks/dataset-agent/run-benchmark.mjs`
- `node --check benchmarks/dataset-agent/adapters/self-healing-output.mjs`
- `git diff --check`
- live Agent canary on `mcp-docs-pages`
- `npm --prefix backend test`
- `npm --prefix backend run build`
- `make verify-self-healing`
