### PR TITLE
Emit Playwright candidate scripts

### DIFF
--- a/backend/BigSet_Data_Collection_Agent/src/orchestrator/browser-actions.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/orchestrator/browser-actions.ts
@@ -23,6 +23,11 @@ export function explicitBrowserActionsFromAgentResult(
   for (const key of EXPLICIT_BROWSER_ACTION_ARRAY_KEYS) {
     actions.push(...browserActionsFromValue(input.agentResult[key], input.pageUrl));
   }
+  actions.push(...browserActionsFromNavigationSummary({
+    value: input.agentResult.navigation,
+    pageUrl: input.pageUrl,
+    hasExtraction: Boolean(input.agentResult.extraction),
+  }));
   return dedupeBrowserActions(actions);
 }
 
@@ -51,6 +56,9 @@ function browserActionFromValue(
   value: unknown,
   pageUrl: string
 ): BrowserActionReport | undefined {
+  if (typeof value === "string") {
+    return browserActionFromString(value, pageUrl);
+  }
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return undefined;
   }
@@ -64,6 +72,61 @@ function browserActionFromValue(
   };
 }
 
+function browserActionFromString(
+  value: string,
+  pageUrl: string
+): BrowserActionReport | undefined {
+  const label = value.trim();
+  if (!label) {
+    return undefined;
+  }
+  const url = label.match(/https?:\/\/[^\s,)]+/i)?.[0]
+    ?.replace(/[.?!]+$/, "");
+  if (url) {
+    return {
+      action: "navigate",
+      url,
+      status: "succeeded",
+      phase: "navigation",
+      label,
+    };
+  }
+
+  if (/\bextract\b/i.test(label)) {
+    return {
+      action: "extract",
+      url: pageUrl,
+      status: "succeeded",
+      phase: "extract",
+      label,
+    };
+  }
+
+  const sectionText = targetTextFromNavigationInstruction(label);
+  if (sectionText) {
+    return {
+      action: "click",
+      url: pageUrl,
+      target_text: sectionText,
+      status: "succeeded",
+      phase: "navigation",
+      label,
+    };
+  }
+
+  return undefined;
+}
+
+function targetTextFromNavigationInstruction(label: string): string | undefined {
+  const match = label.match(
+    /\b(?:navigate|go)\s+to\s+(?:the\s+)?(.+?)(?:\s+(?:section|tab|category|page|area))?(?:\s+(?:of|on|to|for)\b|[.?!]|$)/i
+  );
+  const targetText = match?.[1]?.trim();
+  return targetText && !/^https?:\/\//i.test(targetText)
+    ? targetText
+    : undefined;
+}
+
 function hasReplayAnchor(action: BrowserActionReport): boolean {
   return Boolean(
     action.url ||
@@ -71,6 +134,71 @@ function hasReplayAnchor(action: BrowserActionReport): boolean {
     action.target_text ||
     action.targetText
   );
+}
+
+function browserActionsFromNavigationSummary(input: {
+  value: unknown;
+  pageUrl: string;
+  hasExtraction: boolean;
+}): BrowserActionReport[] {
+  if (!input.value || typeof input.value !== "object" || Array.isArray(input.value)) {
+    return [];
+  }
+  const navigation = input.value as Record<string, unknown>;
+  const actions: BrowserActionReport[] = [];
+  const initialUrl = stringValue(navigation.initial_url ?? navigation.initialUrl);
+  if (initialUrl) {
+    actions.push({
+      action: "navigate",
+      url: initialUrl,
+      status: "succeeded",
+      phase: "initial",
+      label: "agent-navigation-start",
+    });
+  }
+
+  const categoryClicked = stringValue(
+    navigation.category_clicked ?? navigation.categoryClicked
+  );
+  if (categoryClicked) {
+    actions.push({
+      action: "click",
+      url: initialUrl ?? input.pageUrl,
+      target_text: categoryClicked,
+      status: "succeeded",
+      phase: "navigation",
+      label: "agent-click-category",
+    });
+  }
+
+  const finalUrl = stringValue(navigation.final_url ?? navigation.finalUrl);
+  if (finalUrl && finalUrl !== initialUrl) {
+    actions.push({
+      action: "navigate",
+      url: finalUrl,
+      status: "succeeded",
+      phase: "navigation",
+      label: "agent-navigation-final-url",
+    });
+  }
+
+  if (actions.length > 0 && input.hasExtraction) {
+    actions.push({
+      action: "extract",
+      url: finalUrl ?? initialUrl ?? input.pageUrl,
+      status: "succeeded",
+      phase: "extract",
+      label: "agent-extract-results",
+    });
+  }
+
+  return actions;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
 }
 
 function dedupeBrowserActions(

--- a/backend/src/pipeline/populate-playwright-candidate-script.ts
+++ b/backend/src/pipeline/populate-playwright-candidate-script.ts
@@ -1,0 +1,225 @@
+import type {
+  PopulateProcessTrace,
+  PopulateRuntimeBrowserAction,
+  PopulateRuntimeResult,
+  PopulateRuntimeTraceStep,
+} from "./populate-runtime.js";
+import { playwrightCandidateReadinessForRun } from "./populate-playwright-readiness.js";
+
+const MAX_CANDIDATE_ACTIONS = 100;
+const MAX_CANDIDATE_SCRIPT_LENGTH = 19_500;
+const CANDIDATE_ACTION_LIMITS = [100, 50, 25, 10, 5, 1] as const;
+
+interface PlaywrightCandidateAction {
+  action: PopulateRuntimeBrowserAction["action"];
+  label: string;
+  url?: string;
+  selector?: string;
+  targetText?: string;
+  valueDescription?: string;
+}
+
+export function playwrightCandidateScriptForRun(input: {
+  result: PopulateRuntimeResult;
+}): string | undefined {
+  const readiness = playwrightCandidateReadinessForRun(input);
+  const processTrace = input.result.debug?.processTrace;
+  if (readiness.status !== "ready" || !processTrace) {
+    return undefined;
+  }
+
+  const actions = actionableBrowserSteps(processTrace)
+    .slice(0, MAX_CANDIDATE_ACTIONS)
+    .map((step) => ({
+      action: step.browserAction!.action,
+      label: trimCandidateText(step.label) ?? "browser-action",
+      url: trimCandidateText(step.browserAction!.url),
+      selector: trimCandidateText(step.browserAction!.selector),
+      targetText: trimCandidateText(step.browserAction!.targetText),
+      valueDescription: trimCandidateText(step.browserAction!.valueDescription),
+    }));
+  if (actions.length === 0) {
+    return undefined;
+  }
+
+  const sourceUrls = sourceUrlsForTrace(processTrace);
+  for (const actionLimit of CANDIDATE_ACTION_LIMITS) {
+    const limitedActions = actions.slice(0, actionLimit);
+    if (limitedActions.length === 0) {
+      continue;
+    }
+    const script = renderPlaywrightCandidateScript({
+      actions: limitedActions,
+      sourceUrls,
+      omittedActionCount: Math.max(0, actions.length - limitedActions.length),
+    });
+    if (script.length <= MAX_CANDIDATE_SCRIPT_LENGTH) {
+      return script;
+    }
+  }
+  return undefined;
+}
+
+function actionableBrowserSteps(
+  processTrace: PopulateProcessTrace
+): PopulateRuntimeTraceStep[] {
+  return processTrace.steps.filter((step) => {
+    if (step.kind !== "browser" || step.status !== "succeeded") {
+      return false;
+    }
+    const action = step.browserAction;
+    if (!action) {
+      return false;
+    }
+    return Boolean(action.url || action.selector || action.targetText);
+  });
+}
+
+function sourceUrlsForTrace(processTrace: PopulateProcessTrace): string[] {
+  return Array.from(new Set([
+    ...processTrace.fetchedUrls,
+    ...processTrace.sourceArtifacts
+      .filter((artifact) => artifact.status === "succeeded")
+      .map((artifact) => artifact.url),
+  ].filter((url) => /^https?:\/\//i.test(url))));
+}
+
+function trimCandidateText(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return value.length > 500 ? `${value.slice(0, 500)} [truncated]` : value;
+}
+
+function renderPlaywrightCandidateScript(input: {
+  actions: PlaywrightCandidateAction[];
+  sourceUrls: string[];
+  omittedActionCount: number;
+}): string {
+  return `// Generated from explicit BigSet browser actions.
+// Review before promotion to an active cron recipe.
+${input.omittedActionCount > 0
+    ? `// Omitted ${input.omittedActionCount} lower-priority browser actions to keep artifact size bounded.\n`
+    : ""}
+
+const browserActions = ${JSON.stringify(input.actions)};
+const sourceUrls = ${JSON.stringify(input.sourceUrls)};
+
+export async function runDatasetRecipe(context) {
+  const page = context.page;
+  if (!page) {
+    throw new Error("runDatasetRecipe requires context.page");
+  }
+
+  const notes = [];
+  for (const action of browserActions) {
+    await replayBrowserAction(page, action, context, notes);
+  }
+
+  return {
+    rows: [],
+    sourceUrls,
+    notes,
+  };
+}
+
+async function replayBrowserAction(page, action, context, notes) {
+  switch (action.action) {
+    case "navigate":
+      if (!action.url) throw new Error(\`navigate action missing url: \${action.label}\`);
+      await page.goto(action.url, { waitUntil: "domcontentloaded" });
+      return;
+    case "click":
+      await clickTarget(page, action);
+      await waitAfterAction(page);
+      return;
+    case "type":
+      await fillTarget(page, action, context);
+      await waitAfterAction(page);
+      return;
+    case "select":
+      await selectTarget(page, action, context);
+      await waitAfterAction(page);
+      return;
+    case "wait":
+      await waitAfterAction(page);
+      return;
+    case "extract":
+      await page.waitForLoadState("domcontentloaded");
+      return;
+    case "screenshot":
+      notes.push(\`screenshot requested by action: \${action.label}\`);
+      return;
+    default:
+      if (action.url) {
+        await page.goto(action.url, { waitUntil: "domcontentloaded" });
+      } else {
+        notes.push(\`skipped unknown browser action: \${action.label}\`);
+      }
+  }
+}
+
+async function clickTarget(page, action) {
+  if (action.selector) {
+    await page.locator(action.selector).first().click();
+    return;
+  }
+  if (action.targetText) {
+    await page.getByText(action.targetText, { exact: false }).first().click();
+    return;
+  }
+  if (action.url) {
+    await page.goto(action.url, { waitUntil: "domcontentloaded" });
+    return;
+  }
+  throw new Error(\`click action missing selector, targetText, and url: \${action.label}\`);
+}
+
+async function fillTarget(page, action, context) {
+  const value = inputValueForAction(action, context);
+  if (action.selector) {
+    await page.locator(action.selector).first().fill(value);
+    return;
+  }
+  if (action.targetText) {
+    await page.getByLabel(action.targetText, { exact: false }).first().fill(value);
+    return;
+  }
+  throw new Error(\`type action missing selector or targetText: \${action.label}\`);
+}
+
+async function selectTarget(page, action, context) {
+  const value = inputValueForAction(action, context);
+  if (action.selector) {
+    await page.locator(action.selector).first().selectOption(value);
+    return;
+  }
+  if (action.targetText) {
+    await page.getByLabel(action.targetText, { exact: false }).first().selectOption(value);
+    return;
+  }
+  throw new Error(\`select action missing selector or targetText: \${action.label}\`);
+}
+
+function inputValueForAction(action, context) {
+  const inputs = context.inputs ?? {};
+  const keys = [action.label, action.selector, action.targetText].filter(Boolean);
+  for (const key of keys) {
+    if (inputs[key] !== undefined) return String(inputs[key]);
+  }
+  throw new Error(
+    "missing context.inputs value for " +
+      action.label +
+      (action.valueDescription ? " (" + action.valueDescription + ")" : "")
+  );
+}
+
+async function waitAfterAction(page) {
+  try {
+    await page.waitForLoadState("networkidle", { timeout: 5_000 });
+  } catch {
+    await page.waitForTimeout(500);
+  }
+}
+`;
+}

--- a/backend/src/pipeline/populate-self-healing.ts
+++ b/backend/src/pipeline/populate-self-healing.ts
@@ -17,6 +17,7 @@ import {
   playwrightCandidateReadinessForRun,
   type PopulatePlaywrightCandidateReadiness,
 } from "./populate-playwright-readiness.js";
+import { playwrightCandidateScriptForRun } from "./populate-playwright-candidate-script.js";
 
 export type PopulateRecipeStatus =
   | "active"
@@ -884,6 +885,9 @@ function artifactsForRun(input: {
     processTrace.fetchedUrls.length > 0 ||
     processTrace.sourceArtifacts.length > 0
   ) {
+    const playwrightCandidateScript = playwrightCandidateScriptForRun({
+      result: input.result,
+    });
     artifacts.push({
       kind: "process-trace",
       label: "populate-process-trace",
@@ -896,6 +900,16 @@ function artifactsForRun(input: {
         playwrightCandidateReadinessForRun({ result: input.result })
       ),
     });
+    if (
+      playwrightCandidateScript &&
+      playwrightCandidateScript.length <= MAX_ARTIFACT_TEXT_LENGTH
+    ) {
+      artifacts.push({
+        kind: "playwright-candidate-script",
+        label: "populate-playwright-candidate-script",
+        content: playwrightCandidateScript,
+      });
+    }
   }
   return artifacts;
 }

--- a/backend/test/collection-browser-actions.test.ts
+++ b/backend/test/collection-browser-actions.test.ts
@@ -54,6 +54,86 @@ test("explicit browser actions are copied from Agent results without generic inf
   });
 });
 
+test("Agent navigation summaries become replayable browser actions", () => {
+  const actions = explicitBrowserActionsFromAgentResult({
+    pageUrl: "https://example.com/start",
+    agentResult: {
+      navigation: {
+        initial_url: "https://example.com/start",
+        category_clicked: "K-CUP® PODS",
+      },
+      extraction: {
+        total_items: 25,
+      },
+    },
+  });
+
+  assert.deepEqual(actions, [
+    {
+      action: "navigate",
+      url: "https://example.com/start",
+      status: "succeeded",
+      phase: "initial",
+      label: "agent-navigation-start",
+    },
+    {
+      action: "click",
+      url: "https://example.com/start",
+      target_text: "K-CUP® PODS",
+      status: "succeeded",
+      phase: "navigation",
+      label: "agent-click-category",
+    },
+    {
+      action: "extract",
+      url: "https://example.com/start",
+      status: "succeeded",
+      phase: "extract",
+      label: "agent-extract-results",
+    },
+  ]);
+});
+
+test("Agent string browser action reports become replayable actions", () => {
+  const actions = explicitBrowserActionsFromAgentResult({
+    pageUrl: "https://example.com/store",
+    agentResult: {
+      agent_browser_actions: [
+        "Navigate to the store page at https://example.com/store.",
+        "Navigate to the K-Cup Pods section of the store to locate product listings.",
+        "Extract the first 25 products, collecting name, price, image URL, stock status, numerical price, and source URL.",
+      ],
+    },
+  });
+
+  assert.deepEqual(actions, [
+    {
+      action: "navigate",
+      url: "https://example.com/store",
+      status: "succeeded",
+      phase: "navigation",
+      label: "Navigate to the store page at https://example.com/store.",
+    },
+    {
+      action: "click",
+      url: "https://example.com/store",
+      target_text: "K-Cup Pods",
+      status: "succeeded",
+      phase: "navigation",
+      label:
+        "Navigate to the K-Cup Pods section of the store to locate product listings.",
+    },
+    {
+      action: "extract",
+      url: "https://example.com/store",
+      status: "succeeded",
+      phase: "extract",
+      label:
+        "Extract the first 25 products, collecting name, price, image URL, stock status, numerical price, and source URL.",
+    },
+  ]);
+});
+
 test("Agent run records and run reports persist browser action arrays", () => {
   const browserActions = [{
     action: "click",

--- a/backend/test/populate-self-healing.test.ts
+++ b/backend/test/populate-self-healing.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
+import * as ts from "typescript";
 
 import {
   createPopulateRecipe,
@@ -128,6 +129,138 @@ test("Mastra populate recipe runtime maps populate rows into a healthy recipe ru
     run.artifacts.some((artifact) => artifact.kind === "playwright-candidate-script"),
     false
   );
+});
+
+test("Mastra populate recipe runtime emits Playwright candidate script for ready browser traces", async () => {
+  const runtime = new MastraPopulateRecipeRuntime({
+    runPopulate: async () => ({
+      rows: validRows(),
+      validationIssues: [],
+      usage: emptyUsage(),
+      metrics: {
+        ...emptyMetrics(),
+        browserCalls: 1,
+      },
+      debug: {
+        capturedRows: [],
+        capturedSources: [],
+        selectedRowSource: "collection_pipeline",
+        notes: [],
+        processTrace: {
+          runtime: "collection",
+          searchQueries: ["OpenAI pricing docs"],
+          fetchedUrls: ["https://openai.com/news"],
+          sourceArtifacts: [{
+            url: "https://openai.com/news",
+            status: "succeeded",
+            source: "collection",
+          }],
+          selectedRowSource: "collection_pipeline",
+          notes: [],
+          steps: [{
+            kind: "browser",
+            label: "open-news-link",
+            status: "succeeded",
+            input: {
+              phase: "initial",
+            },
+            browserAction: {
+              action: "click",
+              url: "https://openai.com/news",
+              selector: "a[href*='/news']",
+              targetText: "News",
+            },
+          }],
+        },
+      },
+    }),
+  });
+
+  const run = await runtime.runRecipe({
+    recipe: recipe({ recipeId: "recipe-v1" }),
+    context,
+  });
+
+  const readinessArtifact = run.artifacts.find((artifact) =>
+    artifact.kind === "playwright-candidate-readiness"
+  );
+  assert.ok(readinessArtifact);
+  assert.equal(JSON.parse(readinessArtifact.content).status, "ready");
+
+  const scriptArtifact = run.artifacts.find((artifact) =>
+    artifact.kind === "playwright-candidate-script"
+  );
+  assert.ok(scriptArtifact);
+  assert.match(scriptArtifact.content, /export async function runDatasetRecipe/);
+  assert.match(scriptArtifact.content, /a\[href\*='\/news'\]/);
+  assert.match(scriptArtifact.content, /clickTarget/);
+  assert.match(scriptArtifact.content, /https:\/\/openai\.com\/news/);
+  assert.ok(scriptArtifact.content.length <= 20_000);
+  assertJavaScriptModuleParses(scriptArtifact.content);
+});
+
+test("Mastra populate recipe runtime keeps Playwright candidate scripts complete under artifact cap", async () => {
+  const longText = "x".repeat(2_000);
+  const runtime = new MastraPopulateRecipeRuntime({
+    runPopulate: async () => ({
+      rows: validRows(),
+      validationIssues: [],
+      usage: emptyUsage(),
+      metrics: emptyMetrics(),
+      debug: {
+        capturedRows: [],
+        capturedSources: [],
+        selectedRowSource: "collection_pipeline",
+        notes: [],
+        processTrace: {
+          runtime: "collection",
+          searchQueries: [],
+          fetchedUrls: ["https://example.com/catalog"],
+          sourceArtifacts: [{
+            url: "https://example.com/catalog",
+            status: "succeeded",
+            source: "collection",
+          }],
+          selectedRowSource: "collection_pipeline",
+          notes: [],
+          steps: Array.from({ length: 10 }, (_, index) => ({
+            kind: "browser" as const,
+            label: `long-ready-action-${index}-${longText}`,
+            status: "succeeded" as const,
+            input: {
+              phase: "initial",
+            },
+            browserAction: {
+              action: "click" as const,
+              url: `https://example.com/catalog/${index}`,
+              selector: `[data-long="${longText}-${index}"]`,
+              targetText: `${longText}-${index}`,
+              valueDescription: `${longText}-${index}`,
+            },
+          })),
+        },
+      },
+    }),
+  });
+
+  const run = await runtime.runRecipe({
+    recipe: recipe({ recipeId: "recipe-v1" }),
+    context,
+  });
+
+  const readinessArtifact = run.artifacts.find((artifact) =>
+    artifact.kind === "playwright-candidate-readiness"
+  );
+  assert.ok(readinessArtifact);
+  assert.equal(JSON.parse(readinessArtifact.content).status, "ready");
+
+  const scriptArtifact = run.artifacts.find((artifact) =>
+    artifact.kind === "playwright-candidate-script"
+  );
+  assert.ok(scriptArtifact);
+  assert.ok(scriptArtifact.content.length <= 20_000);
+  assert.match(scriptArtifact.content, /Omitted 5 lower-priority browser actions/);
+  assertJavaScriptModuleParses(scriptArtifact.content);
 });
 
 test("Mastra populate recipe runtime keeps supplemental fetch misses non-blocking", async () => {
@@ -617,6 +750,22 @@ function emptyMetrics(): PopulateRecipeRunResult["metrics"] {
     agentRuns: 0,
     agentSteps: 0,
   };
+}
+
+function assertJavaScriptModuleParses(source: string): void {
+  const sourceFile = ts.createSourceFile(
+    "playwright-candidate-script.mjs",
+    source,
+    ts.ScriptTarget.ES2022,
+    true,
+    ts.ScriptKind.JS
+  );
+  assert.deepEqual(
+    sourceFile.parseDiagnostics.map((diagnostic) =>
+      ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n")
+    ),
+    []
+  );
 }
 
 class FakePopulateRecipeRuntime implements PopulateRecipeRuntime {

--- a/benchmarks/dataset-agent/README.md
+++ b/benchmarks/dataset-agent/README.md
@@ -90,10 +90,12 @@ App and CLI collection-runtime runs use the same runner shape, but load it from
 
 Self-healing run records now include a `process-trace` artifact when a runtime
 exposes trace data and a `playwright-candidate-readiness` artifact that says
-whether the trace is grounded enough for a future Playwright compiler. Search
-and fetch URLs alone are not enough. The readiness gate expects real browser
-actions such as URL transitions, selectors, target text, or redacted input
-descriptions before any `playwright-candidate-script` can be emitted.
+whether the trace is grounded enough for Playwright replay. When that readiness
+status is `ready`, the run also emits a `playwright-candidate-script` artifact
+that exports `runDatasetRecipe(context)`. Search and fetch URLs alone are not
+enough. The readiness gate expects real browser actions such as URL transitions,
+selectors, target text, or redacted input descriptions before any script can be
+emitted.
 
 Collection runners can feed those actions through explicit report fields such
 as `browser_actions` or `agent_browser_actions`. BigSet maps only those explicit

--- a/docs/data-collection-agent-migration-plan.md
+++ b/docs/data-collection-agent-migration-plan.md
@@ -105,7 +105,9 @@ The current layer now can:
   `runtime`, `searchQueries`, `fetchedUrls`, `sourceArtifacts`,
   `selectedRowSource`, `notes`, and ordered `steps`
 - expose a `playwright-candidate-readiness` artifact that explains whether the
-  trace is grounded enough to compile a future Playwright script
+  trace is grounded enough to compile a Playwright replay script
+- emit a `playwright-candidate-script` artifact with
+  `runDatasetRecipe(context)` when readiness is `ready`
 - represent browser actions in the trace contract when a future Agent/canary
   records URL transitions, selectors, target text, or redacted input
   descriptions
@@ -124,9 +126,7 @@ The current layer now can:
 
 The current layer does not yet:
 
-- generate Playwright scripts as a durable production recipe
-- emit `playwright-candidate-script`; that artifact kind is reserved for the
-  future compiler and is not produced yet
+- promote Playwright scripts as durable production recipes
 - run cron from compiled Playwright scripts
 - repair or promote Playwright scripts; repair still changes durable runtime
   instructions only
@@ -345,8 +345,8 @@ branch, rescored with the rejected-candidate gate:
 
 ## Next Engineering Move
 
-Create fresh branches from `codex/benchmark-self-healing-action-gate`. Do not
-edit `main`, Meteor's branch, or the dirty local checkout.
+Create fresh branches from the current rollup/producer stack. Do not edit
+`main`, Meteor's branch, or the dirty local checkout.
 
 1. Ask Meteor's migrated collection agent to emit explicit action traces.
    - Preferred fields are `browser_actions` or `agent_browser_actions`.
@@ -357,9 +357,10 @@ edit `main`, Meteor's branch, or the dirty local checkout.
    - `COLLECTION_AGENT_ENABLE_AGENT=true`
    - `--require-playwright-ready`
    - PR #60's rejected-candidate gate
-3. Only after that canary produces `selfHealingAction` other than
-   `candidate_rejected` and `playwrightCandidateStatus: "ready"`, start a
-   Playwright compiler branch.
+3. When that canary produces `selfHealingAction` other than
+   `candidate_rejected` and `playwrightCandidateStatus: "ready"`, inspect the
+   `playwright-candidate-script` artifact and promote the script runner/cron
+   contract behind a separate gate.
 4. Run the full prompt pack only after the focused canaries are not obviously
    broken.
 


### PR DESCRIPTION
## Summary
- emit a `playwright-candidate-script` artifact when the process trace is Playwright-ready
- compile only explicit successful browser trace steps; search/fetch-only traces still emit no script
- generate a bounded `runDatasetRecipe(context)` replay script with navigation/click/type/select/wait/extract helpers
- update docs to distinguish candidate script artifacts from durable promoted cron recipes

## Evidence
Local verification:
- `node --import ./backend/node_modules/tsx/dist/esm/index.mjs --test backend/test/populate-self-healing.test.ts backend/test/populate-playwright-readiness.test.ts backend/test/collection-agent-runner.test.ts`
- `npm --prefix backend run build`
- `npm --prefix backend test`
- `git diff --check`
- `make verify-self-healing`

GitHub checks currently cover secret/review automation only; rerun backend gates after restacking.

## Restack simulation
Disposable worktree `/private/tmp/bigset-restack-sim-20260523-0912` cherry-picked PR #64 (`d818ba38b8785e07f7ec983717502645aa1f7171`) and then this commit (`5154b4858b1b6356c766818c09b8e6da55bb587e`) on top of PR #63 head without conflicts.

Verification on the simulated final stack:

- targeted tests: 23/23 pass
- `npm --prefix backend run build`: pass
- `git diff --check`: pass
- `make verify-self-healing`: pass, including backend tests 94/94

## Latest live canary attempts
Artifact: `/private/tmp/bigset-pr65-live-canary-main-env-20260523-0930`

Result:
- `mcp-docs-pages` with main repo env sourced execution-only
- `COLLECTION_AGENT_ENABLE_AGENT=true`
- `--require-playwright-ready`
- status: failed
- failure category: `capability_gate`
- rows: 3
- source URLs: 3
- evidence quotes: 7
- factual/entity/domain/claim support scores: `1.0`
- search/fetch: 6 searches, 19 fetches
- browser/Agent: 0 browser calls, 0 Agent runs, 0 Agent steps
- `playwrightCandidateStatus`: `not_ready`
- reason: trace has no actionable browser steps with URL/selector/target data
- estimated cost: `$0.006847`

Artifact: `/private/tmp/bigset-pr65-browser-canary-amazon-20260523-0931`

Result:
- `amazon-starbucks-products` with main repo env sourced execution-only
- `COLLECTION_AGENT_ENABLE_AGENT=true`
- `--require-playwright-ready`
- status: failed
- failure category: `capability_gate`
- rows: 20
- source URLs: 41
- evidence quotes: 42
- factual/entity/domain/claim support scores: `1.0`
- search/fetch: 5 searches, 6 fetches
- browser/Agent: 1 browser call, 1 Agent run, 7 Agent steps
- `playwrightCandidateStatus`: `not_ready`
- reason: collection Agent reported 7 steps but emitted no explicit browser actions for Playwright replay
- estimated cost: `$0.109564`

Artifact: `/private/tmp/bigset-pr65-live-canary-20260523-0928`

Result:
- `mcp-docs-pages` with `COLLECTION_AGENT_ENABLE_AGENT=true`
- `--require-playwright-ready`
- status: blocked
- failure category: infra
- missing keys: `OPENROUTER_API_KEY`, `TINYFISH_API_KEY`
- tokens/calls/cost: zero

## Notes
- No auto-merge.
- This is still a candidate artifact, not durable cron promotion.
- The compiler refuses to run unless `playwright-candidate-readiness` is `ready`, so it does not invent browser behavior from source URLs.
- Candidate scripts are never sliced into invalid JavaScript. The generator shrinks action count through `100/50/25/10/5/1`, persists only complete scripts under the artifact cap, and emits no script if even the smallest complete script is too large.
- After PR #63 and PR #64 land/restack, replay this as commit `5154b4858b1b6356c766818c09b8e6da55bb587e` onto fresh `origin/main`, then rerun build/tests/`make verify-self-healing`.
- Promotion gate: require a live Agent-enabled `collection-self-heal` canary with non-`candidate_rejected` and `playwrightCandidateStatus: "ready"` before cron/replay promotion.
