### PR TITLE
Cap self-healing row commits

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -28,3 +28,12 @@ Starts on [localhost:3501](http://localhost:3501).
 | `npm run dev` | Start with hot reload |
 | `npm run build` | Compile TypeScript |
 | `npm run db:push` | Push schema changes to Postgres |
+
+## Self-Healing Commit Cap
+
+`populate:self-heal --commit` and `POST /populate` cap committed rows per
+dataset at 100 rows/hour by default. Override with
+`POPULATE_COMMIT_ROW_LIMIT_PER_HOUR` or CLI
+`--commit-row-limit-per-hour`.
+
+Dry runs and benchmarks do not commit rows, so they do not consume this cap.

--- a/backend/src/pipeline/populate-self-healing-command.ts
+++ b/backend/src/pipeline/populate-self-healing-command.ts
@@ -23,6 +23,7 @@ export interface PopulateSelfHealingCliOptions {
   shouldCommitRows: boolean;
   recipeStoreDirectory?: string;
   maxRows?: number;
+  commitRowLimitPerHour?: number;
 }
 
 export interface PopulateSelfHealingCliDependencies {
@@ -90,6 +91,15 @@ export async function runPopulateSelfHealingCli(
       rowWriter,
       shouldCommitRows: options.shouldCommitRows,
       runtime,
+      commitRowLimit: options.shouldCommitRows
+        ? {
+          maxRowsPerWindow: commitRowLimitPerHour({
+            optionValue: options.commitRowLimitPerHour,
+            envValue: input.env.POPULATE_COMMIT_ROW_LIMIT_PER_HOUR,
+          }),
+          windowMs: 60 * 60 * 1_000,
+        }
+        : undefined,
     });
 
     writeStdout(JSON.stringify(summaryForResult(result, !options.shouldCommitRows)));
@@ -150,6 +160,14 @@ export function parsePopulateSelfHealingCliArgs(
         throw new Error("--max-rows requires a positive integer.");
       }
       options.maxRows = parsed;
+      index += 1;
+    } else if (arg === "--commit-row-limit-per-hour") {
+      const value = argv[index + 1];
+      const parsed = Number(value);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new Error("--commit-row-limit-per-hour requires a positive integer.");
+      }
+      options.commitRowLimitPerHour = parsed;
       index += 1;
     } else {
       throw new Error(`Unknown argument: ${arg}`);
@@ -232,12 +250,32 @@ function summaryForResult(
     action: result.action,
     datasetId: result.datasetId,
     committedRows: result.committedRows,
+    commitLimit: result.commitLimit,
     rowCount: diagnosticRun?.rows.length ?? 0,
     validationIssues: result.validationIssues,
     rejectionReasons: result.rejectionReasons,
     productionValidation: diagnosticRun?.productionValidation,
     metrics: diagnosticRun?.metrics,
   };
+}
+
+function commitRowLimitPerHour(input: {
+  optionValue?: number;
+  envValue?: string;
+}): number {
+  if (input.optionValue !== undefined) {
+    return input.optionValue;
+  }
+  if (input.envValue === undefined || input.envValue === "") {
+    return 100;
+  }
+  const parsed = Number(input.envValue);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(
+      "POPULATE_COMMIT_ROW_LIMIT_PER_HOUR must be a positive integer."
+    );
+  }
+  return parsed;
 }
 
 async function readProcessStdin(): Promise<string> {

--- a/backend/src/pipeline/populate-self-healing-runner.ts
+++ b/backend/src/pipeline/populate-self-healing-runner.ts
@@ -1,4 +1,6 @@
-import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 
 import type { DatasetContext } from "./populate.js";
 import {
@@ -25,6 +27,244 @@ export interface PopulateDatasetWriteResult {
   insertedRowCount: number;
 }
 
+export interface PopulateDatasetRowCommitLimit {
+  maxRowsPerWindow: number;
+  windowMs: number;
+  now?: () => Date;
+  limiter?: PopulateDatasetRowCommitLimiter;
+}
+
+export interface PopulateDatasetRowCommitLimiter {
+  committedRowCount(input: {
+    datasetId: string;
+    since: Date;
+    now: Date;
+  }): Promise<number>;
+  reserveCommit(input: {
+    datasetId: string;
+    rowCount: number;
+    since: Date;
+    now: Date;
+    maxRowsPerWindow: number;
+  }): Promise<PopulateDatasetRowCommitReservation>;
+}
+
+export interface PopulateDatasetRowCommitReservation {
+  decision: PopulateDatasetRowCommitLimitDecision;
+  confirm(input: { rowCount: number }): Promise<void>;
+  release(): Promise<void>;
+}
+
+interface PopulateDatasetRowCommitLimitCheck {
+  datasetId: string;
+  rowCount: number;
+  now: Date;
+  windowStartedAt: Date;
+  maxRowsPerWindow: number;
+  committedRowsInWindow: number;
+}
+
+interface FileSystemCommitLedgerEntry {
+  datasetId: string;
+  committedAt: string;
+  rowCount: number;
+  reservationId?: string;
+  status?: "reserved" | "committed";
+}
+
+interface CommitLedgerReservationInput {
+  entries: FileSystemCommitLedgerEntry[];
+  reservationId: string;
+  datasetId: string;
+  rowCount: number;
+  now: Date;
+  since: Date;
+  maxRowsPerWindow: number;
+}
+
+interface CommitLedgerReservationState {
+  entries: FileSystemCommitLedgerEntry[];
+  decision: PopulateDatasetRowCommitLimitDecision;
+  reservation?: FileSystemCommitLedgerEntry;
+}
+
+interface CommitLedgerMutationInput {
+  reservationId: string;
+  datasetId: string;
+  rowCount?: number;
+}
+
+interface CommitLedgerState {
+  entries: FileSystemCommitLedgerEntry[];
+}
+
+interface CommitLedgerStore {
+  mutateDatasetLedger<T>(
+    datasetId: string,
+    mutate: (state: CommitLedgerState) => Promise<T> | T
+  ): Promise<T>;
+}
+
+interface CommitLedgerReservation {
+  store: CommitLedgerStore;
+  reservationId: string;
+  datasetId: string;
+  decision: PopulateDatasetRowCommitLimitDecision;
+}
+
+function commitLedgerReservation(
+  input: CommitLedgerReservation
+): PopulateDatasetRowCommitReservation {
+  return {
+    decision: input.decision,
+    async confirm(confirmInput) {
+      await input.store.mutateDatasetLedger(input.datasetId, (state) => {
+        confirmReservation({
+          entries: state.entries,
+          reservationId: input.reservationId,
+          datasetId: input.datasetId,
+          rowCount: confirmInput.rowCount,
+        });
+      });
+    },
+    async release() {
+      await input.store.mutateDatasetLedger(input.datasetId, (state) => {
+        releaseReservation({
+          entries: state.entries,
+          reservationId: input.reservationId,
+          datasetId: input.datasetId,
+        });
+      });
+    },
+  };
+}
+
+function deniedCommitReservation(
+  decision: PopulateDatasetRowCommitLimitDecision
+): PopulateDatasetRowCommitReservation {
+  return {
+    decision,
+    async confirm() {
+      return undefined;
+    },
+    async release() {
+      return undefined;
+    },
+  };
+}
+
+function reserveInLedger(input: CommitLedgerReservationInput): CommitLedgerReservationState {
+  const committedRowsInWindow = entriesInWindow(input.entries, {
+    datasetId: input.datasetId,
+    since: input.since,
+    now: input.now,
+  }).reduce((total, entry) => total + entry.rowCount, 0);
+  const decision = commitLimitDecisionFromCheck({
+    datasetId: input.datasetId,
+    rowCount: input.rowCount,
+    now: input.now,
+    windowStartedAt: input.since,
+    maxRowsPerWindow: input.maxRowsPerWindow,
+    committedRowsInWindow,
+  });
+
+  if (!decision.isAllowed) {
+    return { entries: input.entries, decision };
+  }
+
+  const reservation = {
+    datasetId: input.datasetId,
+    committedAt: input.now.toISOString(),
+    rowCount: input.rowCount,
+    reservationId: input.reservationId,
+    status: "reserved" as const,
+  };
+  return {
+    entries: [...input.entries, reservation],
+    decision,
+    reservation,
+  };
+}
+
+function confirmReservation(input: CommitLedgerMutationInput & {
+  entries: FileSystemCommitLedgerEntry[];
+}): void {
+  const entry = matchingReservation(input.entries, input);
+  if (!entry) {
+    return;
+  }
+  entry.status = "committed";
+  if (input.rowCount !== undefined) {
+    entry.rowCount = input.rowCount;
+  }
+}
+
+function releaseReservation(input: CommitLedgerMutationInput & {
+  entries: FileSystemCommitLedgerEntry[];
+}): void {
+  const index = input.entries.findIndex((entry) =>
+    entry.datasetId === input.datasetId &&
+    entry.reservationId === input.reservationId
+  );
+  if (index >= 0) {
+    input.entries.splice(index, 1);
+  }
+}
+
+function matchingReservation(
+  entries: FileSystemCommitLedgerEntry[],
+  input: CommitLedgerMutationInput
+): FileSystemCommitLedgerEntry | undefined {
+  return entries.find((entry) =>
+    entry.datasetId === input.datasetId &&
+    entry.reservationId === input.reservationId
+  );
+}
+
+function commitLimitDecisionFromCheck(
+  input: PopulateDatasetRowCommitLimitCheck
+): PopulateDatasetRowCommitLimitDecision {
+  const remainingRowsInWindow = Math.max(
+    0,
+    input.maxRowsPerWindow - input.committedRowsInWindow
+  );
+  const isAllowed = input.rowCount <= remainingRowsInWindow;
+
+  return {
+    isAllowed,
+    datasetId: input.datasetId,
+    requestedRowCount: input.rowCount,
+    maxRowsPerWindow: input.maxRowsPerWindow,
+    committedRowsInWindow: input.committedRowsInWindow,
+    remainingRowsInWindow,
+    windowStartedAt: input.windowStartedAt.toISOString(),
+    windowEndsAt: input.now.toISOString(),
+    reason: isAllowed
+      ? undefined
+      : `Commit row cap exceeded for ${input.datasetId}: requested ${input.rowCount}, remaining ${remainingRowsInWindow} of ${input.maxRowsPerWindow} rows in the current window.`,
+  };
+}
+
+function reservationId(): string {
+  return randomUUID();
+}
+
+export interface PopulateDatasetRowCommitLimitDecision {
+  isAllowed: boolean;
+  datasetId: string;
+  requestedRowCount: number;
+  maxRowsPerWindow: number;
+  committedRowsInWindow: number;
+  remainingRowsInWindow: number;
+  windowStartedAt: string;
+  windowEndsAt: string;
+  reason?: string;
+}
+
+export type RunSelfHealingPopulateAction =
+  | SelfHealingPopulateTickResult["action"]
+  | "commit_rate_limited";
+
 export interface RunSelfHealingPopulateInput {
   context: DatasetContext;
   store?: PopulateRecipeStore;
@@ -33,18 +273,20 @@ export interface RunSelfHealingPopulateInput {
   rowWriter?: PopulateDatasetRowWriter;
   shouldCommitRows?: boolean;
   recipeStoreDirectory?: string;
+  commitRowLimit?: PopulateDatasetRowCommitLimit;
 }
 
 export interface RunSelfHealingPopulateResult {
   success: boolean;
-  action: SelfHealingPopulateTickResult["action"];
+  action: RunSelfHealingPopulateAction;
   datasetId: string;
   selectedRun?: PopulateRecipeRunResult;
   diagnosticRun?: PopulateRecipeRunResult;
   committedRows?: PopulateDatasetWriteResult;
+  commitLimit?: PopulateDatasetRowCommitLimitDecision;
   rejectionReasons: string[];
   validationIssues: string[];
-  tick: SelfHealingPopulateTickResult;
+  tick?: SelfHealingPopulateTickResult;
 }
 
 export async function runSelfHealingPopulate(
@@ -54,6 +296,22 @@ export async function runSelfHealingPopulate(
     throw new Error("rowWriter is required when shouldCommitRows is true.");
   }
   const rowWriter = input.rowWriter;
+  const commitLimiter = commitLimiterForInput(input);
+
+  if (input.shouldCommitRows && commitLimiter) {
+    const preflightDecision = await commitLimitDecision({
+      context: input.context,
+      rowCount: 1,
+      commitRowLimit: input.commitRowLimit!,
+      limiter: commitLimiter,
+    });
+    if (!preflightDecision.isAllowed && preflightDecision.remainingRowsInWindow <= 0) {
+      return commitRateLimitedResult({
+        datasetId: input.context.datasetId,
+        decision: preflightDecision,
+      });
+    }
+  }
 
   const store = input.store ?? new FileSystemPopulateRecipeStore(
     input.recipeStoreDirectory ?? defaultPopulateRecipeStoreDirectory()
@@ -70,12 +328,38 @@ export async function runSelfHealingPopulate(
   const selectedRun = successfulRunForTick(tick);
   const diagnosticRun = diagnosticRunForTick(tick);
   let committedRows: PopulateDatasetWriteResult | undefined;
+  let commitLimit: PopulateDatasetRowCommitLimitDecision | undefined;
 
   if (input.shouldCommitRows && selectedRun && rowWriter) {
-    committedRows = await rowWriter.replaceRows({
-      datasetId: input.context.datasetId,
-      rows: selectedRun.rows,
-    });
+    let reservation: PopulateDatasetRowCommitReservation | undefined;
+    if (commitLimiter) {
+      reservation = await reserveCommitRows({
+        context: input.context,
+        rowCount: selectedRun.rows.length,
+        commitRowLimit: input.commitRowLimit!,
+        limiter: commitLimiter,
+      });
+      commitLimit = reservation.decision;
+      if (!commitLimit.isAllowed) {
+        return commitRateLimitedResult({
+          datasetId: input.context.datasetId,
+          decision: commitLimit,
+          selectedRun,
+          diagnosticRun,
+          tick,
+        });
+      }
+    }
+    try {
+      committedRows = await rowWriter.replaceRows({
+        datasetId: input.context.datasetId,
+        rows: selectedRun.rows,
+      });
+    } catch (error) {
+      await reservation?.release();
+      throw error;
+    }
+    await reservation?.confirm({ rowCount: committedRows.insertedRowCount });
   }
 
   return {
@@ -85,6 +369,7 @@ export async function runSelfHealingPopulate(
     selectedRun,
     diagnosticRun,
     committedRows,
+    commitLimit,
     rejectionReasons: tick.rejectionReasons,
     validationIssues: validationIssuesForSelfHealingTick(tick),
     tick,
@@ -125,4 +410,271 @@ export function validationIssuesForSelfHealingTick(
 
 function defaultPopulateRecipeStoreDirectory(): string {
   return join(process.cwd(), ".bigset", "populate-recipes");
+}
+
+function commitLimiterForInput(
+  input: RunSelfHealingPopulateInput
+): PopulateDatasetRowCommitLimiter | undefined {
+  if (!input.shouldCommitRows || !input.commitRowLimit) {
+    return undefined;
+  }
+  return input.commitRowLimit.limiter ?? new FileSystemPopulateDatasetRowCommitLimiter(
+    join(
+      input.recipeStoreDirectory ?? defaultPopulateRecipeStoreDirectory(),
+      "commit-ledger"
+    )
+  );
+}
+
+async function commitLimitDecision(input: {
+  context: DatasetContext;
+  rowCount: number;
+  commitRowLimit: PopulateDatasetRowCommitLimit;
+  limiter: PopulateDatasetRowCommitLimiter;
+}): Promise<PopulateDatasetRowCommitLimitDecision> {
+  const now = input.commitRowLimit.now?.() ?? new Date();
+  const windowStartedAt = new Date(now.getTime() - input.commitRowLimit.windowMs);
+  const committedRowsInWindow = await input.limiter.committedRowCount({
+    datasetId: input.context.datasetId,
+    since: windowStartedAt,
+    now,
+  });
+  return commitLimitDecisionFromCheck({
+    datasetId: input.context.datasetId,
+    rowCount: input.rowCount,
+    now,
+    windowStartedAt,
+    maxRowsPerWindow: input.commitRowLimit.maxRowsPerWindow,
+    committedRowsInWindow,
+  });
+}
+
+async function reserveCommitRows(input: {
+  context: DatasetContext;
+  rowCount: number;
+  commitRowLimit: PopulateDatasetRowCommitLimit;
+  limiter: PopulateDatasetRowCommitLimiter;
+}): Promise<PopulateDatasetRowCommitReservation> {
+  const now = input.commitRowLimit.now?.() ?? new Date();
+  const windowStartedAt = new Date(now.getTime() - input.commitRowLimit.windowMs);
+  return input.limiter.reserveCommit({
+    datasetId: input.context.datasetId,
+    rowCount: input.rowCount,
+    since: windowStartedAt,
+    now,
+    maxRowsPerWindow: input.commitRowLimit.maxRowsPerWindow,
+  });
+}
+
+function commitRateLimitedResult(input: {
+  datasetId: string;
+  decision: PopulateDatasetRowCommitLimitDecision;
+  selectedRun?: PopulateRecipeRunResult;
+  diagnosticRun?: PopulateRecipeRunResult;
+  tick?: SelfHealingPopulateTickResult;
+}): RunSelfHealingPopulateResult {
+  const reason = input.decision.reason ??
+    `Commit row cap exceeded for ${input.datasetId}.`;
+  return {
+    success: false,
+    action: "commit_rate_limited",
+    datasetId: input.datasetId,
+    selectedRun: input.selectedRun,
+    diagnosticRun: input.diagnosticRun ?? input.selectedRun,
+    commitLimit: input.decision,
+    rejectionReasons: [reason],
+    validationIssues: [reason],
+    tick: input.tick,
+  };
+}
+
+export class InMemoryPopulateDatasetRowCommitLimiter
+implements PopulateDatasetRowCommitLimiter, CommitLedgerStore {
+  private readonly entries: FileSystemCommitLedgerEntry[] = [];
+
+  async committedRowCount(input: {
+    datasetId: string;
+    since: Date;
+    now: Date;
+  }): Promise<number> {
+    return entriesInWindow(this.entries, input)
+      .reduce((total, entry) => total + entry.rowCount, 0);
+  }
+
+  async reserveCommit(input: {
+    datasetId: string;
+    rowCount: number;
+    since: Date;
+    now: Date;
+    maxRowsPerWindow: number;
+  }): Promise<PopulateDatasetRowCommitReservation> {
+    const id = reservationId();
+    const state = reserveInLedger({
+      entries: this.entries,
+      reservationId: id,
+      datasetId: input.datasetId,
+      rowCount: input.rowCount,
+      since: input.since,
+      now: input.now,
+      maxRowsPerWindow: input.maxRowsPerWindow,
+    });
+    this.entries.splice(0, this.entries.length, ...state.entries);
+    return state.reservation
+      ? commitLedgerReservation({
+        store: this,
+        reservationId: id,
+        datasetId: input.datasetId,
+        decision: state.decision,
+      })
+      : deniedCommitReservation(state.decision);
+  }
+
+  async mutateDatasetLedger<T>(
+    _datasetId: string,
+    mutate: (state: CommitLedgerState) => Promise<T> | T
+  ): Promise<T> {
+    return mutate({ entries: this.entries });
+  }
+}
+
+export class FileSystemPopulateDatasetRowCommitLimiter
+implements PopulateDatasetRowCommitLimiter, CommitLedgerStore {
+  constructor(private readonly rootDirectory: string) {}
+
+  async committedRowCount(input: {
+    datasetId: string;
+    since: Date;
+    now: Date;
+  }): Promise<number> {
+    return entriesInWindow(await this.readEntries(input.datasetId), input)
+      .reduce((total, entry) => total + entry.rowCount, 0);
+  }
+
+  async reserveCommit(input: {
+    datasetId: string;
+    rowCount: number;
+    since: Date;
+    now: Date;
+    maxRowsPerWindow: number;
+  }): Promise<PopulateDatasetRowCommitReservation> {
+    const id = reservationId();
+    const state = await this.mutateDatasetLedger(input.datasetId, (ledger) => {
+      const reservationState = reserveInLedger({
+        entries: ledger.entries,
+        reservationId: id,
+        datasetId: input.datasetId,
+        rowCount: input.rowCount,
+        since: input.since,
+        now: input.now,
+        maxRowsPerWindow: input.maxRowsPerWindow,
+      });
+      ledger.entries.splice(0, ledger.entries.length, ...reservationState.entries);
+      return reservationState;
+    });
+    return state.reservation
+      ? commitLedgerReservation({
+        store: this,
+        reservationId: id,
+        datasetId: input.datasetId,
+        decision: state.decision,
+      })
+      : deniedCommitReservation(state.decision);
+  }
+
+  async mutateDatasetLedger<T>(
+    datasetId: string,
+    mutate: (state: CommitLedgerState) => Promise<T> | T
+  ): Promise<T> {
+    const lockPath = await this.acquireLock(datasetId);
+    try {
+      const entries = await this.readEntries(datasetId);
+      const state = { entries };
+      const result = await mutate(state);
+      await this.writeEntries(datasetId, state.entries);
+      return result;
+    } finally {
+      await rm(lockPath, { recursive: true, force: true });
+    }
+  }
+
+  private async acquireLock(datasetId: string): Promise<string> {
+    await mkdir(this.rootDirectory, { recursive: true });
+    const lockPath = this.lockPath(datasetId);
+    const startedAt = Date.now();
+    while (true) {
+      try {
+        await mkdir(lockPath);
+        return lockPath;
+      } catch (error) {
+        if (!isNodeError(error) || error.code !== "EEXIST") {
+          throw error;
+        }
+        if (Date.now() - startedAt > 5_000) {
+          throw new Error(`Timed out waiting for commit ledger lock for ${datasetId}.`);
+        }
+        await sleep(25);
+      }
+    }
+  }
+
+  private lockPath(datasetId: string): string {
+    return join(this.rootDirectory, `${safePathSegment(datasetId)}.lock`);
+  }
+
+  private async readEntries(datasetId: string): Promise<FileSystemCommitLedgerEntry[]> {
+    try {
+      const text = await readFile(this.ledgerPath(datasetId), "utf8");
+      const parsed = JSON.parse(text) as { entries?: FileSystemCommitLedgerEntry[] };
+      return Array.isArray(parsed.entries) ? parsed.entries : [];
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return [];
+      }
+      throw error;
+    }
+  }
+
+  private async writeEntries(
+    datasetId: string,
+    entries: FileSystemCommitLedgerEntry[]
+  ): Promise<void> {
+    const path = this.ledgerPath(datasetId);
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, `${JSON.stringify({ entries }, null, 2)}\n`, "utf8");
+  }
+
+  private ledgerPath(datasetId: string): string {
+    return join(this.rootDirectory, `${safePathSegment(datasetId)}.json`);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function entriesInWindow(
+  entries: FileSystemCommitLedgerEntry[],
+  input: {
+    datasetId: string;
+    since: Date;
+    now: Date;
+  }
+): FileSystemCommitLedgerEntry[] {
+  return entries.filter((entry) => {
+    if (entry.datasetId !== input.datasetId) {
+      return false;
+    }
+    const committedAtMs = Date.parse(entry.committedAt);
+    return Number.isFinite(committedAtMs) &&
+      committedAtMs >= input.since.getTime() &&
+      committedAtMs <= input.now.getTime();
+  });
+}
+
+function safePathSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -25,6 +25,7 @@ export interface BigSetServerEnv {
   OPENROUTER_API_KEY?: string;
   TINYFISH_API_KEY?: string;
   POPULATE_RECIPE_STORE_DIR: string;
+  POPULATE_COMMIT_ROW_LIMIT_PER_HOUR?: string;
 }
 
 export interface BigSetPopulateDataset {
@@ -134,6 +135,10 @@ export async function createBigSetServer(
           rowWriter: input.populateRowWriter,
           shouldCommitRows: true,
           runtime,
+          commitRowLimit: {
+            maxRowsPerWindow: commitRowLimitPerHour(input.env),
+            windowMs: 60 * 60 * 1_000,
+          },
         });
 
         req.log.info({
@@ -177,10 +182,24 @@ function responseSafePopulateResult(
     datasetId: result.datasetId,
     success: result.success,
     committedRows: result.committedRows,
+    commitLimit: result.commitLimit,
     rejectionReasons: result.rejectionReasons,
     validationIssues: result.validationIssues,
     productionValidation: diagnosticRun?.productionValidation,
     metrics: diagnosticRun?.metrics,
     rowCount: diagnosticRun?.rows.length ?? 0,
   };
+}
+
+function commitRowLimitPerHour(env: BigSetServerEnv): number {
+  if (!env.POPULATE_COMMIT_ROW_LIMIT_PER_HOUR) {
+    return 100;
+  }
+  const parsed = Number(env.POPULATE_COMMIT_ROW_LIMIT_PER_HOUR);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(
+      "POPULATE_COMMIT_ROW_LIMIT_PER_HOUR must be a positive integer."
+    );
+  }
+  return parsed;
 }

--- a/backend/test/populate-self-healing-command.test.ts
+++ b/backend/test/populate-self-healing-command.test.ts
@@ -46,6 +46,21 @@ test("self-healing CLI parses dataset-id mode", () => {
   });
 });
 
+test("self-healing CLI parses commit row limit override", () => {
+  assert.deepEqual(parsePopulateSelfHealingCliArgs([
+    "--dataset-id",
+    "dataset-ai-posts",
+    "--commit",
+    "--commit-row-limit-per-hour",
+    "250",
+  ]), {
+    datasetId: "dataset-ai-posts",
+    shouldReadStdin: false,
+    shouldCommitRows: true,
+    commitRowLimitPerHour: 250,
+  });
+});
+
 test("self-healing CLI rejects dataset-id mixed with context input", () => {
   assert.throws(
     () => parsePopulateSelfHealingCliArgs([
@@ -240,6 +255,8 @@ test("self-healing CLI dataset-id commit loads context and creates writer", asyn
       assert.equal(input.store, undefined);
       assert.equal(input.recipeStoreDirectory, ".bigset/populate-recipes");
       assert.ok(input.rowWriter);
+      assert.equal(input.commitRowLimit?.maxRowsPerWindow, 100);
+      assert.equal(input.commitRowLimit?.windowMs, 60 * 60 * 1_000);
       return successfulResult(input.context.datasetId);
     },
   });

--- a/backend/test/populate-self-healing-runner.test.ts
+++ b/backend/test/populate-self-healing-runner.test.ts
@@ -17,6 +17,8 @@ import {
 } from "../src/pipeline/populate-self-healing.js";
 import {
   diagnosticRunForTick,
+  FileSystemPopulateDatasetRowCommitLimiter,
+  InMemoryPopulateDatasetRowCommitLimiter,
   runSelfHealingPopulate,
   validationIssuesForSelfHealingTick,
   type PopulateDatasetRowWriter,
@@ -71,7 +73,7 @@ test("self-healing runner commits rows only after a successful tick", async () =
   assert.equal(result.committedRows?.insertedRowCount, 1);
   assert.equal(writer.replaceCalls.length, 1);
   assert.equal(writer.replaceCalls[0]?.datasetId, context.datasetId);
-  assert.equal(writer.replaceCalls[0]?.rows[0]?.cells.entity_name, "OpenAI");
+  assert.equal(writer.replaceCalls[0]?.rows[0]?.cells.entity_name, "OpenAI 1");
 });
 
 test("self-healing runner requires a row writer before runtime work when committing", async () => {
@@ -95,6 +97,142 @@ test("self-healing runner requires a row writer before runtime work when committ
   );
 
   assert.equal(runtimeCalls, 0);
+});
+
+test("self-healing runner records committed rows against the hourly cap", async () => {
+  const store = new InMemoryPopulateRecipeStore();
+  const generatedRecipe = recipe({ recipeId: "generated-v1" });
+  const writer = new FakePopulateDatasetRowWriter();
+  const limiter = new InMemoryPopulateDatasetRowCommitLimiter();
+  const now = new Date("2026-05-22T00:30:00.000Z");
+
+  const result = await runSelfHealingPopulate({
+    context,
+    store,
+    runtime: new FakePopulateRecipeRuntime({
+      "generated-v1": validRunWithRows(generatedRecipe, 2),
+    }),
+    author: new FakeRecipeAuthor({ generatedRecipe }),
+    rowWriter: writer,
+    shouldCommitRows: true,
+    commitRowLimit: {
+      maxRowsPerWindow: 100,
+      windowMs: 60 * 60 * 1_000,
+      now: () => now,
+      limiter,
+    },
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.committedRows?.insertedRowCount, 2);
+  assert.equal(result.commitLimit?.remainingRowsInWindow, 100);
+  assert.equal(await limiter.committedRowCount({
+    datasetId: context.datasetId,
+    since: new Date("2026-05-21T23:30:00.000Z"),
+    now,
+  }), 2);
+});
+
+test("self-healing runner skips runtime when commit cap is exhausted", async () => {
+  const limiter = new InMemoryPopulateDatasetRowCommitLimiter();
+  const now = new Date("2026-05-22T00:30:00.000Z");
+  let runtimeCalls = 0;
+  const writer = new FakePopulateDatasetRowWriter();
+  await reserveExistingRows({ limiter, now, rowCount: 100 });
+
+  const result = await runSelfHealingPopulate({
+    context,
+    store: new InMemoryPopulateRecipeStore(),
+    runtime: {
+      async runRecipe(input) {
+        runtimeCalls += 1;
+        return validRun(input.recipe);
+      },
+    },
+    author: new FakeRecipeAuthor({
+      generatedRecipe: recipe({ recipeId: "generated-v1" }),
+    }),
+    rowWriter: writer,
+    shouldCommitRows: true,
+    commitRowLimit: {
+      maxRowsPerWindow: 100,
+      windowMs: 60 * 60 * 1_000,
+      now: () => now,
+      limiter,
+    },
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.action, "commit_rate_limited");
+  assert.equal(result.tick, undefined);
+  assert.equal(result.commitLimit?.remainingRowsInWindow, 0);
+  assert.match(result.validationIssues.join("\n"), /Commit row cap exceeded/);
+  assert.equal(runtimeCalls, 0);
+  assert.equal(writer.replaceCalls.length, 0);
+});
+
+test("self-healing runner blocks commit when selected rows exceed remaining cap", async () => {
+  const store = new InMemoryPopulateRecipeStore();
+  const limiter = new InMemoryPopulateDatasetRowCommitLimiter();
+  const generatedRecipe = recipe({ recipeId: "generated-v1" });
+  const writer = new FakePopulateDatasetRowWriter();
+  const now = new Date("2026-05-22T00:30:00.000Z");
+  await reserveExistingRows({ limiter, now, rowCount: 99 });
+
+  const result = await runSelfHealingPopulate({
+    context,
+    store,
+    runtime: new FakePopulateRecipeRuntime({
+      "generated-v1": validRunWithRows(generatedRecipe, 2),
+    }),
+    author: new FakeRecipeAuthor({ generatedRecipe }),
+    rowWriter: writer,
+    shouldCommitRows: true,
+    commitRowLimit: {
+      maxRowsPerWindow: 100,
+      windowMs: 60 * 60 * 1_000,
+      now: () => now,
+      limiter,
+    },
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.action, "commit_rate_limited");
+  assert.equal(result.selectedRun?.rows.length, 2);
+  assert.equal(result.commitLimit?.requestedRowCount, 2);
+  assert.equal(result.commitLimit?.remainingRowsInWindow, 1);
+  assert.equal(writer.replaceCalls.length, 0);
+});
+
+test("filesystem row commit limiter reserves atomically for concurrent calls", async () => {
+  const rootDirectory = await mkdtemp(join(tmpdir(), "bigset-row-cap-"));
+  const limiter = new FileSystemPopulateDatasetRowCommitLimiter(rootDirectory);
+  const now = new Date("2026-05-22T00:30:00.000Z");
+  const reserve = () => limiter.reserveCommit({
+    datasetId: context.datasetId,
+    rowCount: 60,
+    since: new Date(now.getTime() - 60 * 60 * 1_000),
+    now,
+    maxRowsPerWindow: 100,
+  });
+
+  const reservations = await Promise.all([reserve(), reserve()]);
+  const allowed = reservations.filter((reservation) =>
+    reservation.decision.isAllowed
+  );
+  const denied = reservations.filter((reservation) =>
+    !reservation.decision.isAllowed
+  );
+
+  assert.equal(allowed.length, 1);
+  assert.equal(denied.length, 1);
+  assert.equal(denied[0]?.decision.remainingRowsInWindow, 40);
+  await allowed[0]?.confirm({ rowCount: 60 });
+  assert.equal(await limiter.committedRowCount({
+    datasetId: context.datasetId,
+    since: new Date(now.getTime() - 60 * 60 * 1_000),
+    now,
+  }), 60);
 });
 
 test("self-healing runner commits healthy active reruns", async () => {
@@ -241,23 +379,30 @@ function recipe(input: {
 }
 
 function validRun(recipe: PopulateRecipe): PopulateRecipeRunResult {
+  return validRunWithRows(recipe, 1);
+}
+
+function validRunWithRows(
+  recipe: PopulateRecipe,
+  rowCount: number
+): PopulateRecipeRunResult {
   return runResult({
     recipe,
-    rows: [{
+    rows: Array.from({ length: rowCount }, (_, index) => ({
       cells: {
-        entity_name: "OpenAI",
-        latest_post_title: "Release notes from OpenAI",
+        entity_name: `OpenAI ${index + 1}`,
+        latest_post_title: `Release notes from OpenAI ${index + 1}`,
         source_url: "https://openai.com/news",
-        evidence_quote: "Release notes from OpenAI",
+        evidence_quote: `Release notes from OpenAI ${index + 1}`,
       },
       sourceUrls: ["https://openai.com/news"],
       evidence: [{
         columnName: "latest_post_title",
         sourceUrl: "https://openai.com/news",
-        quote: "Release notes from OpenAI",
+        quote: `Release notes from OpenAI ${index + 1}`,
       }],
       needsReview: true,
-    }],
+    })),
     isValid: true,
     score: 1,
   });
@@ -362,4 +507,20 @@ class FakePopulateDatasetRowWriter implements PopulateDatasetRowWriter {
       insertedRowCount: input.rows.length,
     };
   }
+}
+
+async function reserveExistingRows(input: {
+  limiter: InMemoryPopulateDatasetRowCommitLimiter;
+  now: Date;
+  rowCount: number;
+}): Promise<void> {
+  const reservation = await input.limiter.reserveCommit({
+    datasetId: context.datasetId,
+    rowCount: input.rowCount,
+    since: new Date(input.now.getTime() - 60 * 60 * 1_000),
+    now: input.now,
+    maxRowsPerWindow: 100,
+  });
+  assert.equal(reservation.decision.isAllowed, true);
+  await reservation.confirm({ rowCount: input.rowCount });
 }

--- a/backend/test/populate-server.test.ts
+++ b/backend/test/populate-server.test.ts
@@ -55,6 +55,8 @@ test("POST /populate passes selected runtime into self-healing runner", async ()
       assert.equal(input.shouldCommitRows, true);
       assert.equal(input.recipeStoreDirectory, ".bigset/populate-recipes");
       assert.ok(input.rowWriter);
+      assert.equal(input.commitRowLimit?.maxRowsPerWindow, 100);
+      assert.equal(input.commitRowLimit?.windowMs, 60 * 60 * 1_000);
       return successfulResult(input.context.datasetId);
     },
   });

--- a/docs/data-collection-agent-migration-plan.md
+++ b/docs/data-collection-agent-migration-plan.md
@@ -38,6 +38,10 @@ the collection pipeline is migrated into BigSet.
   `selfHealingAction: "candidate_rejected"` fail benchmark scoring with
   `failureCategory: "capability_gate"`, even when diagnostic rows match answer
   keys.
+- This branch adds a commit-path row cap for self-healing writes. Commit mode
+  defaults to 100 committed rows/hour per dataset and can be overridden with
+  `POPULATE_COMMIT_ROW_LIMIT_PER_HOUR` or
+  `--commit-row-limit-per-hour`.
 - `feat/data-collection-agent-v14` is no longer the branch to build on directly.
   It was the source of the collection pipeline port. New work should branch on
   top of the current draft stack, not edit Meteor's branch or the dirty main
@@ -84,6 +88,7 @@ The current layer:
 - promotes a repaired recipe only if it is valid and does not score below the
   active recipe baseline
 - commits rows only after a successful tick, using one Convex atomic replace
+- enforces a configurable per-dataset hourly row cap before committing rows
 - supports a CLI path for cron/live smoke via `populate:self-heal --dataset-id`
 
 Dry-run and benchmark paths intentionally use in-memory stores so they do not
@@ -133,8 +138,6 @@ The current layer does not yet:
 - run a green live Convex canary in this local environment
 - prove Agent-enabled collection quality on a full real benchmark
 - prove the collection runtime should replace Mastra as the default app runtime
-- enforce the planned per-dataset row commit cap, such as 100 rows/hour, on the
-  self-healing commit path
 
 ## Migration Sequence
 
@@ -253,6 +256,8 @@ Before any merge:
   follow-up
 - live dataset commit is tested only on a throwaway dataset
 - backend build does not depend on `frontend/convex/_generated`
+- commit-mode row caps block Convex writes before the cap is exceeded and skip
+  runtime work when the cap is already exhausted
 
 ## Meteor Handoff Shape
 
@@ -343,21 +348,14 @@ edit `main`, Meteor's branch, or the dirty local checkout.
    - Each action should include at least URL or selector/target text plus safe,
      redacted value descriptions for form inputs.
    - Do not build a Playwright compiler against search/fetch-only traces.
-2. Add a small self-healing commit-path row cap when commit safety becomes the
-   immediate risk.
-   - Start with a configurable per-dataset cap such as 100 committed rows/hour.
-   - Enforce it before `rowWriter.replaceRows(...)` on commit mode.
-   - Keep dry-run and benchmark lanes unaffected.
-   - Gate it with unit tests for allowed commit, blocked commit, and no runtime
-     execution when the cap is already exhausted.
-3. Re-run the Agent-enabled `mcp-docs-pages` canary with:
+2. Re-run the Agent-enabled `mcp-docs-pages` canary with:
    - `COLLECTION_AGENT_ENABLE_AGENT=true`
    - `--require-playwright-ready`
    - PR #60's rejected-candidate gate
-4. Only after that canary produces `selfHealingAction` other than
+3. Only after that canary produces `selfHealingAction` other than
    `candidate_rejected` and `playwrightCandidateStatus: "ready"`, start a
    Playwright compiler branch.
-5. Run the full prompt pack only after the focused canaries are not obviously
+4. Run the full prompt pack only after the focused canaries are not obviously
    broken.
 
 When testing the real app or CLI path, set:
@@ -366,6 +364,7 @@ When testing the real app or CLI path, set:
 POPULATE_AGENT_RUNTIME=collection
 POPULATE_COLLECTION_RUNNER_MODULE=./backend/src/pipeline/collection-agent-runner.ts
 COLLECTION_AGENT_PIPELINE_MODULE=./backend/BigSet_Data_Collection_Agent/src/orchestrator/pipeline.ts
+POPULATE_COMMIT_ROW_LIMIT_PER_HOUR=100
 ```
 
 The BigSet runner keeps TinyFish Agent/browser calls disabled unless


### PR DESCRIPTION
## Summary
- add a self-healing commit-path row cap, defaulting to 100 committed rows/hour per dataset
- wire the cap through `POST /populate` and `populate:self-heal --commit`
- add atomic reservation/confirm/release semantics so concurrent local commits cannot both spend the same remaining row budget
- surface `commitLimit` diagnostics in server/CLI responses and docs

## Evidence
- `node --import ./backend/node_modules/tsx/dist/esm/index.mjs --test backend/test/populate-self-healing-runner.test.ts`
- `npm --prefix backend test`
- `npm --prefix backend run build`
- `git diff --check`
- `make verify-self-healing`

## Review
- First reviewer found a TOCTOU race in check-then-record.
- Fixed with pre-write reservation, post-write confirmation, failure release, and a per-dataset filesystem lock.
- Second reviewer found no blocker after the fix.

## Notes
- Dry runs and benchmark lanes do not commit rows and do not consume the cap.
- Non-blocking known risk: a crash between reservation and confirmation can leave a stale reserved entry in the local filesystem ledger. This is safer than over-committing; a future cleanup/TTL pass can recover stale reservations.
- No auto-merge.
