### PR TITLE
Data Collection Workflow Update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,10 +9,18 @@ CLERK_SECRET_KEY=sk_test_...
 # Generate at https://openrouter.ai/settings/keys
 OPENROUTER_API_KEY=sk-or-...
 
+# TinyFish — required by populate agent web search/fetch.
+# Generate at https://agent.tinyfish.ai/api-keys
+TINYFISH_API_KEY=
+
 # Generate once after the first `make dev` with:
 #   docker compose exec convex ./generate_admin_key.sh
 # Used by the backend container to call internal Convex functions.
 CONVEX_SELF_HOSTED_ADMIN_KEY=
+
+# Durable store for self-healing populate recipe manifests.
+# Docker dev overrides this to /app/.bigset/populate-recipes on a named volume.
+POPULATE_RECIPE_STORE_DIR=.bigset/populate-recipes
 
 # PostHog (optional — leave blank to disable analytics entirely in local dev).
 # Get from https://us.posthog.com/project/settings/general.

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ temp/
 .mastra
 .bigset/
 
+# Accidental root-level npm install (use backend/ and frontend/ package managers).
+/package.json
+/package-lock.json
+
 # Local tarballs
 *.tgz
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Project_BigSet_brief.md
 *.log
 npm-debug.log*
 yarn-debug.log*
+/benchmark-results/
 
 # Local-only files
 *.bak

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 node_modules/
+backend/node_modules
 .env
 .env.local
 Project_BigSet_brief.md
@@ -22,6 +23,7 @@ tmp/
 temp/
 
 .mastra
+.bigset/
 
 # Local tarballs
 *.tgz

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ Frontend on :3500, backend on :3501, Mastra Studio on :4111, Convex dashboard on
    - `CLERK_SECRET_KEY` — from Clerk API Keys
    - `CLERK_JWT_ISSUER_DOMAIN` — your Frontend API URL (e.g. `https://your-app.clerk.accounts.dev`)
 4. Add an OpenRouter API key to the root `.env` file: `OPENROUTER_API_KEY=sk-or-...` (get one at https://openrouter.ai/settings/keys). Docker Compose reads the root `.env` and passes it to the backend and Mastra containers.
+4b. Add a TinyFish API key to the root `.env` file: `TINYFISH_API_KEY=...` (get one at https://agent.tinyfish.ai/api-keys). This enables the populate agent to search the web and fetch page content.
 5. Run `make dev` — this starts all Docker services AND pushes Convex functions automatically.
 6. Generate a Convex admin key (first run only): `docker compose exec convex ./generate_admin_key.sh` and add it as `CONVEX_SELF_HOSTED_ADMIN_KEY` in `frontend/.env.local`, then re-run `make dev`.
 
@@ -28,6 +29,8 @@ Backend is Fastify + Mastra. Fastify serves the HTTP API (Clerk JWT auth on prot
 
 The schema inference pipeline: frontend calls `POST /infer-schema` → Fastify verifies the Clerk JWT → calls `inferSchema()` in `backend/src/pipeline/schema-inference.ts` → Claude Sonnet 4.6 via OpenRouter → returns a Zod-validated `DatasetSchema` → frontend maps it to editable columns in the wizard.
 
+The populate pipeline: frontend calls `POST /populate` with `{ datasetId, datasetName, description, columns }` → Fastify verifies the Clerk JWT → triggers `populateWorkflow` which: (1) clears existing rows, (2) builds a prompt from the schema, (3) runs the populate agent (Claude Sonnet 4.6) which searches the web via TinyFish APIs, then inserts rows into Convex one by one. Rows appear in realtime on the frontend via Convex reactive queries.
+
 Convex functions use `ctx.auth.getUserIdentity()` to get the authenticated user. The `ownerId` field on datasets stores `identity.subject` (Clerk user ID). Do not pass `ownerId` from the client.
 
 ## Environment Variables
@@ -36,6 +39,7 @@ Docker Compose interpolates variables from the root `.env` file. Key variables:
 - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY` — shared by frontend and backend
 - `OPENROUTER_API_KEY` — used by backend and Mastra for AI model calls
 - `CONVEX_SELF_HOSTED_ADMIN_KEY` — used by backend for system-level Convex writes
+- `TINYFISH_API_KEY` — used by the populate agent for web search and fetch (get one at https://agent.tinyfish.ai/api-keys)
 
 The backend container maps `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` → `CLERK_PUBLISHABLE_KEY` (see `docker-compose.dev.yml`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Backend is Fastify + Mastra. Fastify serves the HTTP API (Clerk JWT auth on prot
 
 The schema inference pipeline: frontend calls `POST /infer-schema` → Fastify verifies the Clerk JWT → calls `inferSchema()` in `backend/src/pipeline/schema-inference.ts` → Claude Sonnet 4.6 via OpenRouter → returns a Zod-validated `DatasetSchema` → frontend maps it to editable columns in the wizard.
 
-The populate pipeline: frontend calls `POST /populate` with `{ datasetId, datasetName, description, columns }` → Fastify verifies the Clerk JWT → triggers `populateWorkflow` which: (1) clears existing rows, (2) builds a prompt from the schema, (3) runs the populate agent (Claude Sonnet 4.6) which searches the web via TinyFish APIs, then inserts rows into Convex one by one. Rows appear in realtime on the frontend via Convex reactive queries.
+The populate pipeline: frontend calls `POST /populate` with `{ datasetId, datasetName, description, columns }` → Fastify verifies the Clerk JWT → runs the self-healing populate service. The service builds or reuses a recipe, runs the Mastra populate runtime against TinyFish search/fetch, validates source-backed rows, repairs bad recipes, promotes the passing recipe, then atomically replaces the dataset rows in Convex. Rows appear in realtime on the frontend via Convex reactive queries.
 
 Convex functions use `ctx.auth.getUserIdentity()` to get the authenticated user. The `ownerId` field on datasets stores `identity.subject` (Clerk user ID). Do not pass `ownerId` from the client.
 
@@ -48,5 +48,11 @@ The backend container maps `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` → `CLERK_PUBLIS
 Convex is self-hosted — it does NOT hot-reload when you edit files in `frontend/convex/`. After changing any Convex function, schema, or auth config, you must run `make convex-push` to deploy the updated code to the running instance. `make dev` does this automatically on startup, but subsequent edits require a manual push.
 
 In CI/prod, run `npx convex deploy` with `CONVEX_SELF_HOSTED_URL` and `CONVEX_SELF_HOSTED_ADMIN_KEY` set as env vars.
+
+## Self-Healing Verification
+
+Run `make verify-self-healing` before handing the stack to another agent. It runs backend tests, backend build, adapter syntax checks, and a no-key benchmark smoke that should block cleanly without spending API credits.
+
+Use `bash scripts/verify-self-healing-stack.sh --real-benchmark` for the 2-prompt real Mastra benchmark, and `bash scripts/verify-self-healing-stack.sh --convex-push --dataset-id <dataset-id>` for a live app dataset dry-run. Export the required env vars before live modes; the verifier does not parse secret files itself. Add `--commit` only when you intentionally want to replace rows.
 
 This is an open-source (AGPL) project. Do not commit secrets, API keys, or internal docs.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,3 +14,7 @@ CLERK_PUBLISHABLE_KEY=
 # OpenRouter API key — required by schema inference.
 # Generate at https://openrouter.ai/settings/keys
 OPENROUTER_API_KEY=sk-or-...
+
+# TinyFish API key — used by the populate agent for web search and fetch.
+# Generate at https://agent.tinyfish.ai/api-keys
+TINYFISH_API_KEY=

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,10 +12,42 @@ CONVEX_SELF_HOSTED_ADMIN_KEY=
 CLERK_SECRET_KEY=
 CLERK_PUBLISHABLE_KEY=
 
-# OpenRouter API key — required by schema inference.
+# OpenRouter API key — required by schema inference and populate.
 # Generate at https://openrouter.ai/settings/keys
 OPENROUTER_API_KEY=sk-or-...
 
 # TinyFish API key — used by the populate agent for web search and fetch.
 # Generate at https://agent.tinyfish.ai/api-keys
 TINYFISH_API_KEY=
+
+# Optional model overrides (see backend/src/openrouter-models.ts).
+# Schema inference defaults to anthropic/claude-sonnet-4-6.
+# Populate and other non-inference tasks default to google/gemini-3.1-flash-lite.
+# OPENROUTER_MODEL=google/gemini-3.1-flash-lite
+# OPENROUTER_POPULATE_MODEL=google/gemini-3.1-flash-lite
+
+# Populate runtime limits (see src/pipeline/populate-runtime-limits.ts).
+# POPULATE_MAX_FETCH_CALLS caps prioritized source URLs for the populate agent (default 50).
+# POPULATE_MAX_ROWS=100
+# POPULATE_MAX_SEARCH_CALLS=25
+# POPULATE_MAX_FETCH_CALLS=50
+
+# Parallel populate workers (triage + extract per URL shard).
+# POPULATE_URLS_PER_WORKER=5
+# POPULATE_MAX_TINYFISH_AGENT_RUNS=5
+# POPULATE_ENABLE_TINYFISH_AGENT=true
+# POPULATE_TINYFISH_AGENT_POLL_TIMEOUT_MS=480000
+
+# Central collection memory (repair_loop placeholder + agent_visited_urls).
+# POPULATE_ENABLE_COLLECTION_MEMORY=true
+# POPULATE_COLLECTION_MEMORY_DIR=.bigset/collection-memory
+# POPULATE_MAX_REPAIR_LOOPS=3
+
+# Playwright agent dock (default off; replays URLs with saved Tinyfish emitted_process).
+# POPULATE_ENABLE_PLAYWRIGHT_AGENT=false
+# POPULATE_MAX_PLAYWRIGHT_AGENT_RUNS=5
+# POPULATE_PLAYWRIGHT_AGENT_POLL_TIMEOUT_MS=480000
+
+# When true, Mastra populate benchmark runs write intermediate artifacts under
+# BIGSET_BENCHMARK_ARTIFACT_DIR/debug/ (JSON + CSV). No effect when unset/false.
+# POPULATE_BENCHMARK_DEBUG=true

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,7 @@
 CLIENT_ORIGIN=http://localhost:3500
 CONVEX_URL=http://localhost:3210
 PORT=3501
+POPULATE_RECIPE_STORE_DIR=.bigset/populate-recipes
 
 # Required once the backend starts writing rows via internal Convex mutations.
 # Generate with: docker compose exec convex ./generate_admin_key.sh

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -39,6 +39,7 @@ TINYFISH_API_KEY=
 # POPULATE_TINYFISH_AGENT_POLL_TIMEOUT_MS=480000
 
 # Central collection memory (repair_loop placeholder + agent_visited_urls).
+# Defaults to a sibling of POPULATE_RECIPE_STORE_DIR (e.g. .bigset/collection-memory).
 # POPULATE_ENABLE_COLLECTION_MEMORY=true
 # POPULATE_COLLECTION_MEMORY_DIR=.bigset/collection-memory
 # POPULATE_MAX_REPAIR_LOOPS=3
@@ -50,4 +51,4 @@ TINYFISH_API_KEY=
 
 # When true, Mastra populate benchmark runs write intermediate artifacts under
 # BIGSET_BENCHMARK_ARTIFACT_DIR/debug/ (JSON + CSV). No effect when unset/false.
-# POPULATE_BENCHMARK_DEBUG=true
+# POPULATE_BENCHMARK_DEBUG=false

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,5 +1,16 @@
 node_modules/
 dist/
 .env
+.env.local
 *.tsbuildinfo
 drizzle/
+
+# Local populate / collection runtime (see POPULATE_RECIPE_STORE_DIR, POPULATE_COLLECTION_MEMORY_DIR).
+# Root .gitignore also ignores .bigset/ when those dirs live there.
+
+# BigSet_Data_Collection_Agent CLI output (default: runs/{run_id}/ under cwd).
+runs/
+memory/
+
+# Mastra local dev output
+.mastra/

--- a/backend/BigSet_Data_Collection_Agent/docs/architecture.md
+++ b/backend/BigSet_Data_Collection_Agent/docs/architecture.md
@@ -1,0 +1,463 @@
+# BigSet Data Collection Agent — Architecture (v1.4)
+
+This document describes the **current** end-to-end pipeline. It updates the original stage model with workflow memory, multi-loop repair, follow-up search/fetch, per-field confidence, selective exports, and recurring refresh.
+
+**v1.4 release notes:** [v14-ai-sdk-benchmark-and-quality.md](v14-ai-sdk-benchmark-and-quality.md). **Planned efficiency (v1.5):** [v15-efficiency-planned.md](v15-efficiency-planned.md).
+
+**Related docs:** [data-flow.md](data-flow.md) (types + JSON examples between stages), [AGENTS.md](AGENTS.md) (change guidelines).
+
+## Change guidelines
+
+- Treat bug reports and example inputs as evidence of a **failure mode**, not the full spec.
+- Fix inside existing stages and types; avoid one-off wrappers or post-hoc patches.
+- See [AGENTS.md](AGENTS.md) for full rules.
+
+**Entry points**
+
+| Command | Purpose |
+|---------|---------|
+| `bigset-collector run` | New collection from a user prompt |
+| `bigset-collector refresh --from-run <id>` | Re-acquire data for a prior run; merge by primary key in place |
+
+**External services**
+
+| Service | Role |
+|---------|------|
+| **OpenRouter** | LLM for all agents (spec, triage, extract, repair, goals) via **Vercel AI SDK** (`generateText` + `Output.object`) |
+| **Tinyfish Search** | Web search → candidate URLs |
+| **Tinyfish Fetch** | Page content (markdown) + optional outbound links |
+| **Tinyfish Agent** | Browser automation for navigation / forms / detail pages |
+
+---
+
+## Shareable architecture diagram (v1.4)
+
+| File | Format |
+|------|--------|
+| [architecture-flowchart.png](architecture-flowchart.png) | PNG (recommended for Slack/email) |
+| [architecture-flowchart.jpg](architecture-flowchart.jpg) | JPEG |
+| [architecture-flowchart.svg](architecture-flowchart.svg) | SVG (scalable) |
+| [architecture-flowchart.mmd](architecture-flowchart.mmd) | Mermaid source (edit and re-render) |
+
+Re-render after editing the `.mmd` file:
+
+```bash
+cd backend/BigSet_Data_Collection_Agent/docs
+npx -y @mermaid-js/mermaid-cli -i architecture-flowchart.mmd -o architecture-flowchart.png -b white -w 2400
+```
+
+---
+
+## High-level flow
+
+```mermaid
+flowchart TB
+  S0[Stage 0: Prompt intake]
+  S1[Stage 1: Dataset Spec Agent]
+  S2[Stage 2: Source discovery]
+  S3[Stage 3: Fetch layer]
+  S4[Stage 4: Source Triage Agent]
+  S5A[Stage 5A: Tinyfish Agent path]
+  S5B[Stage 5B: Extraction Agent pool]
+  S6[Stage 6: Merge + normalize]
+  S7[Stage 7: Quality + confidence]
+  S8[Stage 8–9: Coverage + repair loop]
+  S10[Stage 10: CSV compiler]
+
+  MEM[(Workflow memory)]
+  S0 --> S1
+  S1 --> S2
+  MEM -.-> S1
+  S2 --> S3
+  S3 --> S4
+  S4 --> S5A
+  S4 --> S5B
+  S5A --> S6
+  S5B --> S6
+  S6 --> S7
+  S7 --> S8
+  S8 -->|gaps remain| S2
+  S8 -->|done| S10
+  MEM -.-> S2
+  MEM -.-> S4
+  MEM -.-> S5A
+  MEM -.-> S5B
+  MEM -.-> S8
+```
+
+**Orchestrator:** `src/orchestrator/pipeline.ts` (collect + refresh), `acquisition.ts` (search/fetch/triage/extract bundle), `repair-loop.ts` (stages 8–9).
+
+---
+
+## Stage 0: User prompt intake
+
+**What happens**
+
+- CLI receives `--prompt`, `--target-rows`, feature flags (`--no-repair`, `--no-triage`, `--no-agent`), and output directory.
+- **Refresh mode:** loads a prior run (`dataset_spec`, `evidence`, `workflow_memory`, `run_report`) instead of a new prompt-only start. See [v13-selective-results-and-refresh.md](v13-selective-results-and-refresh.md).
+
+**Outputs**
+
+- Run folder `runs/{run_id}/` (new id, or same id with `--in-place` refresh).
+- `prompt` and `target_rows` stored in `run_report.json`.
+
+**Code**
+
+- `src/cli.ts`
+- `src/storage/run-loader.ts` (refresh)
+
+---
+
+## Stage 1: Dataset Spec Agent
+
+**What happens**
+
+- **New run:** OpenRouter agent infers schema from the user prompt.
+- **Refresh:** Reuses `dataset_spec.json` from the source run (no re-inference).
+- Produces:
+  - `row_grain` — what one CSV row represents
+  - `columns[]` — name, type, description, `required`
+  - `dedupe_keys` — **exactly one** column name: primary entity identifier for merge/repair
+  - `search_queries` — seed searches for initial/refresh acquisition
+  - `extraction_hints` — downstream extract guidance
+- Required columns are ordered first; intent fields from the prompt are marked `required: true` so repair can run when data is sparse.
+
+**Memory**
+
+- Loads `memory/{prompt_fingerprint}.json` when `ENABLE_WORKFLOW_MEMORY=true`.
+- Prior query/domain stats inform the spec agent on recurring prompts.
+
+**Outputs**
+
+- `dataset_spec.json`
+- Snapshot in workflow memory: `extraction_schema`, `dedupe_keys`
+
+**Code**
+
+- `src/agents/dataset-spec.ts`
+- `src/memory/workflow-memory.ts`, `store.ts`
+
+---
+
+## Stage 2: Source discovery (Search)
+
+**What happens**
+
+- Parallel Tinyfish Search calls (rate-limited queue).
+- **Initial / refresh phase:** seed queries from the dataset spec (capped by `MAX_SEARCH_QUERIES`).
+- **Repair phase:** mixed plan (see Stage 8):
+  - **Curated** — new repair queries from the Coverage & Query Planning agent (page `0`).
+  - **Pagination follow-up** — top historical query strings at the next Search API page (`last_page + 1`). See [v12-follow-up-repair.md](v12-follow-up-repair.md).
+- Each hit becomes a `SourceCandidate` (`url`, `title`, `snippet`, `query`, `search_page`).
+
+**Ranking (pre-fetch)**
+
+- Candidates are scored and domain-deduplicated before Fetch (`rankCandidates` + `domainMemoryBoost` from workflow memory).
+
+**Outputs**
+
+- `source_candidates.json` (initial)
+- In-memory candidate list per acquisition phase
+
+**Code**
+
+- `src/integrations/tinyfish.ts` — `searchWeb(query, page)`
+- `src/orchestrator/acquisition.ts`
+- `src/memory/search-pagination.ts` — `planRepairSearches`
+- `src/queue/pools.ts` — `createSearchQueue`
+
+---
+
+## Stage 3: Fetch layer
+
+**What happens**
+
+- Top-ranked URLs are fetched in parallel batches (Tinyfish Fetch, markdown).
+- **Repair + link follow:** primary fetch may request `links: true`; a second wave fetches heuristic-ranked outbound URLs (URL-only; future: agent picker). See `src/acquisition/link-follow.ts`.
+- Already-seen URLs are skipped via a run-level `fetchedUrlSet` (refresh can optionally `--refetch-urls`).
+- Pages stored under `runs/{id}/pages/{index}.meta.json` + `.md`.
+
+**Outputs**
+
+- `FetchedPage` objects (`text`, `title`, `final_url`, optional `outbound_links`, errors)
+
+**Code**
+
+- `src/integrations/tinyfish.ts` — `fetchPages`
+- `src/orchestrator/acquisition.ts`
+- `src/storage/run-store.ts` — `saveFetchedPage`
+
+---
+
+## Stage 4: Source Triage Agent
+
+**What happens**
+
+- Each successfully fetched page is classified in parallel (OpenRouter).
+- **Statuses** (see `src/models/source-status.ts`):
+
+| Status | Routing |
+|--------|---------|
+| `extract_now` | Direct extraction (Stage 5B) |
+| `requires_navigation` | Tinyfish Agent (Stage 5A) |
+| `requires_form_submission` | Agent |
+| `requires_detail_page_followup` | Agent |
+| `irrelevant` / `duplicate` / `blocked` / `low_value` | Skipped (or fallback extract if triage fails) |
+
+- Emits **routing** `confidence` and **data** `source_data_confidence` (used later for field-level scoring).
+- Workflow memory (`domain_stats_top` / `weak`) is injected into the triage prompt.
+
+**Flags**
+
+- `--no-triage`: skip classification; extract all pages.
+
+**Outputs**
+
+- `triage_{phase}.json` per acquisition label (`initial`, `refresh`, `repair_N`)
+- `source_outcomes_{phase}.json` (v1.5.2) — per URL `triage_results` + `extraction_results` when inline extract ran
+
+**Code**
+
+- `src/agents/source-triage.ts`
+- `src/orchestrator/process-pages.ts`
+
+---
+
+## Stage 5A: Navigation / Agent path
+
+**What happens**
+
+- For agent-classified pages (budget: `MAX_AGENT_RUNS_PER_PHASE`):
+  1. **Agent Goal Agent** — generates a Tinyfish Agent goal from page + triage + memory.
+  2. **Tinyfish Agent** — async queue + parallel poll (`run-async` / `runs.get`).
+  3. **Extract-from-agent** — structured rows + evidence from agent result.
+- Repair diagnosis may set `prefer_tinyfish_agent` to force agent for the whole repair acquisition.
+
+**Outputs**
+
+- `AgentRunRecord` per URL (goal, status, records extracted)
+- Records merged into the same record stream as 5B
+
+**Code**
+
+- `src/agents/agent-goal.ts`, `extract-from-agent.ts`
+- `src/integrations/tinyfish-agent.ts`
+- `src/orchestrator/process-pages.ts`
+
+---
+
+## Stage 5B: Extraction Agent pool
+
+**What happens**
+
+- Parallel OpenRouter extraction from page markdown (`extract_now` and agent-disabled fallbacks).
+- LLM returns `row`, sparse `evidence`, and `extraction_confidence`; `finalizeExtractedRecord()` attaches evidence URLs and `source_urls`. Provenance URL columns come from the LLM row; fetch URL is only a fallback when still empty.
+- `focusFields` set during repair to target gap columns.
+- Per-field confidence in exports is computed in Stage 7 (quality), not during extraction.
+
+**Outputs**
+
+- Raw records per acquisition phase (before merge)
+
+**Code**
+
+- `src/agents/extract.ts`
+- `src/orchestrator/process-pages.ts`
+- `src/queue/pools.ts` — `createExtractionQueue`
+
+---
+
+## Stage 6: Merge + normalize
+
+**What happens**
+
+- Records merged by **canonical id** (`pk:` from single `dedupe_keys[0]`, or `dk:` composite fallback when primary key empty).
+- **Pair merge:** empty fields filled from newer pass; evidence and `source_urls` unioned; `extraction_confidence` = max of pair.
+- **Refresh:** `mergeRepairIntoExisting(baseline, newRecords)` — same keys update in place, no duplicate entities.
+- Unkeyed rows kept in `records_unkeyed.jsonl`.
+
+**Outputs**
+
+- In-memory merged dataset; snapshots `init_results.csv` after first acquisition pass.
+
+**Code**
+
+- `src/merge/records.ts` — `mergeRecords`, `mergeRepairIntoExisting`, `mergePair`
+
+---
+
+## Stage 7: Data quality & confidence
+
+**What happens**
+
+- Deterministic scoring (not a separate LLM agent): `scoreRecord` / `buildQualityReport`.
+- **Completeness** — share of required columns filled.
+- **Per-field confidence** — from evidence URL triage signals + extraction confidence (`src/quality/field-confidence.ts`).
+- **Record `confidence_score`** — mean of required field confidences.
+- **Status buckets:** `complete` | `partial` | `low_confidence`; `needs_review` flag with reasons.
+- **Source outcomes** — per-URL success/fail/skip across phases.
+
+**Outputs**
+
+- `quality_report.json`
+- `sources_outcomes.json`
+- Segmented CSVs: `records_complete.csv`, `records_partial.csv`, etc.
+
+**Code**
+
+- `src/quality/score-record.ts`, `field-confidence.ts`, `build-report.ts`
+- See [v10-quality.md](v10-quality.md)
+
+---
+
+## Stage 8: Coverage & query planning (repair loop)
+
+**What happens**
+
+- **Coverage analysis** (`analyzeCoverage`) — required-column gaps, `should_repair`, partial row examples.
+- If repair enabled and gaps exist, up to `MAX_REPAIR_LOOPS` iterations:
+
+```text
+Per repair loop:
+  8a. Repair Diagnosis Agent     → why gaps remain, domains/queries, agent preference
+  8b. Repair Queries Agent       → new curated search strings (memory + diagnosis)
+  8c. planRepairSearches()       → append pagination searches for top memory queries
+  8d. Acquisition (repair_N)     → Search → Fetch (+ link follow) → Triage → Extract/Agent
+  8e. mergeRepairIntoExisting    → fill gaps on existing rows; new primary keys add rows (triage may skip duplicate pages only when no new entities)
+  8f. recordPhaseInMemory        → update query/domain/agent_goal stats
+```
+
+**Memory updates**
+
+- Scored aggregates: per-query (incl. page breakdown), per-domain, per-agent-goal.
+- Diagnoses and strategy notes appended for the next loop or a future run.
+
+**Outputs**
+
+- `repair_diagnosis_{n}.json`, `repair_queries_{n}.json` (includes `repair_searches`)
+- `coverage_repair_{n}.json`
+
+**Code**
+
+- `src/coverage/analyze.ts`
+- `src/agents/repair-diagnosis.ts`, `repair-queries.ts`
+- `src/orchestrator/repair-loop.ts`
+- See [v11-workflow-memory.md](v11-workflow-memory.md), [v12-follow-up-repair.md](v12-follow-up-repair.md)
+
+---
+
+## Stage 9: Stop or repeat
+
+**Stop conditions (implemented)**
+
+| Condition | Behavior |
+|-----------|----------|
+| No missing **required** fields | `should_repair = false` — exit repair loop |
+| `repair_loop_count >= MAX_REPAIR_LOOPS` | Stop even if gaps remain |
+| `ENABLE_REPAIR_LOOP=false` or `--no-repair` | Skip stage 8 entirely |
+| Initial coverage satisfied | Repair never starts |
+
+**Not implemented yet**
+
+- Marginal-gain threshold (stop when a loop fills too few fields).
+- LLM link-follow picker or extraction priority arbiter (planned; see team notes).
+
+After repair (or skip), workflow memory is written to `workflow_memory.json` and `memory/{fingerprint}.json`.
+
+---
+
+## Stage 10: CSV compiler & reports
+
+**What happens**
+
+- **Selective export (v1.3):** `results.csv` contains only rows with **all required fields**, sorted by `completeness_pct` ↓ then `confidence_score` ↓. Per-required-field `{column}_confidence` columns included.
+- **Full export:** `results_full.csv` + `evidence_full.jsonl` — entire merged dataset.
+- **Evidence:** `evidence.jsonl` mirrors selective rows with quality + `field_confidences`.
+- **Run report:** stats, repair summary, `visualization_records` count, optional `refreshed_from_run_id`.
+
+**Outputs**
+
+| Artifact | Description |
+|----------|-------------|
+| `results.csv` | Primary consumer-facing dataset (selective, ranked) |
+| `results_full.csv` | Full merge + quality columns |
+| `evidence.jsonl` / `evidence_full.jsonl` | Row + evidence + quality metadata |
+| `run_report.json` | End-to-end stats and configuration echo |
+| `init_results.csv` / `repair_results.csv` | Phase snapshots |
+
+**Code**
+
+- `src/export/csv-compiler.ts`, `select-results.ts`
+- `src/storage/run-store.ts`
+
+---
+
+## Cross-cutting: Workflow memory
+
+Persistent learning keyed by **prompt fingerprint** (`memory/{fingerprint}.json` + per-run `workflow_memory.json`).
+
+| Store | Used for |
+|-------|----------|
+| `query_stats` | URL yield, record quality, search page, weighted quality |
+| `domain_stats` | Fetch failures, avg completeness/confidence |
+| `agent_goal_stats` | Agent URL + goal performance |
+| `diagnoses` / `strategy_notes` | Repair narrative across loops |
+| `last_missing_fields` | Agent context |
+
+Injected into: Dataset Spec, Triage, Extract, Agent Goal, Repair Diagnosis, Repair Queries; also drives search pagination and domain-boosted URL ranking.
+
+---
+
+## Cross-cutting: Parallelism & limits
+
+| Pool | Concurrency / limit | Backpressure |
+|------|---------------------|--------------|
+| Search | `SEARCH_CONCURRENCY`, `TINYFISH_SEARCH_RPM` | Rate limiter + retries |
+| Fetch | `FETCH_CONCURRENCY`, `TINYFISH_FETCH_RPM` | Per-domain throttle |
+| Triage / Extract | `TRIAGE_*`, `EXTRACTION_*`, `OPENROUTER_RPM` | Shared OpenRouter limiter |
+| Agent | `AGENT_*`, `TINYFISH_AGENT_RPM` | Queue + poll concurrency |
+
+See [v04-parallel.md](v04-parallel.md).
+
+---
+
+## Mapping: original stages → current
+
+| Original | Current (v1.4) |
+|----------|----------------|
+| Stage 0: Prompt intake | Unchanged + **refresh** entry |
+| Stage 1: Dataset Spec | Unchanged + memory-informed; skipped on refresh |
+| Stage 2: Source Discovery | Search + **repair pagination** + memory-ranked fetch selection |
+| Stage 3: Fetch | Unchanged + **link-follow** second wave on repair |
+| Stage 4: Triage | Expanded status enum + memory + dual confidence scores |
+| Stage 5A: Navigation Agent | Tinyfish Agent + goal agent + async batch |
+| Stage 5B: Extraction pool | Parallel extract + extract-from-agent |
+| Stage 6: Merge | Dedupe + **in-place refresh merge** |
+| Stage 7: Quality agent | **Deterministic** scorer + **per-field confidence** |
+| Stage 8: Coverage & planning | **Diagnosis agent** + **repair queries** + pagination plan |
+| Stage 9: Stop/repeat | Multi-loop (`MAX_REPAIR_LOOPS`); no marginal-gain stop yet |
+| Stage 10: CSV | **Selective + full** exports, segmented buckets, run report |
+
+---
+
+## Version-specific documentation
+
+| Version | Topic |
+|---------|--------|
+| v0.3 | [Triage & navigation](v03-triage-navigation.md) |
+| v0.4 | [Parallel workers](v04-parallel.md) |
+| v1.0 | [Quality scoring](v10-quality.md) |
+| v1.1 | [Workflow memory & multi-repair](v11-workflow-memory.md) |
+| v1.2 | [Follow-up repair (pagination + links)](v12-follow-up-repair.md) |
+| v1.3 | [Selective results & refresh](v13-selective-results-and-refresh.md) |
+| v1.4 | [AI SDK, benchmark parity, extraction quality](v14-ai-sdk-benchmark-and-quality.md) |
+| v1.5 | [Efficiency improvements](v15-efficiency-planned.md) (planned) |
+| — | [Source selection heuristics](source-selection.md) |
+
+---
+
+## Planned extensions (not in codebase)
+
+- **Link-follow agent** — replace URL heuristics for outbound link selection.
+- **Extraction arbiter agent** — rank fetch/extract tasks by source type (curated vs pagination vs link).
+- **Marginal-gain stop** — end repair when incremental field fills fall below a threshold.

--- a/backend/BigSet_Data_Collection_Agent/docs/data-flow.md
+++ b/backend/BigSet_Data_Collection_Agent/docs/data-flow.md
@@ -1,0 +1,315 @@
+# Data flow and types between pipeline stages
+
+This document describes **what data each stage produces and consumes**. Types are defined in `src/models/schemas.ts` unless noted.
+
+See [architecture.md](architecture.md) for stage responsibilities, [AGENTS.md](AGENTS.md) for change guidelines, and [v14-ai-sdk-benchmark-and-quality.md](v14-ai-sdk-benchmark-and-quality.md) for the v1.4 release summary.
+
+---
+
+## LLM layer (Vercel AI SDK)
+
+Structured agent calls use **`generateText` + `Output.object`** via `src/llm/complete-json.ts`, with **OpenRouter's official AI SDK provider** (`@openrouter/ai-sdk-provider`, not the OpenAI-compatible shim). System prompts use the `system` option; temperature is omitted by default for Gemini/reasoning models (set `OPENROUTER_TEMPERATURE` only when the model supports it).
+
+Token usage is accumulated per pipeline run in **`runWithLlmUsageScope`** (`src/llm/usage.ts`) and written to:
+
+- `PipelineResult.llmUsage`
+- `run_report.json` → `llm_usage`
+- Benchmark stdout → `usage.promptTokens` / `completionTokens` / `totalTokens`
+
+The benchmark harness reads those fields directly (no estimation when `call_count > 0`).
+
+---
+
+```mermaid
+flowchart LR
+  P[Prompt] --> SPEC[DatasetSpec]
+  SPEC --> CAND[SourceCandidate]
+  CAND --> PAGE[FetchedPage]
+  PAGE --> TRIAGE[SourceTriageResult]
+  TRIAGE --> EXT[ExtractedRecord]
+  EXT --> MERGE[Merged ExtractedRecord]
+  MERGE --> COV[CoverageReport]
+  COV --> REPAIR[Repair loop]
+  REPAIR --> MERGE
+  MERGE --> OUT[CSV / evidence.jsonl / RunReport]
+```
+
+**LLM stages:** Dataset Spec, Source Triage, Extraction (row values only), Agent Goal, Extract-from-agent (row values only), Repair Diagnosis, Repair Queries.
+
+**Non-LLM stages:** Search, Fetch, Merge, Coverage, Quality scoring, CSV export.
+
+---
+
+## Stage 0 — Pipeline input
+
+```json
+{
+  "prompt": "restaurants in Menlo Park that serve Coca-Cola",
+  "targetRows": 25,
+  "enableRepair": true,
+  "enableTriage": true,
+  "enableTinyfishAgent": true
+}
+```
+
+Benchmark adapter adds `benchmark.requiredColumns` from `prompts.json` (see `src/agents/benchmark-spec.ts`).
+
+---
+
+## Stage 1 — DatasetSpec (LLM → validated JSON)
+
+**Saved as:** `dataset_spec.json`
+
+```json
+{
+  "intent_summary": "Restaurants in Menlo Park that serve Coca-Cola",
+  "target_row_count": 25,
+  "row_grain": "One row per restaurant",
+  "columns": [
+    { "name": "entity_name", "type": "string", "description": "Restaurant name", "required": true },
+    { "name": "address", "type": "string", "description": "Street address", "required": true },
+    { "name": "serves_requested_item", "type": "boolean", "description": "Menu shows Coca-Cola", "required": true },
+    { "name": "source_url", "type": "string", "description": "URL where menu evidence was found", "required": true }
+  ],
+  "dedupe_keys": ["entity_name"],
+  "search_queries": ["Menlo Park restaurants Coca-Cola menu", "..."],
+  "extraction_hints": "Require menu or beverage list evidence."
+}
+```
+
+**Rule:** `dedupe_keys` must contain **exactly one** column name — the primary entity identifier for merge and repair.
+
+---
+
+## Stage 2 — SourceCandidate (Tinyfish Search)
+
+```json
+{
+  "url": "https://example.com/menu",
+  "title": "Example Bistro Menu",
+  "snippet": "Coca-Cola available...",
+  "site_name": "example.com",
+  "query": "Menlo Park restaurants Coca-Cola menu",
+  "position": 1,
+  "search_page": 0
+}
+```
+
+---
+
+## Stage 3 — FetchedPage (Tinyfish Fetch)
+
+```json
+{
+  "url": "https://example.com/menu",
+  "final_url": "https://example.com/menu",
+  "title": "Menu",
+  "text": "# Drinks\n\nCoca-Cola ...",
+  "outbound_links": ["https://example.com/contact"]
+}
+```
+
+---
+
+## Stage 4 — SourceTriageResult (LLM, optional)
+
+```json
+{
+  "url": "https://example.com/menu",
+  "final_url": "https://example.com/menu",
+  "title": "Menu",
+  "status": "extract_now",
+  "confidence": 0.9,
+  "source_data_confidence": 0.85,
+  "expected_yield": "partial",
+  "reasoning": "Menu page lists beverages inline.",
+  "suggested_action": "Extract drink list."
+}
+```
+
+Routing (v1.5.2): `extract_now` → inline extract in the **same** combined LLM call; `requires_*` → Tinyfish Agent (if enabled); others → skip.
+
+**Artifacts per phase:** `triage_{phase}.json` (triage only, same as before) and `source_outcomes_{phase}.json` (per URL: `triage_results` + `extraction_results` when inline extract ran).
+
+Revert to v1.4 two-call path: `ENABLE_COMBINED_TRIAGE_EXTRACT=false`.
+
+---
+
+## Stage 5 — Extraction (combined or legacy)
+
+### Combined LLM output (v1.5.2 default)
+
+One call returns strict top-level keys:
+
+```json
+{
+  "triage_results": { "...": "see Stage 4 shape" },
+  "extraction_results": {
+    "records": [ "..." ],
+    "notes": "optional"
+  }
+}
+```
+
+When `triage_results.status` is not `extract_now`, `extraction_results.records` must be `[]` (post-processing ignores stray rows).
+
+Page markdown uses **2× `MAX_PAGE_CHARS`** (`TRIAGE_EXTRACT_MAX_PAGE_CHARS`). Default `TRIAGE_CONCURRENCY=10`.
+
+### Legacy / agent / fallback extraction
+
+Separate `extractFromPage` or `extractFromAgentResult` still used when triage is disabled, agent returns JSON, combined call fails, or `ENABLE_COMBINED_TRIAGE_EXTRACT=false`.
+
+### LLM row shape (row + sparse evidence + confidence)
+
+Inline and legacy extract paths return `row`, optional `evidence`, and `extraction_confidence`. They do **not** return `source_urls`.
+
+```json
+{
+  "records": [
+    {
+      "row": {
+        "entity_name": "Stripe",
+        "pricing_page_url": "https://stripe.com/pricing",
+        "plan_or_price": "Standard — 2.9% + 30¢ per card charge",
+        "source_url": "https://stripe.com/pricing"
+      },
+      "evidence": [
+        {
+          "field": "plan_or_price",
+          "quote": "2.9% + 30¢ per successful card charge"
+        }
+      ],
+      "extraction_confidence": 0.85
+    }
+  ],
+  "notes": "Multiple plans on page; extracted Standard tier only."
+}
+```
+
+### Post-processing (`finalizeExtractedRecord` in `src/agents/extract.ts`)
+
+Code keeps LLM **row** values (including provenance URL columns the model set per row). It then:
+
+- Keeps `evidence[].url` from the LLM when provided; uses the fetch `pageUrl` only when the model omitted `url`
+- Sets `source_urls` from the page URL plus any `http` URLs on evidence items
+- **Fallback only:** if a required provenance column is still empty, uses the fetch `pageUrl` (does not overwrite LLM-provided URLs)
+
+### Final ExtractedRecord
+
+```json
+{
+  "row": {
+    "entity_name": "Stripe",
+    "pricing_page_url": "https://stripe.com/pricing",
+    "plan_or_price": "Standard — 2.9% + 30¢ per card charge",
+    "source_url": "https://stripe.com/pricing"
+  },
+  "evidence": [
+    {
+      "field": "plan_or_price",
+      "url": "https://stripe.com/pricing",
+      "quote": "2.9% + 30¢ per successful card charge"
+    }
+  ],
+  "source_urls": ["https://stripe.com/pricing"],
+  "extraction_confidence": 0.85
+}
+```
+
+**Per-field confidence** in CSV quality columns is computed later in Stage 7 (quality scoring), not by the extraction LLM.
+
+---
+
+## Stage 6 — Merge
+
+Input: flat `ExtractedRecord[]` from all pages/agents in a phase.
+
+- Identity: `canonicalRecordId` uses the single `dedupe_keys[0]` value (`pk:{normalized_name}`).
+- `mergePair`: fills empty cells from newer records; unions evidence and `source_urls`.
+- Repair merge uses the same merge — **new primary keys add new rows**; existing keys update in place.
+
+---
+
+## Stage 7 — CoverageReport (code)
+
+```json
+{
+  "total_records": 12,
+  "required_columns": ["entity_name", "address", "serves_requested_item", "source_url"],
+  "field_gaps": [
+    {
+      "column": "serves_requested_item",
+      "description": "Menu shows Coca-Cola",
+      "missing_count": 8,
+      "missing_pct": 0.67,
+      "example_rows": [{ "entity_name": "Foo Bar", "serves_requested_item": null }]
+    }
+  ],
+  "should_repair": true,
+  "complete_count": 4,
+  "partial_count": 8,
+  "partial_record_ids": ["pk:foo bar", "..."]
+}
+```
+
+---
+
+## Stage 8 — Repair loop (optional)
+
+1. **RepairDiagnosis** (LLM) — why gaps remain, domain/query hints
+2. **RepairQueries** (LLM) — new search strings
+3. Repeat Search → Fetch → Triage → Extract
+4. `mergeRepairIntoExisting` — fill gaps **and** accept new entities
+
+Repair acquisition passes `knownEntityKeys` so triage can mark truly duplicate pages as `duplicate` (skipped). Triage should **not** mark `duplicate` when the page may still yield entities not in `known_entities` — those pages are extracted and can add new rows via merge.
+
+---
+
+## Stage 9 — Export
+
+| File | Contents |
+|------|----------|
+| `init_results.csv` | After first acquisition |
+| `results_full.csv` | All merged rows |
+| `results.csv` | Selective: all required fields filled, ranked by quality |
+| `evidence.jsonl` | Selective rows + evidence + quality metadata |
+| `run_report.json` | Full run stats |
+
+---
+
+## Benchmark vs CLI row counts
+
+Benchmark runs often report **fewer rows** than CLI for the same prompt. Common causes (not mutually exclusive):
+
+| Factor | Benchmark | CLI default |
+|--------|-----------|-------------|
+| `targetRows` | `COLLECTION_AGENT_TARGET_ROWS=8` | `-t 25` |
+| Row cap | `targetRows * 2` = 16 | 50 |
+| Repair | `COLLECTION_AGENT_ENABLE_REPAIR=false` | `ENABLE_REPAIR_LOOP=true` |
+| Output rows | Bridge uses **selective** `visualizationRecords` (`results.csv` filter) | User sees `results.csv` + `results_full.csv` |
+| Required columns | Harness `requiredColumns` merged into spec — partial rows fail selective filter | Spec from prompt only |
+
+**Example:** 16 partial rows merged, 0 with all benchmark required fields filled → `visualization_records=0` → benchmark JSON has 0 rows, while `results_full.csv` has 16.
+
+To compare fairly: use the same `targetRows`, repair flags, and read `results_full.csv` / disable `ENABLE_SELECTIVE_RESULTS` for harness output.
+
+---
+
+## Benchmark JSON contract (external)
+
+`backend/src/dataset-agent/collection-bridge.ts` maps `ExtractedRecord` → harness format:
+
+```json
+{
+  "rows": [
+    {
+      "cells": { "entity_name": "Example", "source_url": "https://..." },
+      "sourceUrls": ["https://..."],
+      "evidence": [{ "columnName": "entity_name", "sourceUrl": "https://...", "quote": "..." }],
+      "needsReview": false
+    }
+  ]
+}
+```
+
+By default rows come from selective export (complete required fields only).

--- a/backend/BigSet_Data_Collection_Agent/docs/v15-02-combined-triage-extract.md
+++ b/backend/BigSet_Data_Collection_Agent/docs/v15-02-combined-triage-extract.md
@@ -1,0 +1,52 @@
+# v1.5.2 — Combined triage + extract (shipped)
+
+**Status:** Implemented. Default in code; revert with `ENABLE_COMBINED_TRIAGE_EXTRACT=false`.
+
+## Goal
+
+Reduce **LLM tokens** on `extract_now` pages by replacing two calls (`triagePage` + `extractFromPage`) with **one** combined call that reuses the same page markdown and spec context.
+
+## Behavior (unchanged routing)
+
+| Status | Combined call | Pipeline |
+|--------|---------------|----------|
+| `extract_now` | `triage_results` + `extraction_results` | Records merged; memory attributed via triage + records |
+| `requires_*` | `triage_results` only (`records: []`) | Tinyfish agent → `extract-from-agent` |
+| Other | `triage_results` only | Skip |
+| Agent disabled + `requires_*` | Triage only in combined call | **Fallback** `extractFromPage` (same as v1.4) |
+
+## Per-source tracking
+
+`source_outcomes_{phase}.json` — array of:
+
+```json
+{
+  "url": "...",
+  "final_url": "...",
+  "triage_results": { "status": "extract_now", "..." },
+  "extraction_results": { "records": [...], "notes": "..." }
+}
+```
+
+`extraction_results` is `null` when no inline extract (e.g. `requires_navigation`).
+
+`triage_{phase}.json` is still written (list of `triage_results` only) for tools and memory that expect the prior shape.
+
+## Configuration
+
+```env
+ENABLE_COMBINED_TRIAGE_EXTRACT=true   # default
+TRIAGE_EXTRACT_MAX_PAGE_CHARS=24000 # default 2 × MAX_PAGE_CHARS
+TRIAGE_CONCURRENCY=10                 # default (was 5)
+```
+
+## Files
+
+- `src/agents/triage-extract.ts` — `triageAndExtractPage`, `buildTriageExtractCombinedSchema`
+- `src/orchestrator/process-pages.ts` — combined vs legacy paths, `source_outcomes_*` artifact
+- `src/agents/source-triage.ts` — legacy triage-only (unchanged)
+- `src/agents/extract.ts` — finalize + legacy/fallback extract
+
+## Revert
+
+Set `ENABLE_COMBINED_TRIAGE_EXTRACT=false` to restore v1.4 batched triage then separate extract (no `source_outcomes` inline records from combined call).

--- a/backend/BigSet_Data_Collection_Agent/docs/v15-efficiency-planned.md
+++ b/backend/BigSet_Data_Collection_Agent/docs/v15-efficiency-planned.md
@@ -1,0 +1,61 @@
+# v1.5: Efficiency improvements (planned)
+
+**Status:** v1.5.2 combined triage+extract **shipped**. v1.5.1 async two-call was reverted (latency-only). Revert combined: `ENABLE_COMBINED_TRIAGE_EXTRACT=false`.
+
+v1.5 targets **LLM token cost** (primary) and wall-clock time without regressing v1.4 row quality.
+
+---
+
+## Proposed themes
+
+### 1. Combined triage + extract — **shipped (v1.5.2)**
+
+See [v15-02-combined-triage-extract.md](v15-02-combined-triage-extract.md).
+
+- One LLM call per page: `{ triage_results, extraction_results }`.
+- `source_outcomes_{phase}.json` per-source triage + inline extraction.
+- Default `TRIAGE_CONCURRENCY=10`, 2× page chars for combined agent.
+
+### 2. Task-scoped workflow memory
+
+- Replace one `memoryContextForAgents()` blob with **per-role** slices (triage vs extract vs agent-goal vs repair).
+- Drop `query_stats.page_breakdown` from agent prompts; pass **domain-scoped** stats where helpful.
+- Largest token savings on high page-count phases.
+
+### 3. Outcome-based Tinyfish Agent
+
+- Today: `requires_*` triage → agent queue (no direct extract first).
+- Proposed: after direct extract + merge, run agents only if **complete required rows** &lt; target (with triage + cheap-extract gates).
+- Requires clearer metrics than raw `records_from_extract` (dedupe collapses many rows).
+
+### 4. Priority-ordered extract and agent queues
+
+- Sort pages by `source_data_confidence`, triage confidence, `domainMemoryBoost`.
+- Optional early exit when complete rows ≥ target (with minimum page floor).
+
+### 5. Adaptive agent polling
+
+- Avoid flat **30s** poll interval (adds ~15s average lag per run).
+- Proposed: 3s early, backoff to 10–30s, or 30s only for large batches.
+
+---
+
+## Success metrics
+
+Compare v1.4 vs v1.5 on the same `prompts.json` subset:
+
+| Metric | Source |
+|--------|--------|
+| `duration_ms` | `run_report.json` |
+| `llm_usage.total_tokens` | `run_report.json` |
+| `visualization_records` / complete count | `run_report.json`, `quality_report.json` |
+| Tinyfish agent dispatches | `stats.triage.agent_dispatched` |
+
+Quality must not drop systematically on the 4 “good” benchmark prompts.
+
+---
+
+## References
+
+- Architecture discussion (conversation): efficiency tradeoffs per proposal.
+- [data-flow.md](data-flow.md) — current stage contracts unchanged until v1.5 ships.

--- a/backend/BigSet_Data_Collection_Agent/src/acquisition/link-follow.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/acquisition/link-follow.ts
@@ -7,7 +7,7 @@ const SKIP_HOST =
   /(?:facebook|twitter|x\.com|instagram|youtube|tiktok|pinterest|reddit\.com\/r\/|linkedin\.com\/in\/|accounts\.google|login|signin|signup|register|cookie|privacy|terms|cdn\.|static\.|fonts\.)/i;
 const SKIP_EXT = /\.(?:pdf|zip|png|jpe?g|gif|svg|webp|css|js|woff2?|xml|mp4|mp3)(?:\?|$)/i;
 const POSITIVE_PATH =
-  /\/(?:company|companies|startup|startups|portfolio|team|about|careers|jobs|directory|list|batch|founder|org|organization|profile|detail|view)(?:\/|$|\?)/i;
+  /\/(?:blog|news|docs|documentation|pricing|billing|investor|investors|earnings|financial|reports|press|release|releases|mcp|model-context-protocol|agents|company|companies|startup|startups|portfolio|team|about|careers|jobs|directory|list|batch|founder|org|organization|profile|detail|view)(?:\/|$|\?)/i;
 const NEGATIVE_PATH =
   /\/(?:tag|tags|category|categories|author|feed|rss|search|wp-admin|wp-content)(?:\/|$|\?)/i;
 

--- a/backend/BigSet_Data_Collection_Agent/src/acquisition/link-follow.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/acquisition/link-follow.ts
@@ -1,0 +1,114 @@
+import type { FetchedPage } from "../models/schemas.js";
+import type { WorkflowMemory } from "../memory/types.js";
+import { domainMemoryBoost } from "../memory/workflow-memory.js";
+import { getDomain, normalizeUrl } from "../utils/url.js";
+
+const SKIP_HOST =
+  /(?:facebook|twitter|x\.com|instagram|youtube|tiktok|pinterest|reddit\.com\/r\/|linkedin\.com\/in\/|accounts\.google|login|signin|signup|register|cookie|privacy|terms|cdn\.|static\.|fonts\.)/i;
+const SKIP_EXT = /\.(?:pdf|zip|png|jpe?g|gif|svg|webp|css|js|woff2?|xml|mp4|mp3)(?:\?|$)/i;
+const POSITIVE_PATH =
+  /\/(?:company|companies|startup|startups|portfolio|team|about|careers|jobs|directory|list|batch|founder|org|organization|profile|detail|view)(?:\/|$|\?)/i;
+const NEGATIVE_PATH =
+  /\/(?:tag|tags|category|categories|author|feed|rss|search|wp-admin|wp-content)(?:\/|$|\?)/i;
+
+export interface LinkFollowOptions {
+  pages: FetchedPage[];
+  excludeUrls: Set<string>;
+  focusFields?: string[];
+  maxTotal: number;
+  maxPerSource: number;
+  memory?: WorkflowMemory;
+}
+
+function pathTokensFromFields(fields?: string[]): string[] {
+  if (!fields?.length) return [];
+  return fields
+    .flatMap((field) =>
+      field
+        .split(/[_\s-]+/)
+        .map((part) => part.toLowerCase())
+        .filter((part) => part.length > 3),
+    )
+    .slice(0, 12);
+}
+
+function scoreLink(
+  link: string,
+  sourceDomain: string,
+  focusTokens: string[],
+  memory?: WorkflowMemory,
+): number {
+  let score = 0;
+
+  try {
+    const parsed = new URL(link);
+    const host = parsed.hostname.toLowerCase();
+    const path = `${parsed.pathname}${parsed.search}`.toLowerCase();
+
+    if (SKIP_HOST.test(host) || SKIP_EXT.test(path)) return -1000;
+    if (NEGATIVE_PATH.test(path)) score -= 2;
+    if (POSITIVE_PATH.test(path)) score += 4;
+
+    const linkDomain = getDomain(link);
+    if (linkDomain === sourceDomain) score += 3;
+    else if (linkDomain.endsWith(`.${sourceDomain}`) || sourceDomain.endsWith(`.${linkDomain}`)) {
+      score += 2;
+    }
+
+    for (const token of focusTokens) {
+      if (path.includes(token)) score += 2;
+    }
+
+    if (memory) score += domainMemoryBoost(memory, linkDomain);
+
+    if (path.length > 120) score -= 1;
+    if (parsed.hash.length > 1) score -= 1;
+  } catch {
+    return -1000;
+  }
+
+  return score;
+}
+
+/** Pick outbound links from high-value pages using URL heuristics only. */
+export function selectOutboundLinksToFollow(
+  options: LinkFollowOptions,
+): string[] {
+  const focusTokens = pathTokensFromFields(options.focusFields);
+  const selected: string[] = [];
+  const selectedSet = new Set<string>();
+
+  const pagesWithLinks = options.pages
+    .filter((page) => !page.error && page.outbound_links && page.outbound_links.length > 0)
+    .sort((a, b) => (b.outbound_links?.length ?? 0) - (a.outbound_links?.length ?? 0));
+
+  for (const page of pagesWithLinks) {
+    const sourceUrl = normalizeUrl(page.final_url || page.url);
+    const sourceDomain = getDomain(sourceUrl);
+    let perSource = 0;
+
+    const ranked = [...(page.outbound_links ?? [])]
+      .map((link) => ({
+        link,
+        score: scoreLink(link, sourceDomain, focusTokens, options.memory),
+      }))
+      .filter((item) => item.score > 0)
+      .sort((a, b) => b.score - a.score);
+
+    for (const { link } of ranked) {
+      if (selected.length >= options.maxTotal) return selected;
+      if (perSource >= options.maxPerSource) break;
+
+      const normalized = normalizeUrl(link);
+      if (options.excludeUrls.has(normalized)) continue;
+      if (selectedSet.has(normalized)) continue;
+      if (normalized === sourceUrl) continue;
+
+      selectedSet.add(normalized);
+      selected.push(link);
+      perSource += 1;
+    }
+  }
+
+  return selected;
+}

--- a/backend/BigSet_Data_Collection_Agent/src/agents/agent-goal.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/agents/agent-goal.ts
@@ -1,0 +1,64 @@
+import { completeJson } from "../integrations/openrouter.js";
+import {
+  memoryContextForAgents,
+  type WorkflowMemory,
+} from "../memory/index.js";
+import { agentGoalSchema, type AgentGoal } from "../models/schemas.js";
+import type { DatasetSpec, SourceTriageResult } from "../models/schemas.js";
+
+const AGENT_GOAL_SYSTEM = `You are the Navigation Task Agent for a web data collection pipeline.
+
+Write a Tinyfish Agent goal: a clear natural-language instruction for browser automation on the given URL.
+
+The agent must navigate the site and return structured JSON with extracted data matching the dataset schema.
+
+Rules:
+- Be specific about what to click, search, filter, or paginate.
+- State the exact JSON shape to return: { "records": [ { column_name: value, ... } ] }
+- Include column names from the schema in the goal.
+- For forms: describe fields to fill and how to submit.
+- For detail follow-up: explain how to open each item and which fields to collect.
+- Limit scope (e.g. first 25 rows) to keep runs reliable.
+- Do not invent data; extract only what is visible on the site.
+- When workflow_memory is provided, reuse goal patterns from agent_goal_stats_top (high avg_completeness/confidence); avoid domains in domain_stats_weak unless diagnosis says otherwise.
+- If latest_diagnosis.prefer_tinyfish_agent or agent_strategy_notes exist, follow them.
+- Return ONLY JSON with fields: goal, rationale`;
+
+export async function generateAgentGoal(options: {
+  userPrompt: string;
+  spec: DatasetSpec;
+  triage: SourceTriageResult;
+  focusFields?: string[];
+  memory?: WorkflowMemory;
+}): Promise<AgentGoal> {
+  const columnList = options.spec.columns
+    .map((c) => `${c.name} (${c.type}${c.required ? ", required" : ""})`)
+    .join(", ");
+
+  return completeJson({
+    label: `agent_goal:${options.triage.final_url}`,
+    schema: agentGoalSchema,
+    messages: [
+      { role: "system", content: AGENT_GOAL_SYSTEM },
+      {
+        role: "user",
+        content: JSON.stringify({
+          user_prompt: options.userPrompt,
+          triage_status: options.triage.status,
+          triage_reasoning: options.triage.reasoning,
+          suggested_action: options.triage.suggested_action,
+          page_url: options.triage.final_url,
+          page_title: options.triage.title,
+          row_grain: options.spec.row_grain,
+          columns: columnList,
+          focus_fields: options.focusFields ?? [],
+          extraction_hints: options.spec.extraction_hints,
+          workflow_memory: options.memory
+            ? memoryContextForAgents(options.memory)
+            : undefined,
+          output_shape: { goal: "string", rationale: "string" },
+        }),
+      },
+    ],
+  });
+}

--- a/backend/BigSet_Data_Collection_Agent/src/agents/benchmark-spec.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/agents/benchmark-spec.ts
@@ -1,0 +1,94 @@
+import type { ColumnDef, DatasetSpec } from "../models/schemas.js";
+import { normalizeSpecColumnOrder } from "./dataset-spec.js";
+
+/** Benchmark harness fields from prompts.json (via env in adapters). */
+export interface BenchmarkSpecContext {
+  promptId?: string;
+  promptQuality?: string;
+  persona?: string;
+  expectedStress?: string;
+  requiredColumns: string[];
+}
+
+export function hasBenchmarkRequiredColumns(
+  context?: BenchmarkSpecContext,
+): context is BenchmarkSpecContext & { requiredColumns: string[] } {
+  return Boolean(context?.requiredColumns?.length);
+}
+
+/** Parse comma-separated column names (CLI flag or benchmark env). */
+export function parseRequiredColumns(value: string): string[] {
+  const columns = value
+    .split(",")
+    .map((name) => name.trim())
+    .filter(Boolean);
+  if (columns.length === 0) {
+    throw new Error(
+      "Required columns must include at least one non-empty column name.",
+    );
+  }
+  return columns;
+}
+
+/**
+ * Ensures every benchmark-required column name exists on the spec as required.
+ * Types and descriptions come from the dataset-spec LLM when present; otherwise
+ * minimal placeholders (no per-column name heuristics).
+ */
+export function mergeSpecWithBenchmarkRequiredColumns(
+  spec: DatasetSpec,
+  context: BenchmarkSpecContext,
+): DatasetSpec {
+  const requiredColumns = context.requiredColumns;
+  const columnsByName = new Map(spec.columns.map((column) => [column.name, column]));
+
+  const requiredColumnDefs: ColumnDef[] = requiredColumns.map((name) => {
+    const existing = columnsByName.get(name);
+    if (existing) {
+      return { ...existing, required: true };
+    }
+    return {
+      name,
+      type: "string",
+      description: name,
+      required: true,
+    };
+  });
+
+  const optionalExtras = spec.columns.filter(
+    (column) => !requiredColumns.includes(column.name),
+  );
+
+  const columns = [...requiredColumnDefs, ...optionalExtras];
+  const columnNames = new Set(columns.map((column) => column.name));
+
+  const isEntityLikeColumn = (name: string): boolean =>
+    /(entity|company|organization|business|restaurant|bakery|provider|product|name|title)/i.test(
+      name,
+    );
+
+  const dedupeKey =
+    requiredColumns.find(
+      (name) => columnNames.has(name) && isEntityLikeColumn(name),
+    ) ??
+    spec.dedupe_keys.find((key) => columnNames.has(key)) ??
+    requiredColumns.find((name) => columnNames.has(name)) ??
+    spec.dedupe_keys[0];
+
+  const extractionHints = [
+    spec.extraction_hints,
+    `Benchmark required columns (use as exact row keys): ${requiredColumns.join(", ")}.`,
+    context.expectedStress
+      ? `Benchmark stress note: ${context.expectedStress}`
+      : undefined,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return normalizeSpecColumnOrder({
+    ...spec,
+    columns,
+    dedupe_keys: dedupeKey ? [dedupeKey] : spec.dedupe_keys,
+    extraction_hints: extractionHints,
+  });
+}

--- a/backend/BigSet_Data_Collection_Agent/src/agents/dataset-spec.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/agents/dataset-spec.ts
@@ -10,6 +10,7 @@ import {
   mergeSpecWithBenchmarkRequiredColumns,
   type BenchmarkSpecContext,
 } from "./benchmark-spec.js";
+import { applyPromptSourcePolicyToSpec } from "./source-policy.js";
 
 const DATASET_SPEC_SYSTEM = `You are the Dataset Spec Agent for a web data collection pipeline.
 
@@ -182,6 +183,8 @@ export async function generateDatasetSpec(
       target_row_count: targetRows,
     }),
   );
+
+  normalized = applyPromptSourcePolicyToSpec(normalized, prompt);
 
   if (hasBenchmarkRequiredColumns(benchmark)) {
     normalized = mergeSpecWithBenchmarkRequiredColumns(normalized, benchmark);

--- a/backend/BigSet_Data_Collection_Agent/src/agents/dataset-spec.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/agents/dataset-spec.ts
@@ -1,0 +1,191 @@
+import { completeJson } from "../integrations/openrouter.js";
+import type { WorkflowMemory } from "../memory/types.js";
+import {
+  datasetSpecSchema,
+  type ColumnDef,
+  type DatasetSpec,
+} from "../models/schemas.js";
+import {
+  hasBenchmarkRequiredColumns,
+  mergeSpecWithBenchmarkRequiredColumns,
+  type BenchmarkSpecContext,
+} from "./benchmark-spec.js";
+
+const DATASET_SPEC_SYSTEM = `You are the Dataset Spec Agent for a web data collection pipeline.
+
+Given a user's data gathering prompt, produce a JSON object that defines:
+- what each CSV row represents (row_grain)
+- column names, types, and which are required
+- dedupe_keys: exactly ONE column name that identifies a unique row (the main entity field, e.g. entity_name or restaurant_name — used as primary key for merge/repair)
+- search_queries: diverse web search strings to find sources (use site: operators when helpful)
+- extraction_hints: guidance for downstream extraction
+
+Rules:
+- columns[].name must be snake_case
+- types must be one of: string, number, boolean, date
+- Column order: list every required column first (see ordering below), then optional columns. Do not bury required fields after optional metadata.
+- Required columns (required: true):
+  - The single dedupe_keys field must be required: true.
+  - Every column that the user_prompt explicitly or clearly implies they want per row (e.g. "who's hiring" → is_hiring; "still active" → is_active; "funding amount" → funding column) must be required: true.
+  - Do NOT mark only the entity name/identifier as required while leaving core intent fields optional — that blocks the repair loop from filling sparse rows.
+  - Optional (required: false) only for nice-to-have extras the user did not ask for (e.g. logo_url when they only care about hiring status).
+- Required column ordering within columns[]:
+  1. the dedupe_keys field first
+  2. other required intent fields (what the user asked to collect)
+  3. optional fields last
+- For type "number", embed the measurement unit in the column name using snake_case
+  (e.g. funding_amount_usd(millions), employee_count, market_cap_million_usd, growth_rate_percent).
+  Choose units that match the user's intent; describe the unit in columns[].description when helpful.
+  Do not use bare numeric names like "amount", "price", or "funding" without a unit, for example, if the
+  numeric value is in millions, use "funding_amount_million_usd" instead of "funding_amount_usd".
+- search_queries should be specific, varied (5-8 queries), and likely to surface pages with list/table data
+- Temporal relevance for search_queries:
+  - Use the provided current_date / current_year when a query needs a time anchor (e.g. "2026", "latest", "recent").
+  - Do NOT default to past years (e.g. 2024) unless the user_prompt explicitly names that year or date range.
+  - If the user says "recent", "current", "latest", or implies up-to-date data, anchor queries to current_year.
+  - If the user gives no time constraint, prefer evergreen queries OR current_year only when recency clearly matters for the dataset.
+  - If the user specifies a year or date (e.g. "in 2024", "Q1 2023"), use exactly what they asked for.
+- target_row_count should reflect the user's implied or stated goal
+- Return ONLY JSON, no markdown`;
+
+function currentTimeContext(): { current_date: string; current_year: number } {
+  const now = new Date();
+  return {
+    current_date: now.toISOString().slice(0, 10),
+    current_year: now.getFullYear(),
+  };
+}
+
+/** Ensure exactly one valid dedupe key exists on the spec. */
+export function normalizeDedupeKey(spec: DatasetSpec): DatasetSpec {
+  const columnNames = new Set(spec.columns.map((column) => column.name));
+  let key = spec.dedupe_keys[0];
+
+  if (!key || !columnNames.has(key)) {
+    const firstRequired = spec.columns.find((column) => column.required);
+    key = firstRequired?.name ?? spec.columns[0]?.name ?? key;
+  }
+
+  if (!key) {
+    return spec;
+  }
+
+  return { ...spec, dedupe_keys: [key] };
+}
+
+/** Enforce required-first column order even if the model returns a different order. */
+export function normalizeSpecColumnOrder(spec: DatasetSpec): DatasetSpec {
+  const byName = new Map(spec.columns.map((col) => [col.name, col]));
+  const ordered: ColumnDef[] = [];
+  const used = new Set<string>();
+
+  for (const key of spec.dedupe_keys.slice(0, 1)) {
+    const col = byName.get(key);
+    if (!col || used.has(key)) continue;
+    ordered.push({ ...col, required: true });
+    used.add(key);
+  }
+
+  for (const col of spec.columns) {
+    if (used.has(col.name) || !col.required) continue;
+    ordered.push(col);
+    used.add(col.name);
+  }
+
+  for (const col of spec.columns) {
+    if (used.has(col.name)) continue;
+    ordered.push(col);
+    used.add(col.name);
+  }
+
+  return { ...spec, columns: ordered };
+}
+
+export async function generateDatasetSpec(
+  prompt: string,
+  targetRows: number,
+  priorMemory?: WorkflowMemory | null,
+  benchmark?: BenchmarkSpecContext,
+): Promise<DatasetSpec> {
+  const { current_date, current_year } = currentTimeContext();
+
+  const spec = await completeJson({
+    label: "dataset_spec",
+    schema: datasetSpecSchema,
+    messages: [
+      { role: "system", content: DATASET_SPEC_SYSTEM },
+      {
+        role: "user",
+        content: JSON.stringify({
+          user_prompt: prompt,
+          target_row_count: targetRows,
+          current_date,
+          current_year,
+          prior_workflow_memory:
+            priorMemory && priorMemory.prompt_fingerprint
+              ? {
+                  query_stats_top: [...priorMemory.query_stats]
+                    .filter((q) => q.record_count > 0)
+                    .slice(-8),
+                  domain_stats_top: [...priorMemory.domain_stats]
+                    .filter((d) => d.record_count > 0)
+                    .slice(-8),
+                  domain_stats_weak: [...priorMemory.domain_stats]
+                    .filter(
+                      (d) =>
+                        d.fetch_failures > 0 ||
+                        (d.record_count > 0 && d.avg_completeness < 0.5),
+                    )
+                    .slice(-6),
+                  dedupe_keys: priorMemory.dedupe_keys,
+                  strategy_notes: priorMemory.strategy_notes.slice(-5),
+                }
+              : undefined,
+          column_order_note:
+            "required columns first: dedupe_keys in order, then other required intent fields, then optional",
+          benchmark_context: hasBenchmarkRequiredColumns(benchmark)
+            ? {
+                prompt_id: benchmark.promptId,
+                prompt_quality: benchmark.promptQuality,
+                persona: benchmark.persona,
+                expected_stress: benchmark.expectedStress,
+                required_columns: benchmark.requiredColumns,
+                instruction:
+                  "When required_columns is present, columns[].name MUST use those exact snake_case names as the core schema (all required: true). You may add optional extra columns only if they do not replace or rename required_columns. Align search_queries and extraction_hints to satisfy the user_prompt and expected_stress.",
+              }
+            : undefined,
+          output_shape: {
+            intent_summary: "string",
+            target_row_count: "number",
+            row_grain: "string",
+            columns: [
+              {
+                name: "string (snake_case)",
+                type: "string | number | boolean | date",
+                description: "string",
+                required:
+                  "boolean — true for dedupe_keys and every field the user_prompt asks to collect per row",
+              },
+            ],
+            dedupe_keys: ["string — exactly one primary entity column name"],
+            search_queries: ["string"],
+            extraction_hints: "string",
+          },
+        }),
+      },
+    ],
+  });
+
+  let normalized = normalizeDedupeKey(
+    normalizeSpecColumnOrder({
+      ...spec,
+      target_row_count: targetRows,
+    }),
+  );
+
+  if (hasBenchmarkRequiredColumns(benchmark)) {
+    normalized = mergeSpecWithBenchmarkRequiredColumns(normalized, benchmark);
+  }
+
+  return normalized;
+}

--- a/backend/BigSet_Data_Collection_Agent/src/agents/extract-from-agent.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/agents/extract-from-agent.ts
@@ -1,0 +1,82 @@
+import { completeJson } from "../integrations/openrouter.js";
+import {
+  memoryContextForAgents,
+  type WorkflowMemory,
+} from "../memory/index.js";
+import type { DatasetSpec, ExtractedRecord } from "../models/schemas.js";
+import {
+  buildLlmExtractionResultSchema,
+  finalizeExtractedRecords,
+  type LlmExtractionRecord,
+} from "./extract.js";
+
+/**
+ * Parses one Tinyfish agent result JSON per call (see process-pages.ts agent branch).
+ * Not used for fetched-page markdown; that path uses extractFromPage.
+ */
+
+const EXTRACT_AGENT_SYSTEM = `You are the Extraction Agent parsing output from a Tinyfish browser automation run.
+
+Convert the agent result JSON into dataset records matching the schema.
+
+Rules:
+- Only include facts present in the agent result. Do not invent values.
+- row keys must match spec column names exactly.
+- For number columns, numeric values only (unit is in the column name).
+- evidence: field, quote, and url for fields you populated when you have a supporting quote (url = where that quote was found; use page_url when from this page). Not required for every column.
+- Do not return source_urls.
+- extraction_confidence (0–1) per record when possible.
+- Provenance URL columns: set per row to the URL where that row's data came from (use page_url when appropriate).
+- If the agent result has no usable rows, return an empty records array.
+- Return ONLY JSON`;
+
+export async function extractFromAgentResult(options: {
+  spec: DatasetSpec;
+  pageUrl: string;
+  agentResult: Record<string, unknown> | null;
+  focusFields?: string[];
+  memory?: WorkflowMemory;
+}): Promise<ExtractedRecord[]> {
+  if (!options.agentResult || Object.keys(options.agentResult).length === 0) {
+    return [];
+  }
+
+  const result = await completeJson({
+    label: `extract_agent:${options.pageUrl}`,
+    schema: buildLlmExtractionResultSchema(options.spec),
+    messages: [
+      { role: "system", content: EXTRACT_AGENT_SYSTEM },
+      {
+        role: "user",
+        content: JSON.stringify({
+          dataset_spec: {
+            intent_summary: options.spec.intent_summary,
+            row_grain: options.spec.row_grain,
+            columns: options.spec.columns,
+          },
+          page_url: options.pageUrl,
+          agent_result: options.agentResult,
+          focus_fields: options.focusFields ?? [],
+          workflow_memory: options.memory
+            ? memoryContextForAgents(options.memory)
+            : undefined,
+          output_shape: {
+            records: [
+              {
+                row: { column_name: "value or null" },
+                evidence: [{ field: "column_name", url: "string", quote: "string" }],
+                extraction_confidence: "0-1 number",
+              },
+            ],
+          },
+        }),
+      },
+    ],
+  });
+
+  return finalizeExtractedRecords(
+    result.records as LlmExtractionRecord[],
+    options.pageUrl,
+    options.spec,
+  );
+}

--- a/backend/BigSet_Data_Collection_Agent/src/agents/extract.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/agents/extract.ts
@@ -13,6 +13,7 @@ import {
   type ExtractedRecord,
   type FetchedPage,
 } from "../models/schemas.js";
+import { deriveRecordSourceUrls } from "../records/source-urls.js";
 
 /**
  * Extraction is always one source per LLM call in process-pages.ts:
@@ -169,19 +170,6 @@ function provenanceUrlColumns(spec: DatasetSpec): ColumnDef[] {
   return spec.columns.filter(isProvenanceUrlColumn);
 }
 
-function collectSourceUrls(
-  pageUrl: string,
-  evidence: Array<{ url?: string }>,
-): string[] {
-  const urls = new Set<string>([pageUrl]);
-  for (const item of evidence) {
-    if (item.url?.startsWith("http")) {
-      urls.add(item.url);
-    }
-  }
-  return [...urls];
-}
-
 /** Attach evidence URLs and source_urls; keep LLM row and provenance values. */
 export function finalizeExtractedRecord(
   record: LlmExtractionRecord,
@@ -203,7 +191,12 @@ export function finalizeExtractedRecord(
     }
   }
 
-  const source_urls = collectSourceUrls(pageUrl, evidence);
+  const source_urls = deriveRecordSourceUrls({
+    spec,
+    row,
+    evidence,
+    fallbackUrls: [pageUrl],
+  });
 
   return extractedRecordSchema.parse({
     row,

--- a/backend/BigSet_Data_Collection_Agent/src/agents/extract.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/agents/extract.ts
@@ -13,16 +13,12 @@ import {
   type ExtractedRecord,
   type FetchedPage,
 } from "../models/schemas.js";
-import {
-  deriveRecordSourceUrls,
-  isHttpUrl,
-  isUrlLikeColumnName,
-} from "../records/source-urls.js";
 
 /**
- * Extraction is always one source per LLM call in process-pages.ts:
- * - extractFromPage: one fetched page's markdown per call (parallelized per page).
- * - extractFromAgentResult: one Tinyfish agent JSON payload per call (separate module).
+ * Extraction paths in process-pages.ts:
+ * - triageAndExtractPage (v1.5.2 default): combined triage + inline extract for extract_now.
+ * - extractFromPage: triage disabled, agent-disabled fallback, combined failure fallback, legacy mode.
+ * - extractFromAgentResult: Tinyfish agent JSON payload per call (separate module).
  *
  * LLM returns row + sparse evidence + extraction_confidence; code attaches evidence URLs
  * and source_urls. Provenance URL columns come from the LLM row values per record.
@@ -174,29 +170,17 @@ function provenanceUrlColumns(spec: DatasetSpec): ColumnDef[] {
   return spec.columns.filter(isProvenanceUrlColumn);
 }
 
-function isUrlLikeColumn(column: ColumnDef): boolean {
-  return isUrlLikeColumnName(column.name);
-}
-
-function addUrlCellEvidence(
-  row: Record<string, string | number | boolean | null>,
-  evidence: ExtractedRecord["evidence"],
-  spec: DatasetSpec,
-): void {
-  const fieldsWithEvidence = new Set(evidence.map((item) => item.field));
-  for (const column of spec.columns) {
-    if (!isUrlLikeColumn(column) || fieldsWithEvidence.has(column.name)) {
-      continue;
+function collectSourceUrls(
+  pageUrl: string,
+  evidence: Array<{ url?: string }>,
+): string[] {
+  const urls = new Set<string>([pageUrl]);
+  for (const item of evidence) {
+    if (item.url?.startsWith("http")) {
+      urls.add(item.url);
     }
-    const value = row[column.name];
-    if (!isHttpUrl(value)) continue;
-    evidence.push({
-      field: column.name,
-      url: value.trim(),
-      quote: value.trim(),
-    });
-    fieldsWithEvidence.add(column.name);
   }
+  return [...urls];
 }
 
 /** Attach evidence URLs and source_urls; keep LLM row and provenance values. */
@@ -219,14 +203,8 @@ export function finalizeExtractedRecord(
       row[column.name] = pageUrl;
     }
   }
-  addUrlCellEvidence(row, evidence, spec);
 
-  const source_urls = deriveRecordSourceUrls({
-    spec,
-    row,
-    evidence,
-    fallbackUrls: [pageUrl],
-  });
+  const source_urls = collectSourceUrls(pageUrl, evidence);
 
   return extractedRecordSchema.parse({
     row,

--- a/backend/BigSet_Data_Collection_Agent/src/agents/extract.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/agents/extract.ts
@@ -13,7 +13,11 @@ import {
   type ExtractedRecord,
   type FetchedPage,
 } from "../models/schemas.js";
-import { deriveRecordSourceUrls } from "../records/source-urls.js";
+import {
+  deriveRecordSourceUrls,
+  isHttpUrl,
+  isUrlLikeColumnName,
+} from "../records/source-urls.js";
 
 /**
  * Extraction is always one source per LLM call in process-pages.ts:
@@ -170,6 +174,31 @@ function provenanceUrlColumns(spec: DatasetSpec): ColumnDef[] {
   return spec.columns.filter(isProvenanceUrlColumn);
 }
 
+function isUrlLikeColumn(column: ColumnDef): boolean {
+  return isUrlLikeColumnName(column.name);
+}
+
+function addUrlCellEvidence(
+  row: Record<string, string | number | boolean | null>,
+  evidence: ExtractedRecord["evidence"],
+  spec: DatasetSpec,
+): void {
+  const fieldsWithEvidence = new Set(evidence.map((item) => item.field));
+  for (const column of spec.columns) {
+    if (!isUrlLikeColumn(column) || fieldsWithEvidence.has(column.name)) {
+      continue;
+    }
+    const value = row[column.name];
+    if (!isHttpUrl(value)) continue;
+    evidence.push({
+      field: column.name,
+      url: value.trim(),
+      quote: value.trim(),
+    });
+    fieldsWithEvidence.add(column.name);
+  }
+}
+
 /** Attach evidence URLs and source_urls; keep LLM row and provenance values. */
 export function finalizeExtractedRecord(
   record: LlmExtractionRecord,
@@ -190,6 +219,7 @@ export function finalizeExtractedRecord(
       row[column.name] = pageUrl;
     }
   }
+  addUrlCellEvidence(row, evidence, spec);
 
   const source_urls = deriveRecordSourceUrls({
     spec,

--- a/backend/BigSet_Data_Collection_Agent/src/agents/extract.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/agents/extract.ts
@@ -1,0 +1,289 @@
+import { z } from "zod";
+import { config } from "../config.js";
+import { completeJson } from "../integrations/openrouter.js";
+import {
+  memoryContextForAgents,
+  type WorkflowMemory,
+} from "../memory/index.js";
+import {
+  extractedRecordSchema,
+  fieldEvidenceSchema,
+  type ColumnDef,
+  type DatasetSpec,
+  type ExtractedRecord,
+  type FetchedPage,
+} from "../models/schemas.js";
+
+/**
+ * Extraction is always one source per LLM call in process-pages.ts:
+ * - extractFromPage: one fetched page's markdown per call (parallelized per page).
+ * - extractFromAgentResult: one Tinyfish agent JSON payload per call (separate module).
+ *
+ * LLM returns row + sparse evidence + extraction_confidence; code attaches evidence URLs
+ * and source_urls. Provenance URL columns come from the LLM row values per record.
+ */
+
+const llmFieldEvidenceSchema = fieldEvidenceSchema
+  .omit({ url: true })
+  .extend({ url: z.string().optional() });
+
+export type LlmExtractionRecord = {
+  row: Record<string, string | number | boolean | null>;
+  evidence: z.infer<typeof llmFieldEvidenceSchema>[];
+  extraction_confidence?: number;
+};
+
+function columnValueSchema(
+  column: ColumnDef,
+): z.ZodType<string | number | boolean | null> {
+  switch (column.type) {
+    case "number":
+      return z.union([z.number(), z.null()]);
+    case "boolean":
+      return z.union([z.boolean(), z.null()]);
+    default:
+      return z.union([z.string(), z.null()]);
+  }
+}
+
+/** Explicit column keys so AI SDK structured output guides the model to populate row fields. */
+export function buildLlmExtractionResultSchema(spec: DatasetSpec) {
+  const rowShape: Record<string, z.ZodTypeAny> = {};
+  for (const column of spec.columns) {
+    rowShape[column.name] = columnValueSchema(column);
+  }
+
+  const llmExtractionRecordSchema = z.object({
+    row: z.object(rowShape),
+    evidence: z.array(llmFieldEvidenceSchema),
+    extraction_confidence: z.number().min(0).max(1).optional(),
+  });
+
+  return z.object({
+    records: z.array(llmExtractionRecordSchema),
+    notes: z.string().optional(),
+  });
+}
+
+const EXTRACTION_SYSTEM = `You are the Extraction Agent for a web data collection pipeline.
+
+Extract structured records from the provided page content according to the dataset specification.
+
+Rules:
+- Only extract facts supported by the page text. Do not invent data.
+- row keys must match spec column names exactly.
+- For columns with type "number", store numeric values only (no unit text in the value; the unit is already in the column name).
+- Use null for unknown values.
+- Return multiple records if the page lists multiple entities matching row_grain.
+- If the page has no relevant data, return an empty records array.
+- evidence: include field, quote, and url for fields you populated when you have a supporting quote (url = where that quote was found; use the page URL when from this page). Not required for every column.
+- Do not return source_urls on the record.
+- extraction_confidence (0–1): how confident you are this row is accurate.
+- Provenance URL columns (e.g. source_url, evidence_url, or columns described as where data was found): set each row's value to the URL where that row's facts came from — use the provided page URL when all fields for that row are from this page, or a more specific URL only if clearly stated on the page.
+- Do not copy unrelated URLs into provenance columns (e.g. do not set source_url to the page URL when pricing_page_url already holds the pricing URL and source_url should cite where you read the plan).
+- Return ONLY JSON`;
+
+function truncatePageText(text: string): string {
+  if (text.length <= config.maxPageChars) return text;
+  return `${text.slice(0, config.maxPageChars)}\n\n[truncated]`;
+}
+
+function isEmpty(value: unknown): boolean {
+  return value === null || value === undefined || value === "";
+}
+
+function coerceEvidenceToColumnValue(
+  column: ColumnDef,
+  quote: string,
+): string | number | boolean | null {
+  const trimmed = quote.trim();
+  if (!trimmed) return null;
+
+  switch (column.type) {
+    case "boolean": {
+      const lower = trimmed.toLowerCase();
+      if (
+        /\b(true|yes|active|hiring|looking for|open roles|open positions|join us|join our team|we(?:'re| are) hiring|see open roles)\b/.test(
+          lower,
+        )
+      ) {
+        return true;
+      }
+      if (
+        /\b(false|no|not hiring|no careers|does not contain|lack of|without)\b/.test(
+          lower,
+        )
+      ) {
+        return false;
+      }
+      return null;
+    }
+    case "number": {
+      const parsed = Number(trimmed.replace(/,/g, ""));
+      return Number.isFinite(parsed) ? parsed : null;
+    }
+    default:
+      return trimmed;
+  }
+}
+
+function hydrateRowFromEvidence(
+  row: Record<string, string | number | boolean | null>,
+  evidence: Array<{ field: string; quote: string }>,
+  spec: DatasetSpec,
+): void {
+  const columnByName = new Map(spec.columns.map((column) => [column.name, column]));
+
+  for (const item of evidence) {
+    if (isEmpty(row[item.field])) {
+      const column = columnByName.get(item.field);
+      if (!column) continue;
+      const value = coerceEvidenceToColumnValue(column, item.quote);
+      if (value !== null) {
+        row[item.field] = value;
+      }
+    }
+  }
+}
+
+/** Columns meant to hold a citation URL for where row data was found (not content URLs). */
+export function isProvenanceUrlColumn(column: ColumnDef): boolean {
+  const name = column.name.toLowerCase();
+  if (name === "source_url" || name === "evidence_url") {
+    return true;
+  }
+  if (name.endsWith("_source_url")) {
+    return true;
+  }
+  const description = column.description.toLowerCase();
+  return (
+    name.includes("source") &&
+    name.includes("url") &&
+    (description.includes("evidence") ||
+      description.includes("provenance") ||
+      description.includes("where"))
+  );
+}
+
+function provenanceUrlColumns(spec: DatasetSpec): ColumnDef[] {
+  return spec.columns.filter(isProvenanceUrlColumn);
+}
+
+function collectSourceUrls(
+  pageUrl: string,
+  evidence: Array<{ url?: string }>,
+): string[] {
+  const urls = new Set<string>([pageUrl]);
+  for (const item of evidence) {
+    if (item.url?.startsWith("http")) {
+      urls.add(item.url);
+    }
+  }
+  return [...urls];
+}
+
+/** Attach evidence URLs and source_urls; keep LLM row and provenance values. */
+export function finalizeExtractedRecord(
+  record: LlmExtractionRecord,
+  pageUrl: string,
+  spec: DatasetSpec,
+): ExtractedRecord {
+  const row = { ...record.row };
+  hydrateRowFromEvidence(row, record.evidence, spec);
+
+  const evidence = record.evidence.map((item) => ({
+    field: item.field,
+    quote: item.quote,
+    url: item.url?.trim() || pageUrl,
+  }));
+
+  for (const column of provenanceUrlColumns(spec)) {
+    if (column.required && isEmpty(row[column.name])) {
+      row[column.name] = pageUrl;
+    }
+  }
+
+  const source_urls = collectSourceUrls(pageUrl, evidence);
+
+  return extractedRecordSchema.parse({
+    row,
+    evidence,
+    source_urls,
+    ...(record.extraction_confidence !== undefined
+      ? { extraction_confidence: record.extraction_confidence }
+      : {}),
+  });
+}
+
+export function finalizeExtractedRecords(
+  records: LlmExtractionRecord[],
+  pageUrl: string,
+  spec: DatasetSpec,
+): ExtractedRecord[] {
+  return records.map((record) => finalizeExtractedRecord(record, pageUrl, spec));
+}
+
+export interface ExtractOptions {
+  focusFields?: string[];
+}
+
+export async function extractFromPage(
+  spec: DatasetSpec,
+  page: FetchedPage,
+  options: ExtractOptions & { memory?: WorkflowMemory } = {},
+): Promise<ExtractedRecord[]> {
+  if (page.error || !page.text.trim()) {
+    return [];
+  }
+
+  const pageUrl = page.final_url || page.url;
+  const result = await completeJson({
+    label: `extraction:${pageUrl}`,
+    schema: buildLlmExtractionResultSchema(spec),
+    messages: [
+      { role: "system", content: EXTRACTION_SYSTEM },
+      {
+        role: "user",
+        content: JSON.stringify({
+          dataset_spec: {
+            intent_summary: spec.intent_summary,
+            row_grain: spec.row_grain,
+            columns: spec.columns,
+            extraction_hints: spec.extraction_hints,
+          },
+          page: {
+            url: pageUrl,
+            title: page.title,
+            text: truncatePageText(page.text),
+          },
+          ...(options.focusFields?.length
+            ? {
+                focus_fields: options.focusFields,
+                instruction:
+                  "Prioritize extracting focus_fields. Use null only when the page truly lacks that information.",
+              }
+            : {}),
+          workflow_memory: options.memory
+            ? memoryContextForAgents(options.memory)
+            : undefined,
+          output_shape: {
+            records: [
+              {
+                row: { column_name: "value or null" },
+                evidence: [{ field: "column_name", url: "string", quote: "string" }],
+                extraction_confidence: "0-1 number",
+              },
+            ],
+            notes: "optional string",
+          },
+        }),
+      },
+    ],
+  });
+
+  return finalizeExtractedRecords(
+    result.records as LlmExtractionRecord[],
+    pageUrl,
+    spec,
+  );
+}

--- a/backend/BigSet_Data_Collection_Agent/src/agents/repair-diagnosis.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/agents/repair-diagnosis.ts
@@ -1,0 +1,80 @@
+import type { CoverageReport } from "../coverage/analyze.js";
+import { completeJson } from "../integrations/openrouter.js";
+import {
+  memoryContextForAgents,
+  type WorkflowMemory,
+} from "../memory/index.js";
+import { repairDiagnosisSchema, type RepairDiagnosis } from "../memory/types.js";
+import type { DatasetSpec } from "../models/schemas.js";
+import type { SourcesReport } from "../models/quality.js";
+
+const DIAGNOSIS_SYSTEM = `You are the Repair Diagnosis Agent for a web data collection pipeline.
+
+A repair loop just finished (or is about to start). Analyze workflow memory, coverage gaps, and source outcomes to explain what failed and how the next search/fetch/agent pass should change.
+
+Rules:
+- Be specific and actionable — cite domains, query patterns, and triage/agent failures from memory when relevant.
+- recommended_search_patterns: concrete query templates or angles (not duplicates of failed_queries).
+- domains_to_prioritize: hosts that previously yielded records or match the missing fields.
+- domains_to_avoid: hosts that failed fetch, blocked, or returned no usable rows.
+- prefer_tinyfish_agent: true when static fetch/extract failed but navigation or forms are likely needed.
+- extraction_notes: hints for extract agents (e.g. which columns are still null, evidence issues).
+- Return ONLY JSON`;
+
+export async function generateRepairDiagnosis(options: {
+  userPrompt: string;
+  spec: DatasetSpec;
+  coverage: CoverageReport;
+  memory: WorkflowMemory;
+  sources?: SourcesReport;
+  repairLoop: number;
+  maxRepairLoops: number;
+}): Promise<RepairDiagnosis> {
+  const failedOutcomes =
+    options.sources?.failed.slice(0, 20).map((item) => ({
+      url: item.url,
+      outcome: item.outcome,
+      error: item.error?.slice(0, 120),
+    })) ?? [];
+
+  return completeJson({
+    label: `repair_diagnosis:loop${options.repairLoop}`,
+    schema: repairDiagnosisSchema,
+    messages: [
+      { role: "system", content: DIAGNOSIS_SYSTEM },
+      {
+        role: "user",
+        content: JSON.stringify({
+          user_prompt: options.userPrompt,
+          repair_loop: options.repairLoop,
+          max_repair_loops: options.maxRepairLoops,
+          dataset_spec: {
+            intent_summary: options.spec.intent_summary,
+            row_grain: options.spec.row_grain,
+            columns: options.spec.columns,
+            dedupe_keys: options.spec.dedupe_keys,
+          },
+          coverage: {
+            total_records: options.coverage.total_records,
+            complete_count: options.coverage.complete_count,
+            partial_count: options.coverage.partial_count,
+            required_columns: options.coverage.required_columns,
+            field_gaps: options.coverage.field_gaps,
+          },
+          source_failures_sample: failedOutcomes,
+          workflow_memory: memoryContextForAgents(options.memory),
+          output_shape: {
+            summary: "string",
+            likely_causes: ["string"],
+            recommended_search_patterns: ["string"],
+            domains_to_prioritize: ["string"],
+            domains_to_avoid: ["string"],
+            prefer_tinyfish_agent: "boolean",
+            agent_strategy_notes: "optional string",
+            extraction_notes: "optional string",
+          },
+        }),
+      },
+    ],
+  });
+}

--- a/backend/BigSet_Data_Collection_Agent/src/agents/repair-queries.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/agents/repair-queries.ts
@@ -1,0 +1,108 @@
+import { z } from "zod";
+import type { CoverageReport } from "../coverage/analyze.js";
+import { completeJson } from "../integrations/openrouter.js";
+import {
+  memoryContextForAgents,
+  type WorkflowMemory,
+} from "../memory/index.js";
+import type { RepairDiagnosis } from "../memory/types.js";
+import type { DatasetSpec } from "../models/schemas.js";
+
+const repairQueriesSchema = z.object({
+  repair_queries: z.array(z.string()).min(1),
+  rationale: z.string(),
+});
+
+export type RepairQueriesResult = z.infer<typeof repairQueriesSchema>;
+
+function buildRepairQueriesSystem(maxQueries: number): string {
+  const minQueries = Math.min(2, maxQueries);
+  return `You are the Coverage & Query Planning Agent for a web data collection pipeline.
+
+After an initial extraction pass, some required fields are still missing. Generate targeted web search queries to find pages that can fill those gaps.
+
+Rules:
+- Return between ${minQueries} and ${maxQueries} repair_queries (the user message includes max_queries — use as many distinct queries as needed, up to that limit).
+- Prefer more queries when multiple fields or example rows need coverage (e.g. one query angle per missing field or per entity in example_rows).
+- Each query should aim at a different source angle (company site, press release, database, registry, news).
+- Include entity names or attributes from example_rows when available.
+- Do NOT repeat or lightly rephrase queries already in prior_search_queries.
+- Temporal rules (same as initial search):
+  - Use current_year / current_date when recency matters unless the user_prompt names a specific year.
+  - Do not default to outdated years.
+- Prefer queries likely to return factual detail pages, not generic listicles.
+- Use workflow_memory.query_stats_weak (low completeness/confidence) to avoid repeating bad queries; prefer angles similar to query_stats_top.
+- Use workflow_memory.domain_stats_top / domain_stats_weak when choosing site: operators or domains to target.
+- Follow recommended_search_patterns from latest_diagnosis when present.
+- Return ONLY JSON`;
+}
+
+function currentTimeContext(): { current_date: string; current_year: number } {
+  const now = new Date();
+  return {
+    current_date: now.toISOString().slice(0, 10),
+    current_year: now.getFullYear(),
+  };
+}
+
+export async function generateRepairQueries(options: {
+  userPrompt: string;
+  spec: DatasetSpec;
+  coverage: CoverageReport;
+  priorSearchQueries: string[];
+  maxQueries: number;
+  memory?: WorkflowMemory;
+  diagnosis?: RepairDiagnosis;
+  repairLoop?: number;
+}): Promise<RepairQueriesResult> {
+  const { current_date, current_year } = currentTimeContext();
+
+  const result = await completeJson({
+    label: "repair_queries",
+    schema: repairQueriesSchema,
+    messages: [
+      {
+        role: "system",
+        content: buildRepairQueriesSystem(options.maxQueries),
+      },
+      {
+        role: "user",
+        content: JSON.stringify({
+          user_prompt: options.userPrompt,
+          current_date,
+          current_year,
+          max_queries: options.maxQueries,
+          instruction: `Generate up to ${options.maxQueries} distinct repair_queries. Use as many as needed to cover missing fields and example rows; do not stop at 5 unless you have fewer useful angles.`,
+          dataset_spec: {
+            intent_summary: options.spec.intent_summary,
+            row_grain: options.spec.row_grain,
+            columns: options.spec.columns,
+            dedupe_keys: options.spec.dedupe_keys,
+          },
+          coverage: {
+            total_records: options.coverage.total_records,
+            complete_count: options.coverage.complete_count,
+            partial_count: options.coverage.partial_count,
+            partial_record_ids: options.coverage.partial_record_ids,
+            field_gaps: options.coverage.field_gaps,
+          },
+          prior_search_queries: options.priorSearchQueries,
+          repair_loop: options.repairLoop ?? options.memory?.repair_loop_count ?? 0,
+          repair_diagnosis: options.diagnosis,
+          workflow_memory: options.memory
+            ? memoryContextForAgents(options.memory)
+            : undefined,
+          output_shape: {
+            repair_queries: ["string"],
+            rationale: "string",
+          },
+        }),
+      },
+    ],
+  });
+
+  return {
+    ...result,
+    repair_queries: result.repair_queries.slice(0, options.maxQueries),
+  };
+}

--- a/backend/BigSet_Data_Collection_Agent/src/agents/source-policy.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/agents/source-policy.ts
@@ -1,4 +1,10 @@
-import type { DatasetSpec, SourceCandidate, SourceTriageResult } from "../models/schemas.js";
+import type {
+  DatasetSpec,
+  ExtractedRecord,
+  SourceCandidate,
+  SourceTriageResult,
+} from "../models/schemas.js";
+import { scoreDocsUrlForOfficialSource } from "../records/source-urls.js";
 import { getDomain } from "../utils/url.js";
 
 export interface PromptSourceEntity {
@@ -121,6 +127,32 @@ function searchPhrasesForPrompt(prompt: string): string[] {
   return uniqueStrings(phrases);
 }
 
+function wantsDocsSource(policy: PromptSourcePolicy): boolean {
+  return policy.searchPhrases.some((phrase) =>
+    /\b(?:docs|documentation|mcp|model context protocol)\b/i.test(phrase),
+  );
+}
+
+function isWeakDocsSurface(url: string): boolean {
+  return /\b(?:blog|news|course|academy|directory|skilljar)\b/i.test(url);
+}
+
+function preferredDocsHost(entity: PromptSourceEntity): string {
+  const primary = entity.primaryToken.toLowerCase();
+  if (primary === "openai") return "developers.openai.com";
+  if (primary === "cloudflare") return "developers.cloudflare.com";
+  if (primary === "anthropic") return "platform.claude.com";
+  return `docs.${primary}.com`;
+}
+
+function officialDomainAliasesForEntity(entity: PromptSourceEntity): string[] {
+  const primary = entity.primaryToken.toLowerCase();
+  if (primary === "anthropic") {
+    return ["docs.anthropic.com", "platform.claude.com"];
+  }
+  return [];
+}
+
 export function derivePromptSourcePolicy(prompt: string): PromptSourcePolicy {
   const taskText = taskTextFromPrompt(prompt);
   const entities = extractExplicitEntities(taskText);
@@ -161,11 +193,21 @@ export function promptSourceSearchQueries(policy: PromptSourcePolicy): string[] 
   const phrases = policy.searchPhrases.length
     ? policy.searchPhrases
     : ["official source"];
+  const primaryPhrase = phrases[0] ?? "official source";
+  const siteQualifiedDocsQueries = wantsDocsSource(policy)
+    ? policy.entities.map(
+        (entity) =>
+          `${entity.name} ${primaryPhrase} site:${preferredDocsHost(entity)}`,
+      )
+    : [];
 
   return uniqueStrings(
-    policy.entities.flatMap((entity) =>
-      phrases.map((phrase) => `${entity.name} ${phrase}`),
-    ),
+    [
+      ...siteQualifiedDocsQueries,
+      ...policy.entities.flatMap((entity) =>
+        phrases.map((phrase) => `${entity.name} ${phrase}`),
+      ),
+    ],
   );
 }
 
@@ -199,7 +241,32 @@ export function urlMatchesPromptSourcePolicy(
   if (GENERIC_HOSTED_DOMAIN.test(domain)) {
     return false;
   }
-  return policy.entities.some((entity) => domain.includes(entity.primaryToken));
+  return policy.entities.some(
+    (entity) => urlMatchesEntitySourcePolicy(url, entity, policy),
+  );
+}
+
+function urlMatchesEntitySourcePolicy(
+  url: string,
+  entity: PromptSourceEntity,
+  policy: PromptSourcePolicy,
+): boolean {
+  const domain = getDomain(url).toLowerCase();
+  if (GENERIC_HOSTED_DOMAIN.test(domain)) {
+    return false;
+  }
+  const entityOwnedDomain =
+    domain.includes(entity.primaryToken) ||
+    officialDomainAliasesForEntity(entity).some((alias) =>
+      domain.endsWith(alias),
+    );
+  if (!entityOwnedDomain) {
+    return false;
+  }
+  if (wantsDocsSource(policy) && isWeakDocsSurface(url)) {
+    return false;
+  }
+  return true;
 }
 
 export function sourceCandidatePolicyBoost(
@@ -224,9 +291,20 @@ export function sourceCandidatePolicyBoost(
     /\b(official|pricing|docs|documentation|investor relations|earnings|blog)\b/.test(
       searchableText,
     );
+  const docsSurface =
+    wantsDocsSource(policy) &&
+    /(?:^|\/\/)(?:docs|developers)\.|\/(?:docs|documentation|guides|api\/docs|agents)(?:\/|$)/.test(
+      searchableText,
+    );
+  const weakDocsSurface =
+    wantsDocsSource(policy) &&
+    /\b(?:blog|news|course|academy|directory|skilljar)\b/.test(searchableText);
 
-  if (matchedDomain && matchedEntity && officialLanguage) return 5;
-  if (matchedDomain && matchedEntity) return 4;
+  if (matchedDomain && matchedEntity && docsSurface) return 7;
+  if (matchedDomain && matchedEntity && officialLanguage) {
+    return weakDocsSurface ? 2 : 5;
+  }
+  if (matchedDomain && matchedEntity) return weakDocsSurface ? 1 : 4;
   if (matchedDomain) return 3;
   if (matchedEntity && officialLanguage) return 1;
   return -2;
@@ -263,4 +341,80 @@ export function applyPromptSourcePolicyToTriageResult(
       result.suggested_action ??
       "Search/fetch the named entity's official domain instead of extracting this third-party page.",
   };
+}
+
+export function recordMatchesPromptSourcePolicy(
+  record: ExtractedRecord,
+  spec: DatasetSpec,
+  policy: PromptSourcePolicy,
+): boolean {
+  if (!policy.requiresOfficialSource) {
+    return true;
+  }
+
+  const entity = matchingPromptEntityForRecord(record, spec, policy);
+  if (!entity) {
+    return true;
+  }
+
+  const urls = urlsForRecordSourcePolicy(record, spec);
+  if (urls.length === 0) {
+    return false;
+  }
+
+  return urls.some((url) => urlMatchesEntitySourcePolicy(url, entity, policy));
+}
+
+function matchingPromptEntityForRecord(
+  record: ExtractedRecord,
+  spec: DatasetSpec,
+  policy: PromptSourcePolicy,
+): PromptSourceEntity | null {
+  const primaryColumn =
+    spec.dedupe_keys[0] ??
+    spec.columns.find((column) =>
+      /(name|title|company|organization|entity)/i.test(column.name),
+    )?.name;
+  const primaryValue = String(
+    primaryColumn ? record.row[primaryColumn] ?? "" : "",
+  ).toLowerCase();
+  const rowText = Object.values(record.row).join(" ").toLowerCase();
+
+  return (
+    policy.entities.find((entity) => {
+      const name = entity.name.toLowerCase();
+      return (
+        primaryValue.includes(name) ||
+        primaryValue.includes(entity.primaryToken) ||
+        rowText.includes(name)
+      );
+    }) ?? null
+  );
+}
+
+function urlsForRecordSourcePolicy(
+  record: ExtractedRecord,
+  spec: DatasetSpec,
+): string[] {
+  const urls = new Set<string>();
+  for (const url of record.source_urls) {
+    if (isHttpUrl(url)) urls.add(url.trim());
+  }
+  for (const column of spec.columns) {
+    if (!isUrlLikeColumnName(column.name)) continue;
+    const value = record.row[column.name];
+    if (isHttpUrl(value)) urls.add(value.trim());
+  }
+  return [...urls].sort((a, b) => {
+    return scoreDocsUrlForOfficialSource(b) - scoreDocsUrlForOfficialSource(a);
+  });
+}
+
+function isHttpUrl(value: unknown): value is string {
+  return typeof value === "string" && /^https?:\/\//i.test(value.trim());
+}
+
+function isUrlLikeColumnName(name: string): boolean {
+  const lower = name.toLowerCase();
+  return lower === "url" || lower.endsWith("_url") || lower.includes("url");
 }

--- a/backend/BigSet_Data_Collection_Agent/src/agents/source-policy.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/agents/source-policy.ts
@@ -1,0 +1,266 @@
+import type { DatasetSpec, SourceCandidate, SourceTriageResult } from "../models/schemas.js";
+import { getDomain } from "../utils/url.js";
+
+export interface PromptSourceEntity {
+  name: string;
+  primaryToken: string;
+  domainTokens: string[];
+}
+
+export interface PromptSourcePolicy {
+  requiresOfficialSource: boolean;
+  entities: PromptSourceEntity[];
+  searchPhrases: string[];
+  hint?: string;
+}
+
+const ENTITY_STOPWORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "company",
+  "companies",
+  "corp",
+  "corporation",
+  "for",
+  "from",
+  "inc",
+  "llc",
+  "ltd",
+  "of",
+  "official",
+  "page",
+  "pages",
+  "the",
+]);
+
+const ENTITY_LIST_INTRODUCER = /\b(?:for|from)\s+([^?.;:]+)/gi;
+const ENTITY_LIST_CUTOFF =
+  /\b(?:collect|find|include|give|make|show|table|with|need|return|list|shown)\b/i;
+const GENERIC_HOSTED_DOMAIN =
+  /(?:^|\.)((github|gitlab)\.(io|com)|gitbook\.io|readthedocs\.io|notion\.site|medium\.com|substack\.com)$/i;
+
+function taskTextFromPrompt(prompt: string): string {
+  const taskLine = prompt.match(/^Task:\s*(.+)$/im)?.[1];
+  return taskLine?.trim() || prompt;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
+}
+
+function tokenize(value: string): string[] {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .split(/\s+/)
+    .filter((token) => token.length >= 2 && !ENTITY_STOPWORDS.has(token));
+}
+
+function looksLikeEntityName(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 60) return false;
+  if (/^(?:and|or|the|official|latest|recent|current)$/i.test(trimmed)) {
+    return false;
+  }
+  return /[A-Z]/.test(trimmed[0] ?? "") || /[a-z][A-Z]/.test(trimmed);
+}
+
+function splitEntityList(value: string): string[] {
+  const beforeVerb = value.split(ENTITY_LIST_CUTOFF)[0] ?? value;
+  const nestedFrom = beforeVerb.match(/\bfrom\s+(.+)$/i)?.[1];
+  const entitySegment = nestedFrom ?? beforeVerb;
+  return entitySegment
+    .replace(/\s+and\s+/gi, ",")
+    .split(",")
+    .map((part) => part.trim().replace(/^and\s+/i, "").replace(/[.?!]$/g, ""))
+    .filter(looksLikeEntityName);
+}
+
+function extractExplicitEntities(prompt: string): PromptSourceEntity[] {
+  const names: string[] = [];
+  for (const match of prompt.matchAll(ENTITY_LIST_INTRODUCER)) {
+    names.push(...splitEntityList(match[1] ?? ""));
+  }
+
+  return uniqueStrings(names).map((name) => {
+    const domainTokens = tokenize(name);
+    return {
+      name,
+      primaryToken: domainTokens.at(-1) ?? name.toLowerCase(),
+      domainTokens,
+    };
+  });
+}
+
+function searchPhrasesForPrompt(prompt: string): string[] {
+  const lower = prompt.toLowerCase();
+  const phrases: string[] = [];
+
+  if (lower.includes("pricing")) {
+    phrases.push("official pricing page", "billing pricing");
+  }
+  if (lower.includes("investor relations") || lower.includes("earnings release")) {
+    phrases.push("reports quarterly results", "investor relations earnings release");
+  }
+  if (lower.includes("mcp")) {
+    phrases.push("MCP connector docs", "model context protocol docs");
+  } else if (lower.includes("docs") || lower.includes("documentation")) {
+    phrases.push("official docs");
+  }
+  if (lower.includes("blog post") || lower.includes("blog posts")) {
+    phrases.push("official blog latest post");
+  }
+  if (lower.includes("official website") || lower.includes("official websites")) {
+    phrases.push("official website");
+  }
+  if (lower.includes("official") && phrases.length === 0) {
+    phrases.push("official source");
+  }
+
+  return uniqueStrings(phrases);
+}
+
+export function derivePromptSourcePolicy(prompt: string): PromptSourcePolicy {
+  const taskText = taskTextFromPrompt(prompt);
+  const entities = extractExplicitEntities(taskText);
+  const searchPhrases = searchPhrasesForPrompt(taskText);
+  const lower = taskText.toLowerCase();
+  const asksForCanonicalSource =
+    searchPhrases.length > 0 ||
+    lower.includes("source url") ||
+    lower.includes("source page");
+  const requiresOfficialSource =
+    entities.length > 0 &&
+    asksForCanonicalSource &&
+    (lower.includes("official") ||
+      lower.includes("pricing") ||
+      lower.includes("investor relations") ||
+      lower.includes("earnings release") ||
+      lower.includes("docs") ||
+      lower.includes("documentation") ||
+      lower.includes("blog post"));
+
+  const hint = requiresOfficialSource
+    ? [
+        "Prompt source policy: user requested canonical/official sources for named entities.",
+        `Named entities: ${entities.map((entity) => entity.name).join(", ")}.`,
+        "Use official entity-owned domains for source_url, evidence, pricing/docs/blog/IR URLs, and required facts.",
+        "Use third-party pages only for discovery; do not use them as evidence when an official entity-owned page is available.",
+      ].join("\n")
+    : undefined;
+
+  return { requiresOfficialSource, entities, searchPhrases, hint };
+}
+
+export function promptSourceSearchQueries(policy: PromptSourcePolicy): string[] {
+  if (!policy.requiresOfficialSource || policy.entities.length === 0) {
+    return [];
+  }
+
+  const phrases = policy.searchPhrases.length
+    ? policy.searchPhrases
+    : ["official source"];
+
+  return uniqueStrings(
+    policy.entities.flatMap((entity) =>
+      phrases.map((phrase) => `${entity.name} ${phrase}`),
+    ),
+  );
+}
+
+export function applyPromptSourcePolicyToSpec(
+  spec: DatasetSpec,
+  prompt: string,
+): DatasetSpec {
+  const policy = derivePromptSourcePolicy(prompt);
+  if (!policy.requiresOfficialSource) {
+    return spec;
+  }
+
+  return {
+    ...spec,
+    search_queries: uniqueStrings([
+      ...promptSourceSearchQueries(policy),
+      ...spec.search_queries,
+    ]),
+    extraction_hints: [spec.extraction_hints, policy.hint]
+      .filter(Boolean)
+      .join("\n"),
+  };
+}
+
+export function urlMatchesPromptSourcePolicy(
+  url: string,
+  policy: PromptSourcePolicy,
+): boolean {
+  if (!policy.requiresOfficialSource) return true;
+  const domain = getDomain(url).toLowerCase();
+  if (GENERIC_HOSTED_DOMAIN.test(domain)) {
+    return false;
+  }
+  return policy.entities.some((entity) => domain.includes(entity.primaryToken));
+}
+
+export function sourceCandidatePolicyBoost(
+  candidate: SourceCandidate,
+  policy: PromptSourcePolicy,
+): number {
+  if (!policy.requiresOfficialSource) return 0;
+
+  const searchableText = [
+    candidate.url,
+    candidate.title,
+    candidate.snippet,
+    candidate.site_name,
+  ]
+    .join(" ")
+    .toLowerCase();
+  const matchedEntity = policy.entities.some((entity) =>
+    entity.domainTokens.some((token) => searchableText.includes(token)),
+  );
+  const matchedDomain = urlMatchesPromptSourcePolicy(candidate.url, policy);
+  const officialLanguage =
+    /\b(official|pricing|docs|documentation|investor relations|earnings|blog)\b/.test(
+      searchableText,
+    );
+
+  if (matchedDomain && matchedEntity && officialLanguage) return 5;
+  if (matchedDomain && matchedEntity) return 4;
+  if (matchedDomain) return 3;
+  if (matchedEntity && officialLanguage) return 1;
+  return -2;
+}
+
+export function applyPromptSourcePolicyToTriageResult(
+  result: SourceTriageResult,
+  policy: PromptSourcePolicy,
+): SourceTriageResult {
+  if (
+    !policy.requiresOfficialSource ||
+    ![
+      "extract_now",
+      "requires_navigation",
+      "requires_form_submission",
+      "requires_detail_page_followup",
+    ].includes(result.status) ||
+    urlMatchesPromptSourcePolicy(result.final_url || result.url, policy)
+  ) {
+    return result;
+  }
+
+  const domain = getDomain(result.final_url || result.url);
+  return {
+    ...result,
+    status: "low_value",
+    source_data_confidence: Math.min(result.source_data_confidence, 0.3),
+    expected_yield: "none",
+    reasoning:
+      `Prompt asks for official/canonical sources for named entities; ${domain} ` +
+      `does not match ${policy.entities.map((entity) => entity.name).join(", ")}. ` +
+      `Original triage: ${result.reasoning}`,
+    suggested_action:
+      result.suggested_action ??
+      "Search/fetch the named entity's official domain instead of extracting this third-party page.",
+  };
+}

--- a/backend/BigSet_Data_Collection_Agent/src/agents/source-triage.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/agents/source-triage.ts
@@ -1,0 +1,100 @@
+import { config } from "../config.js";
+import { completeJson } from "../integrations/openrouter.js";
+import { sourceStatusSchema } from "../models/source-status.js";
+import {
+  memoryContextForAgents,
+  type WorkflowMemory,
+} from "../memory/index.js";
+import {
+  sourceTriageResultSchema,
+  type DatasetSpec,
+  type FetchedPage,
+  type SourceTriageResult,
+} from "../models/schemas.js";
+
+const TRIAGE_SYSTEM = `You are the Source Triage Agent for a web data collection pipeline.
+
+Classify each fetched web page to decide how the pipeline should process it.
+
+Status definitions:
+- extract_now: Page already contains a usable list/table or enough inline data to extract rows directly.
+- requires_navigation: Data exists but requires clicking through menus, pagination, tabs, or multi-step browsing.
+- requires_form_submission: Data requires filling and submitting a search/filter form.
+- requires_detail_page_followup: Page is an index; each item needs opening a detail page to get full fields.
+- irrelevant: Page is unrelated to the dataset intent.
+- duplicate: Page largely repeats data already covered (same listings, mirror content).
+- blocked: Login wall, CAPTCHA, access denied, or bot block.
+- low_value: Related but unlikely to yield useful rows (thin content, ads-only, generic homepage).
+
+Rules:
+- Prefer extract_now when markdown already has list/table-style content matching row_grain.
+- Use requires_* statuses when static fetch text is clearly incomplete for the schema.
+- Mark duplicate only when the page would not yield any NEW rows beyond known_entities (if provided): same listings or mirror content with no additional primary keys visible. If the page may list entities not in known_entities, prefer extract_now or partial yield instead of duplicate.
+- source_data_confidence: how confident you are that accurate, complete rows can be extracted (0–1).
+- expected_yield: "complete" if full rows likely available inline; "partial" if only some fields; "none" if no useful rows.
+- confidence: your confidence in this triage classification itself (routing), not data quality.
+- When workflow_memory is provided: use domain_stats_top (high avg_completeness and avg_confidence) as strong extract_now signals; domain_stats_weak suggests blocked, low_value, or partial-only unless content clearly matches intent.
+- Return ONLY JSON`;
+
+function truncate(text: string): string {
+  if (text.length <= config.maxPageChars) return text;
+  return `${text.slice(0, config.maxPageChars)}\n\n[truncated]`;
+}
+
+export async function triagePage(options: {
+  userPrompt: string;
+  spec: DatasetSpec;
+  page: FetchedPage;
+  knownEntityKeys?: string[];
+  memory?: WorkflowMemory;
+}): Promise<SourceTriageResult> {
+  const pageUrl = options.page.final_url || options.page.url;
+
+  const result = await completeJson({
+    label: `triage:${pageUrl}`,
+    schema: sourceTriageResultSchema,
+    messages: [
+      { role: "system", content: TRIAGE_SYSTEM },
+      {
+        role: "user",
+        content: JSON.stringify({
+          user_prompt: options.userPrompt,
+          dataset_spec: {
+            intent_summary: options.spec.intent_summary,
+            row_grain: options.spec.row_grain,
+            columns: options.spec.columns,
+            extraction_hints: options.spec.extraction_hints,
+          },
+          known_entities: options.knownEntityKeys ?? [],
+          workflow_memory: options.memory
+            ? memoryContextForAgents(options.memory)
+            : undefined,
+          page: {
+            url: pageUrl,
+            title: options.page.title,
+            text: truncate(options.page.text),
+          },
+          output_shape: {
+            url: "string",
+            final_url: "string",
+            title: "string",
+            status: "extract_now | requires_navigation | ...",
+            confidence: "0-1 triage routing confidence",
+            source_data_confidence: "0-1 expected data accuracy if extracted",
+            expected_yield: "complete | partial | none",
+            reasoning: "string",
+            suggested_action: "optional string",
+          },
+        }),
+      },
+    ],
+  });
+
+  return {
+    ...result,
+    url: options.page.url,
+    final_url: pageUrl,
+    title: options.page.title || result.title,
+    status: sourceStatusSchema.parse(result.status),
+  };
+}

--- a/backend/BigSet_Data_Collection_Agent/src/agents/source-triage.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/agents/source-triage.ts
@@ -11,6 +11,10 @@ import {
   type FetchedPage,
   type SourceTriageResult,
 } from "../models/schemas.js";
+import {
+  applyPromptSourcePolicyToTriageResult,
+  derivePromptSourcePolicy,
+} from "./source-policy.js";
 
 const TRIAGE_SYSTEM = `You are the Source Triage Agent for a web data collection pipeline.
 
@@ -90,11 +94,15 @@ export async function triagePage(options: {
     ],
   });
 
-  return {
+  const normalizedResult = {
     ...result,
     url: options.page.url,
     final_url: pageUrl,
     title: options.page.title || result.title,
     status: sourceStatusSchema.parse(result.status),
   };
+  return applyPromptSourcePolicyToTriageResult(
+    normalizedResult,
+    derivePromptSourcePolicy(options.userPrompt),
+  );
 }

--- a/backend/BigSet_Data_Collection_Agent/src/agents/triage-extract.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/agents/triage-extract.ts
@@ -1,0 +1,194 @@
+import { z } from "zod";
+import { config } from "../config.js";
+import { completeJson } from "../integrations/openrouter.js";
+import {
+  memoryContextForAgents,
+  type WorkflowMemory,
+} from "../memory/index.js";
+import { sourceStatusSchema } from "../models/source-status.js";
+import {
+  sourceTriageResultSchema,
+  type DatasetSpec,
+  type ExtractedRecord,
+  type FetchedPage,
+  type SourceTriageResult,
+} from "../models/schemas.js";
+import {
+  buildLlmExtractionResultSchema,
+  finalizeExtractedRecords,
+  type LlmExtractionRecord,
+} from "./extract.js";
+
+/** Page text budget for combined triage + extract (default 2× MAX_PAGE_CHARS). */
+export function triageExtractPageCharLimit(): number {
+  return config.triageExtractMaxPageChars;
+}
+
+function truncatePageText(text: string): string {
+  const limit = triageExtractPageCharLimit();
+  if (text.length <= limit) return text;
+  return `${text.slice(0, limit)}\n\n[truncated]`;
+}
+
+const COMBINED_TRIAGE_EXTRACT_SYSTEM = `You are the Source Triage + Extraction Agent for a web data collection pipeline.
+
+You MUST return JSON with exactly these top-level keys:
+- "triage_results" — classification for this page (required)
+- "extraction_results" — extracted rows (required object; use empty records when not extracting)
+
+## triage_results
+
+Classify the fetched page:
+
+Status definitions:
+- extract_now: Page already contains usable list/table or enough inline data to extract rows directly IN THIS SAME RESPONSE.
+- requires_navigation: Data needs clicking menus, pagination, tabs, or multi-step browsing (do NOT extract).
+- requires_form_submission: Data needs filling/submitting a form (do NOT extract).
+- requires_detail_page_followup: Index page; detail pages needed (do NOT extract).
+- irrelevant: Unrelated to dataset intent (do NOT extract).
+- duplicate: Repeats known_entities with no new primary keys (do NOT extract).
+- blocked: Login wall, CAPTCHA, access denied (do NOT extract).
+- low_value: Related but unlikely to yield useful rows (do NOT extract).
+
+Fields: url, final_url, title, status, confidence (routing), source_data_confidence (data quality if extracted), expected_yield (complete|partial|none), reasoning, optional suggested_action.
+
+## extraction_results
+
+ONLY populate records when triage_results.status is extract_now.
+
+When status is extract_now:
+- Extract facts supported by page text only. row keys must match spec column names.
+- Use null for unknown values. Multiple records allowed per row_grain.
+- evidence: field, quote, optional url; extraction_confidence per record.
+- Do not return source_urls on records (added in post-processing).
+
+When status is NOT extract_now:
+- Set extraction_results.records to [] and omit notes or use a brief note explaining skip.
+
+When workflow_memory is provided: use domain_stats_top / query_stats_top as positive signals; domain_stats_weak suggests caution.
+
+Return ONLY JSON.`;
+
+export function buildTriageExtractCombinedSchema(spec: DatasetSpec) {
+  return z.object({
+    triage_results: sourceTriageResultSchema,
+    extraction_results: buildLlmExtractionResultSchema(spec),
+  });
+}
+
+export type InlineExtractionArtifact = {
+  records: ExtractedRecord[];
+  notes?: string;
+};
+
+/** Per-source artifact: triage + inline extraction (if any). */
+export type SourceTriageExtractOutcome = {
+  url: string;
+  final_url: string;
+  triage_results: SourceTriageResult;
+  extraction_results: InlineExtractionArtifact | null;
+};
+
+export interface TriageAndExtractPageResult {
+  triage: SourceTriageResult;
+  records: ExtractedRecord[];
+  outcome: SourceTriageExtractOutcome;
+}
+
+export async function triageAndExtractPage(options: {
+  userPrompt: string;
+  spec: DatasetSpec;
+  page: FetchedPage;
+  knownEntityKeys?: string[];
+  memory?: WorkflowMemory;
+  focusFields?: string[];
+}): Promise<TriageAndExtractPageResult> {
+  const pageUrl = options.page.final_url || options.page.url;
+
+  const combined = await completeJson({
+    label: `triage-extract:${pageUrl}`,
+    schema: buildTriageExtractCombinedSchema(options.spec),
+    messages: [
+      { role: "system", content: COMBINED_TRIAGE_EXTRACT_SYSTEM },
+      {
+        role: "user",
+        content: JSON.stringify({
+          user_prompt: options.userPrompt,
+          dataset_spec: {
+            intent_summary: options.spec.intent_summary,
+            row_grain: options.spec.row_grain,
+            columns: options.spec.columns,
+            extraction_hints: options.spec.extraction_hints,
+          },
+          known_entities: options.knownEntityKeys ?? [],
+          workflow_memory: options.memory
+            ? memoryContextForAgents(options.memory)
+            : undefined,
+          page: {
+            url: pageUrl,
+            title: options.page.title,
+            text: truncatePageText(options.page.text),
+          },
+          ...(options.focusFields?.length
+            ? {
+                focus_fields: options.focusFields,
+                instruction:
+                  "Prioritize focus_fields when extracting under extract_now.",
+              }
+            : {}),
+          required_output_shape: {
+            triage_results: {
+              url: "string",
+              final_url: "string",
+              title: "string",
+              status: "extract_now | requires_* | irrelevant | ...",
+              confidence: "0-1",
+              source_data_confidence: "0-1",
+              expected_yield: "complete | partial | none",
+              reasoning: "string",
+              suggested_action: "optional",
+            },
+            extraction_results: {
+              records: "[] or row objects when extract_now",
+              notes: "optional",
+            },
+          },
+        }),
+      },
+    ],
+  });
+
+  const triage: SourceTriageResult = {
+    ...combined.triage_results,
+    url: options.page.url,
+    final_url: pageUrl,
+    title: options.page.title || combined.triage_results.title,
+    status: sourceStatusSchema.parse(combined.triage_results.status),
+  };
+
+  let records: ExtractedRecord[] = [];
+  let extractionArtifact: InlineExtractionArtifact | null = null;
+
+  if (triage.status === "extract_now") {
+    records = finalizeExtractedRecords(
+      combined.extraction_results.records as LlmExtractionRecord[],
+      pageUrl,
+      options.spec,
+    );
+    extractionArtifact = {
+      records,
+      ...(combined.extraction_results.notes
+        ? { notes: combined.extraction_results.notes }
+        : {}),
+    };
+  }
+
+  const outcome: SourceTriageExtractOutcome = {
+    url: options.page.url,
+    final_url: pageUrl,
+    triage_results: triage,
+    extraction_results: extractionArtifact,
+  };
+
+  return { triage, records, outcome };
+}

--- a/backend/BigSet_Data_Collection_Agent/src/config.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/config.ts
@@ -1,3 +1,5 @@
+import "dotenv/config";
+
 function readBool(name: string, fallback: boolean): boolean {
   const raw = process.env[name];
   if (raw === undefined || raw === "") return fallback;
@@ -34,6 +36,11 @@ function readInt(name: string, fallback: number): number {
   return value;
 }
 
+const maxPageChars = readInt("MAX_PAGE_CHARS", 12000);
+const triageExtractMaxPageChars = process.env.TRIAGE_EXTRACT_MAX_PAGE_CHARS
+  ? readInt("TRIAGE_EXTRACT_MAX_PAGE_CHARS", maxPageChars * 2)
+  : maxPageChars * 2;
+
 export const config = {
   tinyfishApiKey: process.env.TINYFISH_API_KEY ?? "",
   openRouterApiKey: process.env.OPENROUTER_API_KEY ?? "",
@@ -48,7 +55,11 @@ export const config = {
   maxSearchQueries: readInt("MAX_SEARCH_QUERIES", 6),
   maxResultsPerQuery: readInt("MAX_RESULTS_PER_QUERY", 5),
   maxUrlsToFetch: readInt("MAX_URLS_TO_FETCH", 20),
-  maxPageChars: readInt("MAX_PAGE_CHARS", 12000),
+  maxPageChars,
+  /** v1.5.2: combined triage+extract agent page budget (default 2× maxPageChars). */
+  triageExtractMaxPageChars,
+  /** v1.5.2: one LLM call for triage + inline extract (default). Set false for v1.4 two-call path. */
+  enableCombinedTriageExtract: readBool("ENABLE_COMBINED_TRIAGE_EXTRACT", true),
   extractionConcurrency: readInt("EXTRACTION_CONCURRENCY", 5),
   fetchBatchSize: readInt("FETCH_BATCH_SIZE", 10),
   fetchConcurrency: readInt("FETCH_CONCURRENCY", 4),
@@ -86,7 +97,8 @@ export const config = {
   agentPollConcurrency: readInt("AGENT_POLL_CONCURRENCY", 10),
   agentPollIntervalMs: readInt("AGENT_POLL_INTERVAL_MS", 3000),
   agentPollTimeoutMs: readInt("AGENT_POLL_TIMEOUT_MS", 1_200_000),
-  triageConcurrency: readInt("TRIAGE_CONCURRENCY", 5),
+  /** v1.5.2: more parallel combined agents (fewer pages per worker). */
+  triageConcurrency: readInt("TRIAGE_CONCURRENCY", 10),
   enableQualityScoring: readBool("ENABLE_QUALITY_SCORING", true),
   /** results.csv only includes rows with all required fields, ranked by quality. */
   enableSelectiveResults: readBool("ENABLE_SELECTIVE_RESULTS", true),

--- a/backend/BigSet_Data_Collection_Agent/src/config.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/config.ts
@@ -1,0 +1,114 @@
+function readBool(name: string, fallback: boolean): boolean {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return fallback;
+  return ["1", "true", "yes", "on"].includes(raw.toLowerCase());
+}
+
+function readFloat(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const value = Number.parseFloat(raw);
+  if (Number.isNaN(value) || value < 0 || value > 1) {
+    throw new Error(`Invalid ${name}: expected number 0–1, got "${raw}"`);
+  }
+  return value;
+}
+
+function readOptionalFloat(name: string): number | undefined {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return undefined;
+  const value = Number.parseFloat(raw);
+  if (Number.isNaN(value) || value < 0 || value > 2) {
+    throw new Error(`Invalid ${name}: expected number 0–2, got "${raw}"`);
+  }
+  return value;
+}
+
+function readInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const value = Number.parseInt(raw, 10);
+  if (Number.isNaN(value) || value <= 0) {
+    throw new Error(`Invalid ${name}: expected positive integer, got "${raw}"`);
+  }
+  return value;
+}
+
+export const config = {
+  tinyfishApiKey: process.env.TINYFISH_API_KEY ?? "",
+  openRouterApiKey: process.env.OPENROUTER_API_KEY ?? "",
+  openRouterModel: process.env.OPENROUTER_MODEL ?? "google/gemini-3.1-flash-lite",
+  openRouterSiteUrl:
+    process.env.OPENROUTER_SITE_URL ??
+    "https://github.com/MMeteorL/BigSet_Data_Collection_Agent",
+  openRouterAppName:
+    process.env.OPENROUTER_APP_NAME ?? "BigSet Data Collection Agent",
+  /** Omit temperature by default — Gemini/reasoning models on OpenRouter reject it. Set OPENROUTER_TEMPERATURE to override. */
+  openRouterTemperature: readOptionalFloat("OPENROUTER_TEMPERATURE"),
+  maxSearchQueries: readInt("MAX_SEARCH_QUERIES", 6),
+  maxResultsPerQuery: readInt("MAX_RESULTS_PER_QUERY", 5),
+  maxUrlsToFetch: readInt("MAX_URLS_TO_FETCH", 20),
+  maxPageChars: readInt("MAX_PAGE_CHARS", 12000),
+  extractionConcurrency: readInt("EXTRACTION_CONCURRENCY", 5),
+  fetchBatchSize: readInt("FETCH_BATCH_SIZE", 10),
+  fetchConcurrency: readInt("FETCH_CONCURRENCY", 4),
+  searchConcurrency: readInt("SEARCH_CONCURRENCY", 4),
+  maxConcurrentPerDomain: readInt("MAX_CONCURRENT_PER_DOMAIN", 2),
+  maxRetries: readInt("MAX_RETRIES", 2),
+  retryBaseDelayMs: readInt("RETRY_BASE_DELAY_MS", 1000),
+  openRouterRpm: readInt("OPENROUTER_RPM", 60),
+  tinyfishSearchRpm: readInt("TINYFISH_SEARCH_RPM", 30),
+  tinyfishFetchRpm: readInt("TINYFISH_FETCH_RPM", 30),
+  tinyfishAgentRpm: readInt("TINYFISH_AGENT_RPM", 10),
+  enableRepairLoop: readBool("ENABLE_REPAIR_LOOP", true),
+  maxRepairLoops: readInt("MAX_REPAIR_LOOPS", 3),
+  enableWorkflowMemory: readBool("ENABLE_WORKFLOW_MEMORY", true),
+  maxRepairQueries: readInt("MAX_REPAIR_QUERIES", 4),
+  maxRepairResultsPerQuery: readInt("MAX_REPAIR_RESULTS_PER_QUERY", 5),
+  maxRepairUrlsToFetch: readInt("MAX_REPAIR_URLS_TO_FETCH", 10),
+  /** Top historical queries to re-run on the next Search API page during repair. */
+  maxRepairSearchPaginationQueries: readInt(
+    "MAX_REPAIR_SEARCH_PAGINATION_QUERIES",
+    2,
+  ),
+  /** Highest Search API page index (API allows 0–10). */
+  maxSearchPage: readInt("MAX_SEARCH_PAGE", 10),
+  enableRepairLinkFollow: readBool("ENABLE_REPAIR_LINK_FOLLOW", true),
+  maxRepairLinkUrls: readInt("MAX_REPAIR_LINK_URLS", 8),
+  maxLinksPerSourcePage: readInt("MAX_LINKS_PER_SOURCE_PAGE", 3),
+  enableTriage: readBool("ENABLE_TRIAGE", true),
+  enableTinyfishAgent: readBool("ENABLE_TINYFISH_AGENT", true),
+  maxAgentRunsPerPhase: readInt("MAX_AGENT_RUNS_PER_PHASE", 5),
+  agentConcurrency: readInt("AGENT_CONCURRENCY", 2),
+  /** Parallel `/run-async` queue submissions per agent phase. */
+  agentQueueConcurrency: readInt("AGENT_QUEUE_CONCURRENCY", 10),
+  /** Parallel `runs.get` polls while agent jobs execute on Tinyfish. */
+  agentPollConcurrency: readInt("AGENT_POLL_CONCURRENCY", 10),
+  agentPollIntervalMs: readInt("AGENT_POLL_INTERVAL_MS", 3000),
+  agentPollTimeoutMs: readInt("AGENT_POLL_TIMEOUT_MS", 1_200_000),
+  triageConcurrency: readInt("TRIAGE_CONCURRENCY", 5),
+  enableQualityScoring: readBool("ENABLE_QUALITY_SCORING", true),
+  /** results.csv only includes rows with all required fields, ranked by quality. */
+  enableSelectiveResults: readBool("ENABLE_SELECTIVE_RESULTS", true),
+  qualityLowConfidenceThreshold: readFloat("QUALITY_LOW_CONFIDENCE_THRESHOLD", 0.55),
+  qualityReviewThreshold: readFloat("QUALITY_REVIEW_THRESHOLD", 0.75),
+  qualitySourceConfidenceThreshold: readFloat(
+    "QUALITY_SOURCE_CONFIDENCE_THRESHOLD",
+    0.5,
+  ),
+  qualityExtractionConfidenceThreshold: readFloat(
+    "QUALITY_EXTRACTION_CONFIDENCE_THRESHOLD",
+    0.6,
+  ),
+} as const;
+
+export function assertConfig(): void {
+  const missing: string[] = [];
+  if (!config.tinyfishApiKey) missing.push("TINYFISH_API_KEY");
+  if (!config.openRouterApiKey) missing.push("OPENROUTER_API_KEY");
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variables: ${missing.join(", ")}. Copy .env.example to .env and fill in values.`,
+    );
+  }
+}

--- a/backend/BigSet_Data_Collection_Agent/src/coverage/analyze.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/coverage/analyze.ts
@@ -1,0 +1,116 @@
+import { canonicalRecordId } from "../merge/records.js";
+import type { DatasetSpec, ExtractedRecord } from "../models/schemas.js";
+
+export interface FieldGap {
+  column: string;
+  description: string;
+  missing_count: number;
+  missing_pct: number;
+  /** Partial rows missing this field (for repair query context). */
+  example_rows: Record<string, string | number | boolean | null>[];
+}
+
+export interface CoverageReport {
+  total_records: number;
+  required_columns: string[];
+  field_gaps: FieldGap[];
+  should_repair: boolean;
+  /** Rows with all required fields present. */
+  complete_count: number;
+  /** Rows missing at least one required field. */
+  partial_count: number;
+  /** Record ids (canonical) for partial rows — for repair planning. */
+  partial_record_ids: string[];
+}
+
+function isEmpty(value: unknown): boolean {
+  return value === null || value === undefined || value === "";
+}
+
+export function analyzeCoverage(
+  spec: DatasetSpec,
+  records: ExtractedRecord[],
+): CoverageReport {
+  const requiredColumns = spec.columns.filter((col) => col.required);
+
+  const fieldGaps: FieldGap[] = requiredColumns
+    .map((col) => {
+      const missingRecords = records.filter((record) =>
+        isEmpty(record.row[col.name]),
+      );
+
+      return {
+        column: col.name,
+        description: col.description,
+        missing_count: missingRecords.length,
+        missing_pct:
+          records.length > 0 ? missingRecords.length / records.length : 1,
+        example_rows: missingRecords.slice(0, 5).map((record) => record.row),
+      };
+    })
+    .filter((gap) => gap.missing_count > 0 || records.length === 0);
+
+  const shouldRepair =
+    fieldGaps.length > 0 &&
+    (records.length === 0 || fieldGaps.some((gap) => gap.missing_count > 0));
+
+  const partialRecordIds: string[] = [];
+  let completeCount = 0;
+
+  for (const record of records) {
+    const missingRequired = requiredColumns.some((col) =>
+      isEmpty(record.row[col.name]),
+    );
+    if (missingRequired) {
+      const id = canonicalRecordId(record, spec);
+      if (id) partialRecordIds.push(id);
+    } else {
+      completeCount += 1;
+    }
+  }
+
+  return {
+    total_records: records.length,
+    required_columns: requiredColumns.map((col) => col.name),
+    field_gaps: fieldGaps,
+    should_repair: shouldRepair,
+    complete_count: completeCount,
+    partial_count: partialRecordIds.length,
+    partial_record_ids: partialRecordIds,
+  };
+}
+
+export function countFilledGaps(
+  spec: DatasetSpec,
+  before: ExtractedRecord[],
+  after: ExtractedRecord[],
+  columns: string[],
+): Record<string, number> {
+  const filled = Object.fromEntries(columns.map((col) => [col, 0])) as Record<
+    string,
+    number
+  >;
+
+  const afterByKey = new Map<string, ExtractedRecord>();
+  for (const record of after) {
+    const key = canonicalRecordId(record, spec);
+    if (key && !afterByKey.has(key)) {
+      afterByKey.set(key, record);
+    }
+  }
+
+  for (const prev of before) {
+    const key = canonicalRecordId(prev, spec);
+    if (!key) continue;
+    const next = afterByKey.get(key);
+    if (!next) continue;
+
+    for (const column of columns) {
+      if (isEmpty(prev.row[column]) && !isEmpty(next.row[column])) {
+        filled[column] = (filled[column] ?? 0) + 1;
+      }
+    }
+  }
+
+  return filled;
+}

--- a/backend/BigSet_Data_Collection_Agent/src/export/csv-compiler.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/export/csv-compiler.ts
@@ -1,0 +1,199 @@
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { canonicalRecordId } from "../merge/records.js";
+import type { RecordQuality } from "../models/quality.js";
+import type { DatasetSpec, ExtractedRecord } from "../models/schemas.js";
+
+function escapeCsv(value: string): string {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function cellValue(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "boolean") return value ? "true" : "false";
+  return String(value);
+}
+
+const QUALITY_COLUMNS = [
+  "record_id",
+  "record_status",
+  "needs_review",
+  "completeness_pct",
+  "confidence_score",
+  "missing_required_fields",
+  "review_reasons",
+] as const;
+
+function fieldConfidenceColumns(spec: DatasetSpec): string[] {
+  return spec.columns
+    .filter((col) => col.required)
+    .map((col) => `${col.name}_confidence`);
+}
+
+function qualityCells(
+  quality: RecordQuality | undefined,
+  spec: DatasetSpec,
+): string[] {
+  if (!quality) {
+    return [
+      ...QUALITY_COLUMNS.map(() => ""),
+      ...fieldConfidenceColumns(spec).map(() => ""),
+    ];
+  }
+  const requiredConfidenceCells = spec.columns
+    .filter((col) => col.required)
+    .map((col) => {
+      const value = quality.field_confidences[col.name];
+      return escapeCsv(value !== undefined ? String(value) : "");
+    });
+
+  return [
+    escapeCsv(quality.record_id),
+    escapeCsv(quality.record_status),
+    escapeCsv(quality.needs_review ? "true" : "false"),
+    escapeCsv(String(quality.completeness_pct)),
+    escapeCsv(String(quality.confidence_score)),
+    escapeCsv(quality.missing_required_fields.join("; ")),
+    escapeCsv(quality.review_reasons.join("; ")),
+    ...requiredConfidenceCells,
+  ];
+}
+
+export async function writeResultsCsv(
+  path: string,
+  spec: DatasetSpec,
+  records: ExtractedRecord[],
+  qualityByRecordId?: Map<string, RecordQuality>,
+): Promise<void> {
+  const columnNames = spec.columns.map((c) => c.name);
+  const metaColumns = ["primary_source_url", "all_source_urls"];
+  const includeQuality = qualityByRecordId !== undefined;
+  const header = [
+    ...columnNames,
+    ...metaColumns,
+    ...(includeQuality
+      ? [...QUALITY_COLUMNS, ...fieldConfidenceColumns(spec)]
+      : []),
+  ];
+
+  const lines = [header.map(escapeCsv).join(",")];
+
+  for (const record of records) {
+    const cells = columnNames.map((name) =>
+      escapeCsv(cellValue(record.row[name])),
+    );
+    const primarySource = record.source_urls[0] ?? "";
+    const allSources = record.source_urls.join(" | ");
+    cells.push(escapeCsv(primarySource), escapeCsv(allSources));
+
+    if (includeQuality) {
+      const recordId = canonicalRecordId(record, spec);
+      const quality = recordId ? qualityByRecordId.get(recordId) : undefined;
+      cells.push(...qualityCells(quality, spec));
+    }
+
+    lines.push(cells.join(","));
+  }
+
+  await writeFile(path, `${lines.join("\n")}\n`, "utf8");
+}
+
+export async function writeEvidenceJsonl(
+  path: string,
+  spec: DatasetSpec,
+  records: ExtractedRecord[],
+  qualityByRecordId?: Map<string, RecordQuality>,
+): Promise<void> {
+  const lines = records.map((record) => {
+    const recordId = canonicalRecordId(record, spec);
+    const payload: Record<string, unknown> = {
+      row: record.row,
+      evidence: record.evidence,
+      source_urls: record.source_urls,
+    };
+    if (record.extraction_confidence !== undefined) {
+      payload.extraction_confidence = record.extraction_confidence;
+    }
+    if (recordId && qualityByRecordId?.has(recordId)) {
+      const quality = qualityByRecordId.get(recordId)!;
+      payload.quality = quality;
+      if (Object.keys(quality.field_confidences).length > 0) {
+        payload.field_confidences = quality.field_confidences;
+      }
+    }
+    return JSON.stringify(payload);
+  });
+
+  const body = lines.length > 0 ? `${lines.join("\n")}\n` : "";
+  await writeFile(path, body, "utf8");
+}
+
+export function qualityMapFromReport(
+  qualities: RecordQuality[],
+): Map<string, RecordQuality> {
+  return new Map(qualities.map((quality) => [quality.record_id, quality]));
+}
+
+export async function writeSegmentedRecordCsvs(
+  root: string,
+  spec: DatasetSpec,
+  records: ExtractedRecord[],
+  qualities: RecordQuality[],
+): Promise<void> {
+  const qualityById = qualityMapFromReport(qualities);
+  const recordIdFor = (record: ExtractedRecord) => canonicalRecordId(record, spec);
+
+  const complete = records.filter((record) => {
+    const id = recordIdFor(record);
+    return id && qualityById.get(id)?.record_status === "complete";
+  });
+  const partial = records.filter((record) => {
+    const id = recordIdFor(record);
+    return id && qualityById.get(id)?.record_status === "partial";
+  });
+  const lowConfidence = records.filter((record) => {
+    const id = recordIdFor(record);
+    return id && qualityById.get(id)?.record_status === "low_confidence";
+  });
+  const needingReview = records.filter((record) => {
+    const id = recordIdFor(record);
+    return id && qualityById.get(id)?.needs_review === true;
+  });
+
+  await writeResultsCsv(
+    join(root, "records_complete.csv"),
+    spec,
+    complete,
+    qualityById,
+  );
+  await writeResultsCsv(
+    join(root, "records_partial.csv"),
+    spec,
+    partial,
+    qualityById,
+  );
+  await writeResultsCsv(
+    join(root, "records_low_confidence.csv"),
+    spec,
+    lowConfidence,
+    qualityById,
+  );
+  await writeResultsCsv(
+    join(root, "records_needing_review.csv"),
+    spec,
+    needingReview,
+    qualityById,
+  );
+}
+
+export async function writeUnkeyedRecordsJsonl(
+  path: string,
+  records: ExtractedRecord[],
+): Promise<void> {
+  const lines = records.map((record) => JSON.stringify(record));
+  const body = lines.length > 0 ? `${lines.join("\n")}\n` : "";
+  await writeFile(path, body, "utf8");
+}

--- a/backend/BigSet_Data_Collection_Agent/src/export/select-results.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/export/select-results.ts
@@ -1,0 +1,47 @@
+import { canonicalRecordId } from "../merge/records.js";
+import type { RecordQuality } from "../models/quality.js";
+import type { DatasetSpec, ExtractedRecord } from "../models/schemas.js";
+
+function isEmpty(value: unknown): boolean {
+  return value === null || value === undefined || value === "";
+}
+
+/** Row has every required column populated. */
+export function hasAllRequiredFields(
+  spec: DatasetSpec,
+  record: ExtractedRecord,
+): boolean {
+  return spec.columns
+    .filter((col) => col.required)
+    .every((col) => !isEmpty(record.row[col.name]));
+}
+
+/**
+ * Records for the primary results view: all required fields present,
+ * ranked by completeness (desc) then confidence (desc).
+ */
+export function selectVisualizationRecords(
+  spec: DatasetSpec,
+  records: ExtractedRecord[],
+  qualityById: Map<string, RecordQuality>,
+): ExtractedRecord[] {
+  const eligible = records.filter((record) => {
+    if (!hasAllRequiredFields(spec, record)) return false;
+    const id = canonicalRecordId(record, spec);
+    if (!id) return false;
+    const quality = qualityById.get(id);
+    return quality !== undefined && quality.missing_required_fields.length === 0;
+  });
+
+  return eligible.sort((a, b) => {
+    const idA = canonicalRecordId(a, spec)!;
+    const idB = canonicalRecordId(b, spec)!;
+    const qA = qualityById.get(idA)!;
+    const qB = qualityById.get(idB)!;
+
+    if (qB.completeness_pct !== qA.completeness_pct) {
+      return qB.completeness_pct - qA.completeness_pct;
+    }
+    return qB.confidence_score - qA.confidence_score;
+  });
+}

--- a/backend/BigSet_Data_Collection_Agent/src/integrations/openrouter.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/integrations/openrouter.ts
@@ -1,0 +1,2 @@
+/** @deprecated Import from `../llm/complete-json.js` instead. */
+export { completeJson, type LlmMessage } from "../llm/complete-json.js";

--- a/backend/BigSet_Data_Collection_Agent/src/integrations/tinyfish-agent.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/integrations/tinyfish-agent.ts
@@ -37,6 +37,10 @@ export interface TinyfishAgentJob {
   goal: string;
 }
 
+export interface TinyfishAgentRunOptions {
+  pollTimeoutMs?: number;
+}
+
 function runToResult(run: Run): TinyfishAgentRunResult {
   const errorMessage =
     run.error?.message ??
@@ -114,8 +118,10 @@ export async function queueTinyfishAgent(
 /** Poll `runs.get` until the run reaches a terminal status or times out. */
 export async function pollTinyfishAgentUntilDone(
   runId: string,
+  options: TinyfishAgentRunOptions = {},
 ): Promise<TinyfishAgentRunResult> {
   const startedAt = Date.now();
+  const pollTimeoutMs = options.pollTimeoutMs ?? config.agentPollTimeoutMs;
   let lastStatus = RunStatus.PENDING;
 
   while (true) {
@@ -134,7 +140,7 @@ export async function pollTinyfishAgentUntilDone(
       return runToResult(run);
     }
 
-    if (Date.now() - startedAt >= config.agentPollTimeoutMs) {
+    if (Date.now() - startedAt >= pollTimeoutMs) {
       await cancelTinyfishAgentRun(runId);
 
       try {
@@ -146,7 +152,7 @@ export async function pollTinyfishAgentUntilDone(
               ...result,
               error:
                 result.error ??
-                `Agent run cancelled after ${config.agentPollTimeoutMs}ms (was ${lastStatus})`,
+                `Agent run cancelled after ${pollTimeoutMs}ms (was ${lastStatus})`,
             };
           }
           return result;
@@ -159,7 +165,7 @@ export async function pollTinyfishAgentUntilDone(
         run_id: runId,
         status: "TIMEOUT",
         result: null,
-        error: `Agent run timed out after ${config.agentPollTimeoutMs}ms (last status: ${lastStatus}); cancel requested`,
+        error: `Agent run timed out after ${pollTimeoutMs}ms (last status: ${lastStatus}); cancel requested`,
       };
     }
 
@@ -173,6 +179,7 @@ export async function pollTinyfishAgentUntilDone(
 export async function runTinyfishAgent(
   url: string,
   goal: string,
+  options: TinyfishAgentRunOptions = {},
 ): Promise<TinyfishAgentRunResult> {
   const queued = await queueTinyfishAgent(url, goal);
   if (queued.error || !queued.run_id) {
@@ -183,7 +190,7 @@ export async function runTinyfishAgent(
       error: queued.error ?? "Failed to queue agent run",
     };
   }
-  return pollTinyfishAgentUntilDone(queued.run_id);
+  return pollTinyfishAgentUntilDone(queued.run_id, options);
 }
 
 /**
@@ -191,6 +198,7 @@ export async function runTinyfishAgent(
  */
 export async function runTinyfishAgentsBatch(
   jobs: TinyfishAgentJob[],
+  options: TinyfishAgentRunOptions = {},
 ): Promise<TinyfishAgentRunResult[]> {
   if (jobs.length === 0) return [];
 
@@ -224,7 +232,7 @@ export async function runTinyfishAgentsBatch(
     pollTargets,
     config.agentPollConcurrency,
     async ({ index, run_id }) => {
-      results[index] = await pollTinyfishAgentUntilDone(run_id);
+      results[index] = await pollTinyfishAgentUntilDone(run_id, options);
     },
   );
 

--- a/backend/BigSet_Data_Collection_Agent/src/integrations/tinyfish-agent.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/integrations/tinyfish-agent.ts
@@ -1,0 +1,232 @@
+import { RunStatus, TinyFish, type Run } from "@tiny-fish/sdk";
+import { config } from "../config.js";
+import { sleep, withRetry } from "../queue/retry.js";
+import { mapWithConcurrency } from "../utils/concurrency.js";
+
+let client: TinyFish | null = null;
+
+const TINYFISH_API_BASE = "https://agent.tinyfish.ai";
+
+function getClient(): TinyFish {
+  if (!client) {
+    client = new TinyFish({ apiKey: config.tinyfishApiKey });
+  }
+  return client;
+}
+
+const TERMINAL_STATUSES: ReadonlySet<string> = new Set([
+  RunStatus.COMPLETED,
+  RunStatus.FAILED,
+  RunStatus.CANCELLED,
+]);
+
+export interface TinyfishAgentRunResult {
+  run_id: string | null;
+  status: string;
+  result: Record<string, unknown> | null;
+  error: string | null;
+}
+
+export interface QueueTinyfishAgentResult {
+  run_id: string | null;
+  error: string | null;
+}
+
+export interface TinyfishAgentJob {
+  url: string;
+  goal: string;
+}
+
+function runToResult(run: Run): TinyfishAgentRunResult {
+  const errorMessage =
+    run.error?.message ??
+    (run.status === RunStatus.FAILED ? "Agent run failed" : null);
+
+  return {
+    run_id: run.run_id,
+    status: run.status,
+    result: (run.result as Record<string, unknown> | null) ?? null,
+    error: errorMessage,
+  };
+}
+
+/** Best-effort cancel for async agent runs (POST /v1/runs/{id}/cancel). */
+export async function cancelTinyfishAgentRun(runId: string): Promise<void> {
+  if (!runId.trim()) return;
+
+  try {
+    await withRetry(
+      async () => {
+        const response = await fetch(
+          `${TINYFISH_API_BASE}/v1/runs/${encodeURIComponent(runId)}/cancel`,
+          {
+            method: "POST",
+            headers: {
+              "X-API-Key": config.tinyfishApiKey,
+              "Content-Type": "application/json",
+            },
+          },
+        );
+
+        if (!response.ok) {
+          const body = await response.text();
+          throw new Error(
+            `Cancel failed (${response.status})${body ? `: ${body.slice(0, 200)}` : ""}`,
+          );
+        }
+      },
+      {
+        maxRetries: 1,
+        baseDelayMs: config.retryBaseDelayMs,
+        label: `agent.cancel:${runId}`,
+      },
+    );
+  } catch {
+    // Cancel is best-effort — polling timeout still reports failure.
+  }
+}
+
+/** Submit a run via `/run-async` (returns immediately with run_id). */
+export async function queueTinyfishAgent(
+  url: string,
+  goal: string,
+): Promise<QueueTinyfishAgentResult> {
+  const response = await withRetry(
+    () => getClient().agent.queue({ url, goal }),
+    {
+      maxRetries: config.maxRetries,
+      baseDelayMs: config.retryBaseDelayMs,
+      label: `agent.queue:${url}`,
+    },
+  );
+
+  if (response.error) {
+    return { run_id: null, error: response.error.message };
+  }
+
+  if (!response.run_id) {
+    return { run_id: null, error: "Failed to queue agent run (no run_id)" };
+  }
+
+  return { run_id: response.run_id, error: null };
+}
+
+/** Poll `runs.get` until the run reaches a terminal status or times out. */
+export async function pollTinyfishAgentUntilDone(
+  runId: string,
+): Promise<TinyfishAgentRunResult> {
+  const startedAt = Date.now();
+  let lastStatus = RunStatus.PENDING;
+
+  while (true) {
+    const run = await withRetry(
+      () => getClient().runs.get(runId),
+      {
+        maxRetries: config.maxRetries,
+        baseDelayMs: config.retryBaseDelayMs,
+        label: `agent.poll:${runId}`,
+      },
+    );
+
+    lastStatus = run.status;
+
+    if (TERMINAL_STATUSES.has(run.status)) {
+      return runToResult(run);
+    }
+
+    if (Date.now() - startedAt >= config.agentPollTimeoutMs) {
+      await cancelTinyfishAgentRun(runId);
+
+      try {
+        const finalRun = await getClient().runs.get(runId);
+        if (TERMINAL_STATUSES.has(finalRun.status)) {
+          const result = runToResult(finalRun);
+          if (finalRun.status === RunStatus.CANCELLED) {
+            return {
+              ...result,
+              error:
+                result.error ??
+                `Agent run cancelled after ${config.agentPollTimeoutMs}ms (was ${lastStatus})`,
+            };
+          }
+          return result;
+        }
+      } catch {
+        // Fall through to TIMEOUT result below.
+      }
+
+      return {
+        run_id: runId,
+        status: "TIMEOUT",
+        result: null,
+        error: `Agent run timed out after ${config.agentPollTimeoutMs}ms (last status: ${lastStatus}); cancel requested`,
+      };
+    }
+
+    await sleep(config.agentPollIntervalMs);
+  }
+}
+
+/**
+ * Queue then poll — drop-in replacement for the old synchronous `/run` helper.
+ */
+export async function runTinyfishAgent(
+  url: string,
+  goal: string,
+): Promise<TinyfishAgentRunResult> {
+  const queued = await queueTinyfishAgent(url, goal);
+  if (queued.error || !queued.run_id) {
+    return {
+      run_id: null,
+      status: RunStatus.FAILED,
+      result: null,
+      error: queued.error ?? "Failed to queue agent run",
+    };
+  }
+  return pollTinyfishAgentUntilDone(queued.run_id);
+}
+
+/**
+ * Queue all jobs quickly, then poll in parallel — better overlap than sync `/run` waves.
+ */
+export async function runTinyfishAgentsBatch(
+  jobs: TinyfishAgentJob[],
+): Promise<TinyfishAgentRunResult[]> {
+  if (jobs.length === 0) return [];
+
+  const queued = await mapWithConcurrency(
+    jobs,
+    config.agentQueueConcurrency,
+    async (job) => {
+      const queueResult = await queueTinyfishAgent(job.url, job.goal);
+      return { job, ...queueResult };
+    },
+  );
+
+  const results: TinyfishAgentRunResult[] = new Array(jobs.length);
+
+  const pollTargets: { index: number; run_id: string }[] = [];
+  for (let index = 0; index < queued.length; index++) {
+    const item = queued[index]!;
+    if (item.error || !item.run_id) {
+      results[index] = {
+        run_id: null,
+        status: RunStatus.FAILED,
+        result: null,
+        error: item.error ?? "Failed to queue agent run",
+      };
+      continue;
+    }
+    pollTargets.push({ index, run_id: item.run_id });
+  }
+
+  await mapWithConcurrency(
+    pollTargets,
+    config.agentPollConcurrency,
+    async ({ index, run_id }) => {
+      results[index] = await pollTinyfishAgentUntilDone(run_id);
+    },
+  );
+
+  return results;
+}

--- a/backend/BigSet_Data_Collection_Agent/src/integrations/tinyfish.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/integrations/tinyfish.ts
@@ -1,0 +1,70 @@
+import { TinyFish } from "@tiny-fish/sdk";
+import { config } from "../config.js";
+import type { FetchedPage, SourceCandidate } from "../models/schemas.js";
+
+let client: TinyFish | null = null;
+
+function getClient(): TinyFish {
+  if (!client) {
+    client = new TinyFish({ apiKey: config.tinyfishApiKey });
+  }
+  return client;
+}
+
+export async function searchWeb(
+  query: string,
+  page = 0,
+): Promise<SourceCandidate[]> {
+  const response = await getClient().search.query({ query, page });
+  return response.results.map((result) => ({
+    url: result.url,
+    title: result.title,
+    snippet: result.snippet,
+    site_name: result.site_name,
+    query,
+    position: result.position,
+    search_page: page,
+  }));
+}
+
+export async function fetchPages(
+  urls: string[],
+  options?: { includeLinks?: boolean },
+): Promise<FetchedPage[]> {
+  if (urls.length === 0) return [];
+
+  const response = await getClient().fetch.getContents({
+    urls,
+    format: "markdown",
+    links: options?.includeLinks ?? false,
+  });
+
+  const pages: FetchedPage[] = response.results.map((page) => ({
+    url: page.url,
+    final_url: page.final_url ?? page.url,
+    title: page.title ?? "",
+    description: page.description ?? undefined,
+    text: typeof page.text === "string" ? page.text : JSON.stringify(page.text),
+    outbound_links: page.links,
+  }));
+
+  for (const err of response.errors) {
+    pages.push({
+      url: err.url,
+      final_url: err.url,
+      title: "",
+      text: "",
+      error: err.error,
+    });
+  }
+
+  return pages;
+}
+
+export function chunkUrls(urls: string[], size: number): string[][] {
+  const chunks: string[][] = [];
+  for (let i = 0; i < urls.length; i += size) {
+    chunks.push(urls.slice(i, i + size));
+  }
+  return chunks;
+}

--- a/backend/BigSet_Data_Collection_Agent/src/llm/complete-json.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/llm/complete-json.ts
@@ -1,0 +1,93 @@
+import { generateText, Output } from "ai";
+import type { z } from "zod";
+
+import { config } from "../config.js";
+import { getOpenRouterLimiter } from "../queue/pools.js";
+import { getOpenRouterChatModel } from "./provider.js";
+import { recordLanguageModelUsage } from "./usage.js";
+
+export interface LlmMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+type ConversationMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+function splitPromptMessages(messages: LlmMessage[]): {
+  system?: string;
+  messages: ConversationMessage[];
+} {
+  const systemParts: string[] = [];
+  const conversation: ConversationMessage[] = [];
+
+  for (const message of messages) {
+    if (message.role === "system") {
+      systemParts.push(message.content);
+      continue;
+    }
+    conversation.push({ role: message.role, content: message.content });
+  }
+
+  return {
+    system: systemParts.length > 0 ? systemParts.join("\n\n") : undefined,
+    messages: conversation,
+  };
+}
+
+/**
+ * Structured JSON completion via Vercel AI SDK (`generateText` + `Output.object`).
+ * Token usage is recorded into the current `runWithLlmUsageScope` when active.
+ */
+export async function completeJson<T>(options: {
+  messages: LlmMessage[];
+  schema: z.ZodType<T>;
+  label: string;
+  maxRetries?: number;
+}): Promise<T> {
+  const maxRetries = options.maxRetries ?? 2;
+  let messages = [...options.messages];
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    await getOpenRouterLimiter().acquire();
+
+    const { system, messages: conversation } = splitPromptMessages(messages);
+
+    try {
+      const result = await generateText({
+        model: getOpenRouterChatModel(),
+        ...(system ? { system } : {}),
+        messages: conversation,
+        output: Output.object({ schema: options.schema }),
+        ...(config.openRouterTemperature !== undefined
+          ? { temperature: config.openRouterTemperature }
+          : {}),
+      });
+
+      recordLanguageModelUsage(result.usage);
+      return result.output as T;
+    } catch (error) {
+      lastError = error;
+      if (attempt < maxRetries) {
+        messages = [
+          ...messages,
+          {
+            role: "user",
+            content: `Your JSON was invalid for ${options.label}. Error: ${
+              error instanceof Error ? error.message : String(error)
+            }. Return only valid JSON matching the requested schema.`,
+          },
+        ];
+      }
+    }
+  }
+
+  throw new Error(
+    `${options.label} failed after ${maxRetries + 1} attempts: ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`,
+  );
+}

--- a/backend/BigSet_Data_Collection_Agent/src/llm/provider.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/llm/provider.ts
@@ -1,0 +1,23 @@
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+
+import { config } from "../config.js";
+
+let openRouterProvider: ReturnType<typeof createOpenRouter> | null = null;
+
+function getOpenRouterProvider(): ReturnType<typeof createOpenRouter> {
+  if (!openRouterProvider) {
+    openRouterProvider = createOpenRouter({
+      apiKey: config.openRouterApiKey,
+      headers: {
+        "HTTP-Referer": config.openRouterSiteUrl,
+        "X-Title": config.openRouterAppName,
+      },
+    });
+  }
+  return openRouterProvider;
+}
+
+/** OpenRouter chat model via the official AI SDK provider (not OpenAI-compatible shim). */
+export function getOpenRouterChatModel() {
+  return getOpenRouterProvider().chat(config.openRouterModel);
+}

--- a/backend/BigSet_Data_Collection_Agent/src/llm/usage.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/llm/usage.ts
@@ -1,0 +1,57 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { LanguageModelUsage } from "ai";
+
+export interface LlmUsageTotals {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  callCount: number;
+}
+
+const storage = new AsyncLocalStorage<LlmUsageTotals>();
+
+export function emptyLlmUsage(): LlmUsageTotals {
+  return {
+    promptTokens: 0,
+    completionTokens: 0,
+    totalTokens: 0,
+    callCount: 0,
+  };
+}
+
+/** Run pipeline (or other work) with a scoped LLM usage accumulator. */
+export async function runWithLlmUsageScope<T>(
+  fn: () => Promise<T>,
+): Promise<{ result: T; usage: LlmUsageTotals }> {
+  const usage = emptyLlmUsage();
+  const result = await storage.run(usage, fn);
+  return { result, usage: { ...usage } };
+}
+
+export function getCurrentLlmUsage(): LlmUsageTotals {
+  return storage.getStore() ?? emptyLlmUsage();
+}
+
+export function recordLanguageModelUsage(usage: LanguageModelUsage | undefined): void {
+  const totals = storage.getStore();
+  if (!totals || !usage) {
+    return;
+  }
+
+  const promptTokens = usage.inputTokens ?? 0;
+  const completionTokens = usage.outputTokens ?? 0;
+  totals.promptTokens += promptTokens;
+  totals.completionTokens += completionTokens;
+  totals.totalTokens += usage.totalTokens ?? promptTokens + completionTokens;
+  totals.callCount += 1;
+}
+
+export function toDatasetAgentUsage(
+  usage: LlmUsageTotals,
+): { promptTokens: number; completionTokens: number; totalTokens: number } {
+  return {
+    promptTokens: usage.promptTokens,
+    completionTokens: usage.completionTokens,
+    totalTokens: usage.totalTokens,
+  };
+}

--- a/backend/BigSet_Data_Collection_Agent/src/memory/fingerprint.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/memory/fingerprint.ts
@@ -1,0 +1,6 @@
+import { createHash } from "node:crypto";
+
+export function promptFingerprint(prompt: string): string {
+  const normalized = prompt.trim().toLowerCase().replace(/\s+/g, " ");
+  return createHash("sha256").update(normalized).digest("hex").slice(0, 16);
+}

--- a/backend/BigSet_Data_Collection_Agent/src/memory/index.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/memory/index.ts
@@ -1,0 +1,26 @@
+export { promptFingerprint } from "./fingerprint.js";
+export {
+  createWorkflowMemory,
+  domainMemoryBoost,
+  memoryContextForAgents,
+  mergePersistentMemory,
+  recordCoverageGaps,
+  recordDiagnosis,
+  recordPhaseInMemory,
+  snapshotExtractionSchema,
+} from "./workflow-memory.js";
+export { loadPersistentMemory, savePersistentMemory, saveRunMemory } from "./store.js";
+export {
+  aggregateQueryStatsByText,
+  effectiveWeightedQuality,
+  planRepairSearches,
+  type SearchPlan,
+} from "./search-pagination.js";
+export type {
+  AgentGoalMemoryEntry,
+  DomainMemoryEntry,
+  QueryMemoryEntry,
+  RepairDiagnosis,
+  WorkflowMemory,
+} from "./types.js";
+export { repairDiagnosisSchema, workflowMemorySchema } from "./types.js";

--- a/backend/BigSet_Data_Collection_Agent/src/memory/scored-aggregates.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/memory/scored-aggregates.ts
@@ -1,0 +1,481 @@
+import type {
+  AgentRunRecord,
+  DatasetSpec,
+  ExtractedRecord,
+  SourceCandidate,
+  SourceTriageResult,
+} from "../models/schemas.js";
+import { agentExtractedUrls, triageByUrl } from "../quality/index.js";
+import { scoreRecord, type ScoreRecordContext } from "../quality/score-record.js";
+import { getDomain, normalizeUrl } from "../utils/url.js";
+import { recomputeWeightedQuality } from "./search-pagination.js";
+import type {
+  AgentGoalMemoryEntry,
+  DomainMemoryEntry,
+  QueryMemoryEntry,
+  QueryPageBreakdown,
+  WorkflowMemory,
+} from "./types.js";
+
+export interface RecordMetrics {
+  completeness: number;
+  confidence: number;
+}
+
+function rollingAvg(current: number, count: number, value: number): number {
+  if (count <= 0) return value;
+  return (current * count + value) / (count + 1);
+}
+
+export function metricsForRecord(
+  spec: DatasetSpec,
+  record: ExtractedRecord,
+  context: ScoreRecordContext,
+): RecordMetrics {
+  const quality = scoreRecord(spec, record, context, "memory");
+  return {
+    completeness: quality.completeness_pct,
+    confidence: quality.confidence_score,
+  };
+}
+
+export function buildUrlToQueryMap(
+  candidates: SourceCandidate[],
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const candidate of candidates) {
+    map.set(normalizeUrl(candidate.url), candidate.query);
+  }
+  return map;
+}
+
+function getOrCreateQueryEntry(
+  memory: WorkflowMemory,
+  query: string,
+  phase: string,
+  repairLoop: number,
+): QueryMemoryEntry {
+  let entry = memory.query_stats.find(
+    (item) => item.query === query && item.phase === phase,
+  );
+  if (!entry) {
+    entry = {
+      query,
+      phase,
+      repair_loop: repairLoop,
+      urls_produced: 0,
+      urls_with_records: 0,
+      record_count: 0,
+      avg_completeness: 0,
+      avg_confidence: 0,
+      search_page: 0,
+      weighted_quality: 0,
+      page_breakdown: [],
+    };
+    memory.query_stats.push(entry);
+  }
+  return entry;
+}
+
+function getOrCreatePageSlice(
+  entry: QueryMemoryEntry,
+  page: number,
+): QueryPageBreakdown {
+  let slice = entry.page_breakdown.find((item) => item.page === page);
+  if (!slice) {
+    slice = {
+      page,
+      urls_produced: 0,
+      urls_with_records: 0,
+      record_count: 0,
+      avg_completeness: 0,
+      avg_confidence: 0,
+    };
+    entry.page_breakdown.push(slice);
+  }
+  return slice;
+}
+
+function applyMetricsToPageSlice(
+  slice: QueryPageBreakdown,
+  metrics: RecordMetrics,
+): void {
+  slice.avg_completeness = rollingAvg(
+    slice.avg_completeness,
+    slice.record_count,
+    metrics.completeness,
+  );
+  slice.avg_confidence = rollingAvg(
+    slice.avg_confidence,
+    slice.record_count,
+    metrics.confidence,
+  );
+  slice.record_count += 1;
+}
+
+function getOrCreateDomainEntry(
+  memory: WorkflowMemory,
+  domain: string,
+  repairLoop: number,
+): DomainMemoryEntry {
+  let entry = memory.domain_stats.find((item) => item.domain === domain);
+  if (!entry) {
+    entry = {
+      domain,
+      record_count: 0,
+      fetch_failures: 0,
+      avg_completeness: 0,
+      avg_confidence: 0,
+      last_repair_loop: repairLoop,
+    };
+    memory.domain_stats.push(entry);
+  }
+  return entry;
+}
+
+function applyMetricsToDomain(
+  entry: DomainMemoryEntry,
+  metrics: RecordMetrics,
+  repairLoop: number,
+): void {
+  entry.avg_completeness = rollingAvg(
+    entry.avg_completeness,
+    entry.record_count,
+    metrics.completeness,
+  );
+  entry.avg_confidence = rollingAvg(
+    entry.avg_confidence,
+    entry.record_count,
+    metrics.confidence,
+  );
+  entry.record_count += 1;
+  entry.last_repair_loop = repairLoop;
+}
+
+function applyMetricsToQuery(
+  entry: QueryMemoryEntry,
+  metrics: RecordMetrics,
+  searchPage = 0,
+): void {
+  entry.avg_completeness = rollingAvg(
+    entry.avg_completeness,
+    entry.record_count,
+    metrics.completeness,
+  );
+  entry.avg_confidence = rollingAvg(
+    entry.avg_confidence,
+    entry.record_count,
+    metrics.confidence,
+  );
+  entry.record_count += 1;
+  entry.search_page = Math.max(entry.search_page ?? 0, searchPage);
+
+  const slice = getOrCreatePageSlice(entry, searchPage);
+  applyMetricsToPageSlice(slice, metrics);
+  recomputeWeightedQuality(entry);
+}
+
+export function attributeRecordsToMemory(options: {
+  memory: WorkflowMemory;
+  spec: DatasetSpec;
+  phase: string;
+  repairLoop: number;
+  queries: string[];
+  candidates: SourceCandidate[];
+  records: ExtractedRecord[];
+  failedUrls: string[];
+  agentRuns: AgentRunRecord[];
+  triageResults: SourceTriageResult[];
+}): void {
+  const {
+    memory,
+    spec,
+    phase,
+    repairLoop,
+    queries,
+    candidates,
+    records,
+    failedUrls,
+    agentRuns,
+    triageResults,
+  } = options;
+
+  const urlToQuery = buildUrlToQueryMap(candidates);
+  const context: ScoreRecordContext = {
+    triageByUrl: triageByUrl(triageResults),
+    agentExtractedUrls: agentExtractedUrls(agentRuns),
+  };
+
+  const candidateUrlsByQuery = new Map<string, Set<string>>();
+  const candidateUrlsByQueryPage = new Map<string, Map<number, Set<string>>>();
+  const urlToSearchPage = new Map<string, number>();
+
+  for (const candidate of candidates) {
+    const normalized = normalizeUrl(candidate.url);
+    const page = candidate.search_page ?? 0;
+    urlToSearchPage.set(normalized, page);
+
+    if (!candidateUrlsByQuery.has(candidate.query)) {
+      candidateUrlsByQuery.set(candidate.query, new Set());
+    }
+    candidateUrlsByQuery.get(candidate.query)!.add(normalized);
+
+    if (!candidateUrlsByQueryPage.has(candidate.query)) {
+      candidateUrlsByQueryPage.set(candidate.query, new Map());
+    }
+    const byPage = candidateUrlsByQueryPage.get(candidate.query)!;
+    if (!byPage.has(page)) byPage.set(page, new Set());
+    byPage.get(page)!.add(normalized);
+  }
+
+  for (const query of queries) {
+    const entry = getOrCreateQueryEntry(memory, query, phase, repairLoop);
+    const urls = candidateUrlsByQuery.get(query);
+    if (urls) entry.urls_produced += urls.size;
+
+    const byPage = candidateUrlsByQueryPage.get(query);
+    if (byPage) {
+      for (const [page, pageUrls] of byPage) {
+        const slice = getOrCreatePageSlice(entry, page);
+        slice.urls_produced += pageUrls.size;
+        entry.search_page = Math.max(entry.search_page ?? 0, page);
+      }
+    }
+  }
+
+  const urlsWithRecordsByQuery = new Map<string, Set<string>>();
+  const urlsWithRecordsByQueryPage = new Map<string, Map<number, Set<string>>>();
+
+  for (const record of records) {
+    const metrics = metricsForRecord(spec, record, context);
+    const queriesHit = new Set<string>();
+    const domainsHit = new Set<string>();
+
+    const attributeUrl = (rawUrl: string) => {
+      const normalized = normalizeUrl(rawUrl);
+      const domain = getDomain(rawUrl);
+
+      if (!domainsHit.has(domain)) {
+        domainsHit.add(domain);
+        applyMetricsToDomain(
+          getOrCreateDomainEntry(memory, domain, repairLoop),
+          metrics,
+          repairLoop,
+        );
+      }
+
+      const query = urlToQuery.get(normalized);
+      if (query) {
+        if (!urlsWithRecordsByQuery.has(query)) {
+          urlsWithRecordsByQuery.set(query, new Set());
+        }
+        urlsWithRecordsByQuery.get(query)!.add(normalized);
+        queriesHit.add(query);
+
+        const page = urlToSearchPage.get(normalized) ?? 0;
+        if (!urlsWithRecordsByQueryPage.has(query)) {
+          urlsWithRecordsByQueryPage.set(query, new Map());
+        }
+        const byPage = urlsWithRecordsByQueryPage.get(query)!;
+        if (!byPage.has(page)) byPage.set(page, new Set());
+        byPage.get(page)!.add(normalized);
+      }
+    };
+
+    for (const sourceUrl of record.source_urls) {
+      attributeUrl(sourceUrl);
+    }
+    for (const item of record.evidence) {
+      attributeUrl(item.url);
+    }
+
+    for (const query of queriesHit) {
+      let searchPage = 0;
+      for (const sourceUrl of record.source_urls) {
+        const normalized = normalizeUrl(sourceUrl);
+        if (urlToQuery.get(normalized) === query) {
+          searchPage = urlToSearchPage.get(normalized) ?? 0;
+          break;
+        }
+      }
+      if (searchPage === 0) {
+        for (const item of record.evidence) {
+          const normalized = normalizeUrl(item.url);
+          if (urlToQuery.get(normalized) === query) {
+            searchPage = urlToSearchPage.get(normalized) ?? 0;
+            break;
+          }
+        }
+      }
+      applyMetricsToQuery(
+        getOrCreateQueryEntry(memory, query, phase, repairLoop),
+        metrics,
+        searchPage,
+      );
+    }
+  }
+
+  for (const [query, urls] of urlsWithRecordsByQuery) {
+    const entry = getOrCreateQueryEntry(memory, query, phase, repairLoop);
+    entry.urls_with_records = Math.max(entry.urls_with_records, urls.size);
+
+    const byPage = urlsWithRecordsByQueryPage.get(query);
+    if (byPage) {
+      for (const [page, pageUrls] of byPage) {
+        const slice = getOrCreatePageSlice(entry, page);
+        slice.urls_with_records = Math.max(slice.urls_with_records, pageUrls.size);
+      }
+    }
+    recomputeWeightedQuality(entry);
+  }
+
+  for (const url of failedUrls) {
+    const entry = getOrCreateDomainEntry(memory, getDomain(url), repairLoop);
+    entry.fetch_failures += 1;
+    entry.last_repair_loop = repairLoop;
+  }
+
+  for (const run of agentRuns) {
+    const normalizedUrl = normalizeUrl(run.url);
+    const domain = getDomain(run.url);
+
+    if (run.records_extracted > 0 && run.goal) {
+      const matching = records.filter((record) =>
+        record.source_urls.some((u) => normalizeUrl(u) === normalizedUrl),
+      );
+
+      let goalEntry = memory.agent_goal_stats.find(
+        (item) => item.url === run.url && item.goal === run.goal,
+      );
+      if (!goalEntry) {
+        goalEntry = {
+          url: run.url,
+          goal: run.goal,
+          repair_loop: repairLoop,
+          record_count: 0,
+          avg_completeness: 0,
+          avg_confidence: 0,
+        };
+        memory.agent_goal_stats.push(goalEntry);
+      }
+
+      for (const record of matching) {
+        const metrics = metricsForRecord(spec, record, context);
+        goalEntry.avg_completeness = rollingAvg(
+          goalEntry.avg_completeness,
+          goalEntry.record_count,
+          metrics.completeness,
+        );
+        goalEntry.avg_confidence = rollingAvg(
+          goalEntry.avg_confidence,
+          goalEntry.record_count,
+          metrics.confidence,
+        );
+        goalEntry.record_count += 1;
+      }
+    } else {
+      const domainEntry = getOrCreateDomainEntry(memory, domain, repairLoop);
+      domainEntry.fetch_failures += 1;
+    }
+  }
+
+  capMemoryLists(memory);
+}
+
+function capMemoryLists(memory: WorkflowMemory): void {
+  if (memory.query_stats.length > 80) {
+    memory.query_stats.splice(0, memory.query_stats.length - 80);
+  }
+  if (memory.domain_stats.length > 50) {
+    memory.domain_stats.sort((a, b) => b.record_count - a.record_count);
+    memory.domain_stats = memory.domain_stats.slice(0, 50);
+  }
+  if (memory.agent_goal_stats.length > 40) {
+    memory.agent_goal_stats = memory.agent_goal_stats
+      .filter((item) => item.record_count > 0)
+      .slice(-40);
+  }
+}
+
+export function mergeQueryEntry(
+  target: QueryMemoryEntry,
+  source: QueryMemoryEntry,
+): void {
+  const totalRecords = target.record_count + source.record_count;
+  if (totalRecords > 0) {
+    target.avg_completeness =
+      (target.avg_completeness * target.record_count +
+        source.avg_completeness * source.record_count) /
+      totalRecords;
+    target.avg_confidence =
+      (target.avg_confidence * target.record_count +
+        source.avg_confidence * source.record_count) /
+      totalRecords;
+  }
+  target.record_count = totalRecords;
+  target.urls_produced += source.urls_produced;
+  target.urls_with_records += source.urls_with_records;
+  target.repair_loop = Math.max(target.repair_loop, source.repair_loop);
+  target.search_page = Math.max(
+    target.search_page ?? 0,
+    source.search_page ?? 0,
+  );
+
+  for (const slice of source.page_breakdown ?? []) {
+    const targetSlice = getOrCreatePageSlice(target, slice.page);
+    const combinedRecords = targetSlice.record_count + slice.record_count;
+    if (combinedRecords > 0) {
+      targetSlice.avg_completeness =
+        (targetSlice.avg_completeness * targetSlice.record_count +
+          slice.avg_completeness * slice.record_count) /
+        combinedRecords;
+      targetSlice.avg_confidence =
+        (targetSlice.avg_confidence * targetSlice.record_count +
+          slice.avg_confidence * slice.record_count) /
+        combinedRecords;
+    }
+    targetSlice.record_count = combinedRecords;
+    targetSlice.urls_produced += slice.urls_produced;
+    targetSlice.urls_with_records += slice.urls_with_records;
+  }
+  recomputeWeightedQuality(target);
+}
+
+export function mergeDomainEntry(
+  target: DomainMemoryEntry,
+  source: DomainMemoryEntry,
+): void {
+  const totalRecords = target.record_count + source.record_count;
+  if (totalRecords > 0) {
+    target.avg_completeness =
+      (target.avg_completeness * target.record_count +
+        source.avg_completeness * source.record_count) /
+      totalRecords;
+    target.avg_confidence =
+      (target.avg_confidence * target.record_count +
+        source.avg_confidence * source.record_count) /
+      totalRecords;
+  }
+  target.record_count = totalRecords;
+  target.fetch_failures += source.fetch_failures;
+  target.last_repair_loop = Math.max(target.last_repair_loop, source.last_repair_loop);
+}
+
+export function mergeAgentGoalEntry(
+  target: AgentGoalMemoryEntry,
+  source: AgentGoalMemoryEntry,
+): void {
+  const totalRecords = target.record_count + source.record_count;
+  if (totalRecords > 0) {
+    target.avg_completeness =
+      (target.avg_completeness * target.record_count +
+        source.avg_completeness * source.record_count) /
+      totalRecords;
+    target.avg_confidence =
+      (target.avg_confidence * target.record_count +
+        source.avg_confidence * source.record_count) /
+      totalRecords;
+  }
+  target.record_count = totalRecords;
+  target.repair_loop = Math.max(target.repair_loop, source.repair_loop);
+}

--- a/backend/BigSet_Data_Collection_Agent/src/memory/search-pagination.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/memory/search-pagination.ts
@@ -1,0 +1,184 @@
+import { config } from "../config.js";
+import type { QueryMemoryEntry, WorkflowMemory } from "./types.js";
+
+export interface SearchPlan {
+  /** Base query string sent to the Search API. */
+  query: string;
+  /** Search API page index (0-based, max 10). */
+  page: number;
+}
+
+/** Front pages count more toward recurring-search ranking. */
+const PAGE_WEIGHTS = [1.0, 0.75, 0.5, 0.35, 0.25, 0.2, 0.15, 0.12, 0.1, 0.08, 0.05];
+
+export function pageWeight(page: number): number {
+  if (page < 0) return 0.05;
+  return PAGE_WEIGHTS[page] ?? 0.05;
+}
+
+export function effectiveWeightedQuality(entry: QueryMemoryEntry): number {
+  if (entry.weighted_quality > 0) return entry.weighted_quality;
+  if (entry.record_count <= 0) return 0;
+  return (entry.avg_completeness + entry.avg_confidence) / 2;
+}
+
+export function recomputeWeightedQuality(entry: QueryMemoryEntry): void {
+  const breakdown = entry.page_breakdown ?? [];
+  if (breakdown.length === 0) {
+    entry.weighted_quality =
+      entry.record_count > 0
+        ? (entry.avg_completeness + entry.avg_confidence) / 2
+        : 0;
+    return;
+  }
+
+  let numerator = 0;
+  let denominator = 0;
+  for (const slice of breakdown) {
+    if (slice.record_count <= 0) continue;
+    const w = pageWeight(slice.page) * slice.record_count;
+    const q = (slice.avg_completeness + slice.avg_confidence) / 2;
+    numerator += w * q;
+    denominator += w;
+  }
+  entry.weighted_quality = denominator > 0 ? numerator / denominator : 0;
+}
+
+/** Roll up stats for the same query text across phases. */
+export function aggregateQueryStatsByText(
+  memory: WorkflowMemory,
+): Map<string, QueryMemoryEntry & { phases: string[] }> {
+  const map = new Map<string, QueryMemoryEntry & { phases: string[] }>();
+
+  for (const item of memory.query_stats) {
+    const existing = map.get(item.query);
+    if (!existing) {
+      map.set(item.query, {
+        ...item,
+        phases: [item.phase],
+        search_page: item.search_page ?? 0,
+        weighted_quality: item.weighted_quality ?? 0,
+        page_breakdown: [...(item.page_breakdown ?? [])],
+      });
+      continue;
+    }
+
+    existing.phases.push(item.phase);
+    existing.record_count += item.record_count;
+    existing.urls_produced += item.urls_produced;
+    existing.urls_with_records += item.urls_with_records;
+    existing.search_page = Math.max(
+      existing.search_page ?? 0,
+      item.search_page ?? 0,
+    );
+    existing.repair_loop = Math.max(existing.repair_loop, item.repair_loop);
+
+    const totalRecords = existing.record_count;
+    if (totalRecords > 0) {
+      const prevCount = totalRecords - item.record_count;
+      if (prevCount > 0) {
+        existing.avg_completeness =
+          (existing.avg_completeness * prevCount +
+            item.avg_completeness * item.record_count) /
+          totalRecords;
+        existing.avg_confidence =
+          (existing.avg_confidence * prevCount +
+            item.avg_confidence * item.record_count) /
+          totalRecords;
+      } else {
+        existing.avg_completeness = item.avg_completeness;
+        existing.avg_confidence = item.avg_confidence;
+      }
+    }
+
+    for (const slice of item.page_breakdown ?? []) {
+      const target = existing.page_breakdown!.find((p) => p.page === slice.page);
+      if (!target) {
+        existing.page_breakdown!.push({ ...slice });
+      } else {
+        const combined = target.record_count + slice.record_count;
+        if (combined > 0) {
+          target.avg_completeness =
+            (target.avg_completeness * target.record_count +
+              slice.avg_completeness * slice.record_count) /
+            combined;
+          target.avg_confidence =
+            (target.avg_confidence * target.record_count +
+              slice.avg_confidence * slice.record_count) /
+            combined;
+        }
+        target.record_count = combined;
+        target.urls_produced += slice.urls_produced;
+        target.urls_with_records += slice.urls_with_records;
+      }
+    }
+    recomputeWeightedQuality(existing);
+  }
+
+  return map;
+}
+
+/** New repair queries at page 0; top historical queries at the next page. */
+export function planRepairSearches(
+  memory: WorkflowMemory,
+  newQueries: string[],
+): SearchPlan[] {
+  const plans: SearchPlan[] = [];
+  const seen = new Set<string>();
+
+  for (const raw of newQueries) {
+    const query = raw.trim();
+    if (!query || seen.has(query)) continue;
+    seen.add(query);
+    plans.push({ query, page: 0 });
+  }
+
+  const aggregated = aggregateQueryStatsByText(memory);
+  const top = [...aggregated.values()]
+    .filter((item) => item.record_count > 0)
+    .sort(
+      (a, b) => effectiveWeightedQuality(b) - effectiveWeightedQuality(a),
+    )
+    .slice(0, config.maxRepairSearchPaginationQueries);
+
+  for (const entry of top) {
+    const nextPage = (entry.search_page ?? 0) + 1;
+    if (nextPage > config.maxSearchPage) continue;
+    if (seen.has(entry.query)) continue;
+    seen.add(entry.query);
+    plans.push({ query: entry.query, page: nextPage });
+  }
+
+  return plans;
+}
+
+/** After a repair search pass, persist the highest page used per query. */
+export function markSearchPagesUsed(
+  memory: WorkflowMemory,
+  plans: SearchPlan[],
+  phase: string,
+  repairLoop: number,
+): void {
+  for (const plan of plans) {
+    let entry = memory.query_stats.find(
+      (item) => item.query === plan.query && item.phase === phase,
+    );
+    if (!entry) {
+      entry = {
+        query: plan.query,
+        phase,
+        repair_loop: repairLoop,
+        urls_produced: 0,
+        urls_with_records: 0,
+        record_count: 0,
+        avg_completeness: 0,
+        avg_confidence: 0,
+        search_page: plan.page,
+        weighted_quality: 0,
+        page_breakdown: [],
+      };
+      memory.query_stats.push(entry);
+    }
+    entry.search_page = Math.max(entry.search_page ?? 0, plan.page);
+  }
+}

--- a/backend/BigSet_Data_Collection_Agent/src/memory/store.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/memory/store.ts
@@ -1,0 +1,125 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { workflowMemorySchema, type WorkflowMemory } from "./types.js";
+
+export function globalMemoryPath(memoryDir: string, fingerprint: string): string {
+  return join(memoryDir, `${fingerprint}.json`);
+}
+
+/** Migrate v1.1 coarse memory format to scored stats (best-effort). */
+function migrateLegacyMemory(raw: Record<string, unknown>): WorkflowMemory {
+  const base = workflowMemorySchema.parse({
+    prompt_fingerprint: raw.prompt_fingerprint,
+    user_prompt: raw.user_prompt,
+    repair_loop_count: raw.repair_loop_count ?? 0,
+    query_stats: [],
+    domain_stats: [],
+    agent_goal_stats: [],
+    extraction_schema: raw.extraction_schema,
+    dedupe_keys: raw.dedupe_keys ?? [],
+    diagnoses: raw.diagnoses ?? [],
+    strategy_notes: raw.strategy_notes ?? [],
+    last_missing_fields: raw.last_missing_fields,
+  });
+
+  const successfulDomains = raw.successful_domains as string[] | undefined;
+  const failedDomains = raw.failed_domains as string[] | undefined;
+
+  for (const domain of successfulDomains ?? []) {
+    base.domain_stats.push({
+      domain,
+      record_count: 1,
+      fetch_failures: 0,
+      avg_completeness: 0.7,
+      avg_confidence: 0.7,
+      last_repair_loop: 0,
+    });
+  }
+  for (const domain of failedDomains ?? []) {
+    base.domain_stats.push({
+      domain,
+      record_count: 0,
+      fetch_failures: 1,
+      avg_completeness: 0,
+      avg_confidence: 0,
+      last_repair_loop: 0,
+    });
+  }
+
+  const successfulQueries = raw.successful_queries as
+    | { query: string; phase: string; repair_loop: number }[]
+    | undefined;
+  for (const item of successfulQueries ?? []) {
+    base.query_stats.push({
+      query: item.query,
+      phase: item.phase,
+      repair_loop: item.repair_loop,
+      urls_produced: 1,
+      urls_with_records: 1,
+      record_count: 1,
+      avg_completeness: 0.7,
+      avg_confidence: 0.7,
+      search_page: 0,
+      weighted_quality: 0.7,
+      page_breakdown: [],
+    });
+  }
+
+  for (const query of (raw.failed_queries as string[] | undefined) ?? []) {
+    base.query_stats.push({
+      query,
+      phase: "legacy",
+      repair_loop: 0,
+      urls_produced: 1,
+      urls_with_records: 0,
+      record_count: 0,
+      avg_completeness: 0,
+      avg_confidence: 0,
+      search_page: 0,
+      weighted_quality: 0,
+      page_breakdown: [],
+    });
+  }
+
+  return base;
+}
+
+export async function loadPersistentMemory(
+  memoryDir: string,
+  fingerprint: string,
+): Promise<WorkflowMemory | null> {
+  try {
+    const raw = JSON.parse(
+      await readFile(globalMemoryPath(memoryDir, fingerprint), "utf8"),
+    ) as Record<string, unknown>;
+
+    if (Array.isArray(raw.query_stats)) {
+      return workflowMemorySchema.parse(raw);
+    }
+
+    return migrateLegacyMemory(raw);
+  } catch {
+    return null;
+  }
+}
+
+export async function savePersistentMemory(
+  memoryDir: string,
+  memory: WorkflowMemory,
+): Promise<void> {
+  await mkdir(memoryDir, { recursive: true });
+  await writeFile(
+    globalMemoryPath(memoryDir, memory.prompt_fingerprint),
+    `${JSON.stringify(memory, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+export async function saveRunMemory(
+  runRoot: string,
+  memory: WorkflowMemory,
+): Promise<string> {
+  const path = join(runRoot, "workflow_memory.json");
+  await writeFile(path, `${JSON.stringify(memory, null, 2)}\n`, "utf8");
+  return path;
+}

--- a/backend/BigSet_Data_Collection_Agent/src/memory/types.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/memory/types.ts
@@ -1,0 +1,101 @@
+import { z } from "zod";
+
+export const queryPageBreakdownSchema = z.object({
+  page: z.number().int().min(0),
+  urls_produced: z.number().int().nonnegative(),
+  urls_with_records: z.number().int().nonnegative(),
+  record_count: z.number().int().nonnegative(),
+  avg_completeness: z.number().min(0).max(1),
+  avg_confidence: z.number().min(0).max(1),
+});
+
+export type QueryPageBreakdown = z.infer<typeof queryPageBreakdownSchema>;
+
+/** Rolling aggregate for a search query based on records from URLs it surfaced. */
+export const queryMemoryEntrySchema = z.object({
+  query: z.string(),
+  phase: z.string(),
+  repair_loop: z.number(),
+  urls_produced: z.number().int().nonnegative(),
+  urls_with_records: z.number().int().nonnegative(),
+  record_count: z.number().int().nonnegative(),
+  avg_completeness: z.number().min(0).max(1),
+  avg_confidence: z.number().min(0).max(1),
+  /** Last Search API page index used for this query (0-based). */
+  search_page: z.number().int().min(0).default(0),
+  /** Page-weighted quality for recurring search (earlier pages weigh more). */
+  weighted_quality: z.number().min(0).max(1).default(0),
+  page_breakdown: z.array(queryPageBreakdownSchema).default([]),
+});
+
+export type QueryMemoryEntry = z.infer<typeof queryMemoryEntrySchema>;
+
+/** Rolling aggregate for a hostname from records attributed to that domain. */
+export const domainMemoryEntrySchema = z.object({
+  domain: z.string(),
+  record_count: z.number().int().nonnegative(),
+  fetch_failures: z.number().int().nonnegative(),
+  avg_completeness: z.number().min(0).max(1),
+  avg_confidence: z.number().min(0).max(1),
+  last_repair_loop: z.number().int().nonnegative(),
+});
+
+export type DomainMemoryEntry = z.infer<typeof domainMemoryEntrySchema>;
+
+/** Rolling aggregate for a Tinyfish Agent goal from records on that URL. */
+export const agentGoalMemoryEntrySchema = z.object({
+  url: z.string(),
+  goal: z.string(),
+  repair_loop: z.number(),
+  record_count: z.number().int().nonnegative(),
+  avg_completeness: z.number().min(0).max(1),
+  avg_confidence: z.number().min(0).max(1),
+});
+
+export type AgentGoalMemoryEntry = z.infer<typeof agentGoalMemoryEntrySchema>;
+
+export const extractionSchemaSnapshotSchema = z.object({
+  columns: z.array(
+    z.object({
+      name: z.string(),
+      type: z.string(),
+      required: z.boolean(),
+    }),
+  ),
+  dedupe_keys: z.array(z.string()),
+  row_grain: z.string(),
+});
+
+export const repairDiagnosisSchema = z.object({
+  summary: z.string(),
+  likely_causes: z.array(z.string()),
+  recommended_search_patterns: z.array(z.string()),
+  domains_to_prioritize: z.array(z.string()),
+  domains_to_avoid: z.array(z.string()),
+  prefer_tinyfish_agent: z.boolean(),
+  agent_strategy_notes: z.string().optional(),
+  extraction_notes: z.string().optional(),
+});
+
+export type RepairDiagnosis = z.infer<typeof repairDiagnosisSchema>;
+
+export const workflowMemorySchema = z.object({
+  prompt_fingerprint: z.string(),
+  user_prompt: z.string(),
+  repair_loop_count: z.number(),
+  query_stats: z.array(queryMemoryEntrySchema),
+  domain_stats: z.array(domainMemoryEntrySchema),
+  agent_goal_stats: z.array(agentGoalMemoryEntrySchema),
+  extraction_schema: extractionSchemaSnapshotSchema.optional(),
+  dedupe_keys: z.array(z.string()),
+  diagnoses: z.array(
+    z.object({
+      repair_loop: z.number(),
+      diagnosis: repairDiagnosisSchema,
+    }),
+  ),
+  strategy_notes: z.array(z.string()),
+  last_missing_fields: z.array(z.string()).optional(),
+});
+
+export type WorkflowMemory = z.infer<typeof workflowMemorySchema>;

--- a/backend/BigSet_Data_Collection_Agent/src/memory/workflow-memory.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/memory/workflow-memory.ts
@@ -1,0 +1,208 @@
+import type { CoverageReport } from "../coverage/analyze.js";
+import type {
+  AgentRunRecord,
+  DatasetSpec,
+  ExtractedRecord,
+  SourceCandidate,
+  SourceTriageResult,
+} from "../models/schemas.js";
+import { promptFingerprint } from "./fingerprint.js";
+import { effectiveWeightedQuality } from "./search-pagination.js";
+import {
+  attributeRecordsToMemory,
+  mergeAgentGoalEntry,
+  mergeDomainEntry,
+  mergeQueryEntry,
+} from "./scored-aggregates.js";
+import type {
+  RepairDiagnosis,
+  WorkflowMemory,
+} from "./types.js";
+
+export function createWorkflowMemory(
+  userPrompt: string,
+  spec?: DatasetSpec,
+): WorkflowMemory {
+  return {
+    prompt_fingerprint: promptFingerprint(userPrompt),
+    user_prompt: userPrompt,
+    repair_loop_count: 0,
+    query_stats: [],
+    domain_stats: [],
+    agent_goal_stats: [],
+    dedupe_keys: spec?.dedupe_keys ?? [],
+    extraction_schema: spec ? snapshotExtractionSchema(spec) : undefined,
+    diagnoses: [],
+    strategy_notes: [],
+  };
+}
+
+export function snapshotExtractionSchema(
+  spec: DatasetSpec,
+): WorkflowMemory["extraction_schema"] {
+  return {
+    row_grain: spec.row_grain,
+    dedupe_keys: spec.dedupe_keys,
+    columns: spec.columns.map((col) => ({
+      name: col.name,
+      type: col.type,
+      required: col.required,
+    })),
+  };
+}
+
+export function recordPhaseInMemory(options: {
+  memory: WorkflowMemory;
+  spec: DatasetSpec;
+  phase: string;
+  repairLoop: number;
+  queries: string[];
+  candidates: SourceCandidate[];
+  records: ExtractedRecord[];
+  failedUrls: string[];
+  agentRuns: AgentRunRecord[];
+  triageResults: SourceTriageResult[];
+}): void {
+  attributeRecordsToMemory(options);
+}
+
+export function recordDiagnosis(
+  memory: WorkflowMemory,
+  repairLoop: number,
+  diagnosis: RepairDiagnosis,
+): void {
+  memory.diagnoses.push({ repair_loop: repairLoop, diagnosis });
+  if (diagnosis.summary) {
+    memory.strategy_notes.push(`[loop ${repairLoop}] ${diagnosis.summary}`);
+  }
+  if (memory.strategy_notes.length > 30) {
+    memory.strategy_notes.splice(0, memory.strategy_notes.length - 30);
+  }
+}
+
+export function recordCoverageGaps(
+  memory: WorkflowMemory,
+  coverage: CoverageReport,
+): void {
+  memory.last_missing_fields = coverage.field_gaps.map((gap) => gap.column);
+}
+
+export function mergePersistentMemory(
+  base: WorkflowMemory,
+  prior: WorkflowMemory | null,
+): WorkflowMemory {
+  if (!prior || prior.prompt_fingerprint !== base.prompt_fingerprint) {
+    return base;
+  }
+
+  for (const source of prior.query_stats) {
+    const target = base.query_stats.find(
+      (item) => item.query === source.query && item.phase === source.phase,
+    );
+    if (target) mergeQueryEntry(target, source);
+    else base.query_stats.push({ ...source });
+  }
+
+  for (const source of prior.domain_stats) {
+    const target = base.domain_stats.find((item) => item.domain === source.domain);
+    if (target) mergeDomainEntry(target, source);
+    else base.domain_stats.push({ ...source });
+  }
+
+  for (const source of prior.agent_goal_stats) {
+    const target = base.agent_goal_stats.find(
+      (item) => item.url === source.url && item.goal === source.goal,
+    );
+    if (target) mergeAgentGoalEntry(target, source);
+    else base.agent_goal_stats.push({ ...source });
+  }
+
+  for (const note of prior.strategy_notes) {
+    if (!base.strategy_notes.includes(note)) {
+      base.strategy_notes.push(note);
+    }
+  }
+
+  return base;
+}
+
+function topQueries(memory: WorkflowMemory, limit: number) {
+  return [...memory.query_stats]
+    .filter((item) => item.record_count > 0)
+    .sort(
+      (a, b) => effectiveWeightedQuality(b) - effectiveWeightedQuality(a),
+    )
+    .slice(0, limit);
+}
+
+function weakQueries(memory: WorkflowMemory, limit: number) {
+  return [...memory.query_stats]
+    .filter((item) => item.urls_produced > 0 && item.record_count === 0)
+    .slice(-limit);
+}
+
+function topDomains(memory: WorkflowMemory, limit: number) {
+  return [...memory.domain_stats]
+    .filter((item) => item.record_count > 0)
+    .sort(
+      (a, b) =>
+        b.avg_completeness + b.avg_confidence - (a.avg_completeness + a.avg_confidence),
+    )
+    .slice(-limit);
+}
+
+function weakDomains(memory: WorkflowMemory, limit: number) {
+  return [...memory.domain_stats]
+    .filter(
+      (item) =>
+        item.fetch_failures > 0 ||
+        (item.record_count > 0 && item.avg_completeness < 0.5),
+    )
+    .sort((a, b) => b.fetch_failures - a.fetch_failures)
+    .slice(-limit);
+}
+
+function topAgentGoals(memory: WorkflowMemory, limit: number) {
+  return [...memory.agent_goal_stats]
+    .filter((item) => item.record_count > 0)
+    .sort(
+      (a, b) =>
+        b.avg_completeness + b.avg_confidence - (a.avg_completeness + a.avg_confidence),
+    )
+    .slice(-limit);
+}
+
+/** Compact context injected into LLM agent calls. */
+export function memoryContextForAgents(memory: WorkflowMemory): Record<string, unknown> {
+  return {
+    repair_loop_count: memory.repair_loop_count,
+    query_stats_top: topQueries(memory, 12),
+    query_stats_weak: weakQueries(memory, 10),
+    domain_stats_top: topDomains(memory, 15),
+    domain_stats_weak: weakDomains(memory, 12),
+    agent_goal_stats_top: topAgentGoals(memory, 6),
+    extraction_schema: memory.extraction_schema,
+    dedupe_keys: memory.dedupe_keys,
+    last_missing_fields: memory.last_missing_fields,
+    strategy_notes: memory.strategy_notes.slice(-8),
+    latest_diagnosis:
+      memory.diagnoses.length > 0
+        ? memory.diagnoses[memory.diagnoses.length - 1]!.diagnosis
+        : undefined,
+  };
+}
+
+export function domainMemoryBoost(
+  memory: WorkflowMemory,
+  domain: string,
+): number {
+  const stats = memory.domain_stats.find((item) => item.domain === domain);
+  if (!stats) return 0;
+
+  if (stats.record_count === 0 && stats.fetch_failures > 0) {
+    return -4;
+  }
+
+  const qualityScore = (stats.avg_completeness + stats.avg_confidence) / 2;
+  return (qualityScore - 0.5) * 4;
+}

--- a/backend/BigSet_Data_Collection_Agent/src/merge/records.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/merge/records.ts
@@ -1,8 +1,28 @@
 import type { DatasetSpec, ExtractedRecord } from "../models/schemas.js";
+import {
+  deriveRecordSourceUrls,
+  scoreDocsUrlForOfficialSource,
+} from "../records/source-urls.js";
 
 function normalizeValue(value: unknown): string {
   if (value === null || value === undefined) return "";
   return String(value).trim().toLowerCase();
+}
+
+function isEmpty(value: unknown): boolean {
+  return value === null || value === undefined || value === "";
+}
+
+function normalizeComparableValue(value: unknown): string {
+  return normalizeValue(value)
+    .replace(/https?:\/\/(?:www\.)?/g, "")
+    .replace(/[/#?]+$/g, "")
+    .replace(/\s+/g, " ");
+}
+
+function valuesMatch(a: unknown, b: unknown): boolean {
+  if (isEmpty(a) || isEmpty(b)) return false;
+  return normalizeComparableValue(a) === normalizeComparableValue(b);
 }
 
 /** Normalize entity names for stable primary-key matching. */
@@ -115,27 +135,58 @@ export function mergePair(
   spec: DatasetSpec,
 ): ExtractedRecord {
   const row: Record<string, string | number | boolean | null> = { ...a.row };
+  const fieldsFilledFromIncoming = new Set<string>();
+  let replacedDocsUrlFromIncoming = false;
 
   for (const col of spec.columns) {
     const current = row[col.name];
     const incoming = b.row[col.name];
-    const currentEmpty =
-      current === null || current === undefined || current === "";
-    const incomingFilled =
-      incoming !== null && incoming !== undefined && incoming !== "";
+    const currentEmpty = isEmpty(current);
+    const incomingFilled = !isEmpty(incoming);
 
     if (currentEmpty && incomingFilled) {
       row[col.name] = incoming ?? null;
+      fieldsFilledFromIncoming.add(col.name);
+    } else if (incomingFilled && shouldReplaceCell(col.name, current, incoming)) {
+      row[col.name] = incoming ?? null;
+      fieldsFilledFromIncoming.add(col.name);
+      replacedDocsUrlFromIncoming ||= isDocsUrlColumn(col.name);
     }
   }
 
-  const evidence = [...a.evidence];
-  const evidenceFields = new Set(evidence.map((e) => e.field));
-  for (const item of b.evidence) {
-    if (!evidenceFields.has(item.field)) {
-      evidence.push(item);
+  if (replacedDocsUrlFromIncoming) {
+    for (const col of spec.columns) {
+      const incoming = b.row[col.name];
+      if (
+        isDocsCompanionColumn(col.name) &&
+        !isEmpty(incoming) &&
+        !spec.dedupe_keys.includes(col.name)
+      ) {
+        row[col.name] = incoming ?? null;
+        fieldsFilledFromIncoming.add(col.name);
+      }
     }
   }
+
+  const evidence = a.evidence.filter((item) =>
+    valuesMatch(row[item.field], a.row[item.field]),
+  );
+  const evidenceFields = new Set(evidence.map((e) => e.field));
+  for (const item of b.evidence) {
+    if (
+      !evidenceFields.has(item.field) &&
+      shouldMergeIncomingEvidence({
+        field: item.field,
+        mergedRow: row,
+        incomingRow: b.row,
+        fieldsFilledFromIncoming,
+      })
+    ) {
+      evidence.push(item);
+      evidenceFields.add(item.field);
+    }
+  }
+  const coherentEvidence = filterEvidenceForRetainedDocsUrl(spec, row, evidence);
 
   const extractionConfidence = Math.max(
     a.extraction_confidence ?? 0,
@@ -144,10 +195,141 @@ export function mergePair(
 
   return {
     row,
-    evidence,
-    source_urls: [...new Set([...a.source_urls, ...b.source_urls])],
+    evidence: coherentEvidence,
+    source_urls: deriveRecordSourceUrls({
+      spec,
+      row,
+      evidence: coherentEvidence,
+      fallbackUrls: coherentEvidence.length > 0 ? [] : a.source_urls,
+    }),
     ...(extractionConfidence > 0
       ? { extraction_confidence: extractionConfidence }
       : {}),
   };
+}
+
+function shouldMergeIncomingEvidence(input: {
+  field: string;
+  mergedRow: Record<string, string | number | boolean | null>;
+  incomingRow: Record<string, string | number | boolean | null>;
+  fieldsFilledFromIncoming: Set<string>;
+}): boolean {
+  if (
+    isDocsUrlColumn(input.field) &&
+    !urlsReferenceSamePage(
+      input.incomingRow[input.field],
+      input.mergedRow[input.field],
+    )
+  ) {
+    return false;
+  }
+  if (input.fieldsFilledFromIncoming.has(input.field)) {
+    return true;
+  }
+  return valuesMatch(input.mergedRow[input.field], input.incomingRow[input.field]);
+}
+
+function shouldReplaceCell(
+  columnName: string,
+  current: string | number | boolean | null | undefined,
+  incoming: string | number | boolean | null | undefined,
+): boolean {
+  if (!isDocsUrlColumn(columnName)) {
+    return false;
+  }
+  return (
+    scoreDocsUrlForOfficialSource(incoming) >
+    scoreDocsUrlForOfficialSource(current)
+  );
+}
+
+function isDocsUrlColumn(columnName: string): boolean {
+  const lower = columnName.toLowerCase();
+  return (
+    lower === "docs_url" ||
+    lower.endsWith("_docs_url") ||
+    (lower.includes("docs") && lower.includes("url"))
+  );
+}
+
+function isDocsCompanionColumn(columnName: string): boolean {
+  const lower = columnName.toLowerCase();
+  return (
+    lower === "summary" ||
+    lower === "description" ||
+    lower === "docs_title" ||
+    (lower.includes("docs") && lower.includes("title"))
+  );
+}
+
+function filterEvidenceForRetainedDocsUrl(
+  spec: DatasetSpec,
+  row: Record<string, string | number | boolean | null>,
+  evidence: ExtractedRecord["evidence"],
+): ExtractedRecord["evidence"] {
+  const retainedDocsUrl = bestRetainedDocsUrl(spec, row);
+  if (!retainedDocsUrl) {
+    return evidence;
+  }
+
+  return evidence.filter((item) => {
+    if (isDocsUrlColumn(item.field)) {
+      return urlsReferenceSamePage(item.url, row[item.field]);
+    }
+
+    if (
+      isDocsCompanionColumn(item.field) ||
+      spec.dedupe_keys.includes(item.field)
+    ) {
+      return sourceUrlSupportsRetainedDocsUrl(item.url, retainedDocsUrl);
+    }
+
+    return true;
+  });
+}
+
+function bestRetainedDocsUrl(
+  spec: DatasetSpec,
+  row: Record<string, string | number | boolean | null>,
+): string | null {
+  let bestUrl: string | null = null;
+  let bestScore = 0;
+  for (const col of spec.columns) {
+    if (!isDocsUrlColumn(col.name)) continue;
+    const value = row[col.name];
+    const score = scoreDocsUrlForOfficialSource(value);
+    if (typeof value === "string" && score > bestScore) {
+      bestUrl = value;
+      bestScore = score;
+    }
+  }
+  return bestScore >= 4 ? bestUrl : null;
+}
+
+function sourceUrlSupportsRetainedDocsUrl(
+  evidenceUrl: unknown,
+  retainedDocsUrl: string,
+): boolean {
+  if (urlsReferenceSamePage(evidenceUrl, retainedDocsUrl)) {
+    return true;
+  }
+  return (
+    sameHostname(evidenceUrl, retainedDocsUrl) &&
+    scoreDocsUrlForOfficialSource(evidenceUrl) >= 4
+  );
+}
+
+function urlsReferenceSamePage(a: unknown, b: unknown): boolean {
+  if (isEmpty(a) || isEmpty(b)) return false;
+  return normalizeComparableValue(a) === normalizeComparableValue(b);
+}
+
+function sameHostname(a: unknown, b: unknown): boolean {
+  try {
+    const aHost = new URL(String(a)).hostname.replace(/^www\./, "");
+    const bHost = new URL(String(b)).hostname.replace(/^www\./, "");
+    return aHost === bHost;
+  } catch {
+    return false;
+  }
 }

--- a/backend/BigSet_Data_Collection_Agent/src/merge/records.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/merge/records.ts
@@ -1,0 +1,153 @@
+import type { DatasetSpec, ExtractedRecord } from "../models/schemas.js";
+
+function normalizeValue(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  return String(value).trim().toLowerCase();
+}
+
+/** Normalize entity names for stable primary-key matching. */
+export function normalizePrimaryKey(value: unknown): string {
+  return normalizeValue(value)
+    .replace(/\s+/g, " ")
+    .replace(/[''`]/g, "'");
+}
+
+export function recordDedupeKey(
+  record: ExtractedRecord,
+  keys: string[],
+): string {
+  return keys.map((key) => normalizeValue(record.row[key])).join("||");
+}
+
+function isEmptyCompositeKey(key: string, keyCount: number): boolean {
+  return !key || key === Array.from({ length: keyCount }, () => "").join("||");
+}
+
+/**
+ * Primary identity column: first dedupe key, or first column whose name suggests a name/title.
+ */
+export function getPrimaryKeyColumn(spec: DatasetSpec): string | null {
+  if (spec.dedupe_keys.length > 0) {
+    return spec.dedupe_keys[0]!;
+  }
+
+  const nameLike = spec.columns.find((col) =>
+    /(name|title|company|organization|entity)/i.test(col.name),
+  );
+  return nameLike?.name ?? spec.columns[0]?.name ?? null;
+}
+
+export function getPrimaryKeyValue(
+  record: ExtractedRecord,
+  spec: DatasetSpec,
+): string {
+  const column = getPrimaryKeyColumn(spec);
+  if (!column) return "";
+  return normalizePrimaryKey(record.row[column]);
+}
+
+/**
+ * Canonical row id: primary key when present, otherwise full composite dedupe key.
+ */
+export function canonicalRecordId(
+  record: ExtractedRecord,
+  spec: DatasetSpec,
+): string | null {
+  const primary = getPrimaryKeyValue(record, spec);
+  if (primary) {
+    return `pk:${primary}`;
+  }
+
+  const composite = recordDedupeKey(record, spec.dedupe_keys);
+  if (!isEmptyCompositeKey(composite, spec.dedupe_keys.length)) {
+    return `dk:${composite}`;
+  }
+
+  return null;
+}
+
+export interface MergeResult {
+  records: ExtractedRecord[];
+  unkeyed: ExtractedRecord[];
+}
+
+export function mergeRecords(
+  spec: DatasetSpec,
+  records: ExtractedRecord[],
+): MergeResult {
+  const seen = new Map<string, ExtractedRecord>();
+  const unkeyed: ExtractedRecord[] = [];
+
+  for (const record of records) {
+    const id = canonicalRecordId(record, spec);
+    if (!id) {
+      unkeyed.push(record);
+      continue;
+    }
+
+    const existing = seen.get(id);
+    if (!existing) {
+      seen.set(id, record);
+      continue;
+    }
+
+    seen.set(id, mergePair(existing, record, spec));
+  }
+
+  return { records: [...seen.values()], unkeyed };
+}
+
+/**
+ * Merge repair-pass rows into an existing dataset.
+ * Rows with the same primary key (e.g. restaurant name) update in place; new keys add rows.
+ */
+export function mergeRepairIntoExisting(
+  spec: DatasetSpec,
+  existing: ExtractedRecord[],
+  repairRecords: ExtractedRecord[],
+): MergeResult {
+  return mergeRecords(spec, [...existing, ...repairRecords]);
+}
+
+export function mergePair(
+  a: ExtractedRecord,
+  b: ExtractedRecord,
+  spec: DatasetSpec,
+): ExtractedRecord {
+  const row: Record<string, string | number | boolean | null> = { ...a.row };
+
+  for (const col of spec.columns) {
+    const current = row[col.name];
+    const incoming = b.row[col.name];
+    const currentEmpty =
+      current === null || current === undefined || current === "";
+    const incomingFilled =
+      incoming !== null && incoming !== undefined && incoming !== "";
+
+    if (currentEmpty && incomingFilled) {
+      row[col.name] = incoming ?? null;
+    }
+  }
+
+  const evidence = [...a.evidence];
+  const evidenceFields = new Set(evidence.map((e) => e.field));
+  for (const item of b.evidence) {
+    if (!evidenceFields.has(item.field)) {
+      evidence.push(item);
+    }
+  }
+
+  const extractionConfidence = Math.max(
+    a.extraction_confidence ?? 0,
+    b.extraction_confidence ?? 0,
+  );
+
+  return {
+    row,
+    evidence,
+    source_urls: [...new Set([...a.source_urls, ...b.source_urls])],
+    ...(extractionConfidence > 0
+      ? { extraction_confidence: extractionConfidence }
+      : {}),
+  };
+}

--- a/backend/BigSet_Data_Collection_Agent/src/merge/records.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/merge/records.ts
@@ -1,7 +1,9 @@
 import type { DatasetSpec, ExtractedRecord } from "../models/schemas.js";
 import {
   deriveRecordSourceUrls,
+  isUrlLikeColumnName,
   scoreDocsUrlForOfficialSource,
+  scoreUrlForCanonicalSource,
 } from "../records/source-urls.js";
 
 function normalizeValue(value: unknown): string {
@@ -28,7 +30,12 @@ function valuesMatch(a: unknown, b: unknown): boolean {
 /** Normalize entity names for stable primary-key matching. */
 export function normalizePrimaryKey(value: unknown): string {
   return normalizeValue(value)
+    .replace(
+      /\b(?:incorporated|inc|corporation|corp|company|co|llc|ltd|limited|plc)\b\.?$/i,
+      "",
+    )
     .replace(/\s+/g, " ")
+    .trim()
     .replace(/[''`]/g, "'");
 }
 
@@ -136,7 +143,12 @@ export function mergePair(
 ): ExtractedRecord {
   const row: Record<string, string | number | boolean | null> = { ...a.row };
   const fieldsFilledFromIncoming = new Set<string>();
-  let replacedDocsUrlFromIncoming = false;
+  const shouldPreferIncomingCanonicalRecord = prefersIncomingCanonicalRecord(
+    a,
+    b,
+    spec,
+  );
+  let replacedCanonicalUrlFromIncoming = false;
 
   for (const col of spec.columns) {
     const current = row[col.name];
@@ -147,18 +159,26 @@ export function mergePair(
     if (currentEmpty && incomingFilled) {
       row[col.name] = incoming ?? null;
       fieldsFilledFromIncoming.add(col.name);
+    } else if (
+      incomingFilled &&
+      shouldPreferIncomingCanonicalRecord &&
+      !spec.dedupe_keys.includes(col.name)
+    ) {
+      row[col.name] = incoming ?? null;
+      fieldsFilledFromIncoming.add(col.name);
+      replacedCanonicalUrlFromIncoming ||= isCanonicalSourceUrlColumn(col.name);
     } else if (incomingFilled && shouldReplaceCell(col.name, current, incoming)) {
       row[col.name] = incoming ?? null;
       fieldsFilledFromIncoming.add(col.name);
-      replacedDocsUrlFromIncoming ||= isDocsUrlColumn(col.name);
+      replacedCanonicalUrlFromIncoming ||= isCanonicalSourceUrlColumn(col.name);
     }
   }
 
-  if (replacedDocsUrlFromIncoming) {
+  if (replacedCanonicalUrlFromIncoming) {
     for (const col of spec.columns) {
       const incoming = b.row[col.name];
       if (
-        isDocsCompanionColumn(col.name) &&
+        shouldReplaceCompanionColumn(col.name, spec) &&
         !isEmpty(incoming) &&
         !spec.dedupe_keys.includes(col.name)
       ) {
@@ -186,7 +206,7 @@ export function mergePair(
       evidenceFields.add(item.field);
     }
   }
-  const coherentEvidence = filterEvidenceForRetainedDocsUrl(spec, row, evidence);
+  const coherentEvidence = filterEvidenceForRetainedCanonicalUrl(spec, row, evidence);
 
   const extractionConfidence = Math.max(
     a.extraction_confidence ?? 0,
@@ -215,7 +235,7 @@ function shouldMergeIncomingEvidence(input: {
   fieldsFilledFromIncoming: Set<string>;
 }): boolean {
   if (
-    isDocsUrlColumn(input.field) &&
+    isCanonicalSourceUrlColumn(input.field) &&
     !urlsReferenceSamePage(
       input.incomingRow[input.field],
       input.mergedRow[input.field],
@@ -234,13 +254,57 @@ function shouldReplaceCell(
   current: string | number | boolean | null | undefined,
   incoming: string | number | boolean | null | undefined,
 ): boolean {
-  if (!isDocsUrlColumn(columnName)) {
+  if (!isCanonicalSourceUrlColumn(columnName)) {
     return false;
   }
   return (
-    scoreDocsUrlForOfficialSource(incoming) >
-    scoreDocsUrlForOfficialSource(current)
+    scoreUrlForCanonicalSource(incoming) > scoreUrlForCanonicalSource(current)
   );
+}
+
+function prefersIncomingCanonicalRecord(
+  current: ExtractedRecord,
+  incoming: ExtractedRecord,
+  spec: DatasetSpec,
+): boolean {
+  const currentScore = bestCanonicalScore(current, spec);
+  const incomingScore = bestCanonicalScore(incoming, spec);
+  if (incomingScore > currentScore) {
+    return true;
+  }
+  if (incomingScore < currentScore) {
+    return false;
+  }
+
+  const currentDate = bestRecordTimestamp(current, spec);
+  const incomingDate = bestRecordTimestamp(incoming, spec);
+  return incomingDate !== null && currentDate !== null && incomingDate > currentDate;
+}
+
+function bestCanonicalScore(record: ExtractedRecord, spec: DatasetSpec): number {
+  let bestScore = 0;
+  for (const column of spec.columns) {
+    if (!isCanonicalSourceUrlColumn(column.name)) continue;
+    bestScore = Math.max(
+      bestScore,
+      scoreUrlForCanonicalSource(record.row[column.name]),
+    );
+  }
+  return bestScore;
+}
+
+function bestRecordTimestamp(
+  record: ExtractedRecord,
+  spec: DatasetSpec,
+): number | null {
+  const timestamps = spec.columns
+    .filter((column) => column.name.toLowerCase().includes("date"))
+    .map((column) => Date.parse(String(record.row[column.name] ?? "")))
+    .filter(Number.isFinite);
+  if (timestamps.length === 0) {
+    return null;
+  }
+  return Math.max(...timestamps);
 }
 
 function isDocsUrlColumn(columnName: string): boolean {
@@ -262,60 +326,91 @@ function isDocsCompanionColumn(columnName: string): boolean {
   );
 }
 
-function filterEvidenceForRetainedDocsUrl(
+function isCanonicalSourceUrlColumn(columnName: string): boolean {
+  return isUrlLikeColumnName(columnName);
+}
+
+function shouldReplaceCompanionColumn(
+  columnName: string,
+  spec: DatasetSpec,
+): boolean {
+  if (spec.dedupe_keys.includes(columnName)) {
+    return false;
+  }
+  return !isCanonicalSourceUrlColumn(columnName);
+}
+
+function filterEvidenceForRetainedCanonicalUrl(
   spec: DatasetSpec,
   row: Record<string, string | number | boolean | null>,
   evidence: ExtractedRecord["evidence"],
 ): ExtractedRecord["evidence"] {
-  const retainedDocsUrl = bestRetainedDocsUrl(spec, row);
-  if (!retainedDocsUrl) {
+  const retainedUrl = bestRetainedCanonicalUrl(spec, row);
+  if (!retainedUrl) {
     return evidence;
   }
 
   return evidence.filter((item) => {
-    if (isDocsUrlColumn(item.field)) {
+    if (isCanonicalSourceUrlColumn(item.field)) {
       return urlsReferenceSamePage(item.url, row[item.field]);
     }
 
     if (
       isDocsCompanionColumn(item.field) ||
+      isLikelySourceCompanionColumn(item.field) ||
       spec.dedupe_keys.includes(item.field)
     ) {
-      return sourceUrlSupportsRetainedDocsUrl(item.url, retainedDocsUrl);
+      return sourceUrlSupportsRetainedCanonicalUrl(item.url, retainedUrl);
     }
 
     return true;
   });
 }
 
-function bestRetainedDocsUrl(
+function bestRetainedCanonicalUrl(
   spec: DatasetSpec,
   row: Record<string, string | number | boolean | null>,
 ): string | null {
   let bestUrl: string | null = null;
   let bestScore = 0;
   for (const col of spec.columns) {
-    if (!isDocsUrlColumn(col.name)) continue;
+    if (!isCanonicalSourceUrlColumn(col.name)) continue;
     const value = row[col.name];
-    const score = scoreDocsUrlForOfficialSource(value);
+    const score = scoreUrlForCanonicalSource(value);
     if (typeof value === "string" && score > bestScore) {
       bestUrl = value;
       bestScore = score;
     }
   }
-  return bestScore >= 4 ? bestUrl : null;
+  return bestScore >= 2 ? bestUrl : null;
 }
 
-function sourceUrlSupportsRetainedDocsUrl(
+function isLikelySourceCompanionColumn(columnName: string): boolean {
+  const lower = columnName.toLowerCase();
+  return (
+    lower.includes("date") ||
+    lower.includes("quarter") ||
+    lower.includes("price") ||
+    lower.includes("plan") ||
+    lower.includes("title") ||
+    lower.includes("summary") ||
+    lower.includes("description")
+  );
+}
+
+function sourceUrlSupportsRetainedCanonicalUrl(
   evidenceUrl: unknown,
-  retainedDocsUrl: string,
+  retainedUrl: string,
 ): boolean {
-  if (urlsReferenceSamePage(evidenceUrl, retainedDocsUrl)) {
+  if (urlsReferenceSamePage(evidenceUrl, retainedUrl)) {
     return true;
   }
+  if (scoreDocsUrlForOfficialSource(retainedUrl) < 4) {
+    return false;
+  }
   return (
-    sameHostname(evidenceUrl, retainedDocsUrl) &&
-    scoreDocsUrlForOfficialSource(evidenceUrl) >= 4
+    sameHostname(evidenceUrl, retainedUrl) &&
+    scoreUrlForCanonicalSource(evidenceUrl) >= 2
   );
 }
 

--- a/backend/BigSet_Data_Collection_Agent/src/models/quality.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/models/quality.ts
@@ -1,0 +1,79 @@
+import { z } from "zod";
+
+export const recordStatusSchema = z.enum([
+  "complete",
+  "partial",
+  "low_confidence",
+]);
+
+export type RecordStatus = z.infer<typeof recordStatusSchema>;
+
+export const recordQualitySchema = z.object({
+  record_id: z.string(),
+  record_status: recordStatusSchema,
+  needs_review: z.boolean(),
+  completeness_pct: z.number().min(0).max(1),
+  /** Mean confidence across required fields (from per-field source signals). */
+  confidence_score: z.number().min(0).max(1),
+  field_confidences: z.record(z.string(), z.number().min(0).max(1)).default({}),
+  missing_required_fields: z.array(z.string()),
+  missing_optional_fields: z.array(z.string()),
+  fields_without_evidence: z.array(z.string()),
+  review_reasons: z.array(z.string()),
+});
+
+export type RecordQuality = z.infer<typeof recordQualitySchema>;
+
+export const qualityBucketSchema = z.object({
+  count: z.number().int().nonnegative(),
+  record_ids: z.array(z.string()),
+});
+
+export type QualityBucket = z.infer<typeof qualityBucketSchema>;
+
+export const qualityReportSchema = z.object({
+  total_records: z.number().int().nonnegative(),
+  unkeyed_records: z.number().int().nonnegative(),
+  complete: qualityBucketSchema,
+  partial: qualityBucketSchema,
+  low_confidence: qualityBucketSchema,
+  needs_review: qualityBucketSchema,
+  records: z.array(recordQualitySchema),
+});
+
+export type QualityReport = z.infer<typeof qualityReportSchema>;
+
+export const sourceOutcomeTypeSchema = z.enum([
+  "success",
+  "fetch_failed",
+  "skipped",
+  "extract_failed",
+  "agent_failed",
+  "agent_deferred",
+  "no_records",
+]);
+
+export type SourceOutcomeType = z.infer<typeof sourceOutcomeTypeSchema>;
+
+export const sourceOutcomeSchema = z.object({
+  url: z.string(),
+  phase: z.enum(["initial", "repair"]),
+  outcome: sourceOutcomeTypeSchema,
+  triage_status: z.string().optional(),
+  triage_confidence: z.number().optional(),
+  source_data_confidence: z.number().optional(),
+  expected_yield: z.string().optional(),
+  error: z.string().optional(),
+  records_extracted: z.number().optional(),
+});
+
+export type SourceOutcome = z.infer<typeof sourceOutcomeSchema>;
+
+export const sourcesReportSchema = z.object({
+  total: z.number().int().nonnegative(),
+  failed: z.array(sourceOutcomeSchema),
+  by_outcome: z.record(z.string(), z.number()),
+  outcomes: z.array(sourceOutcomeSchema),
+});
+
+export type SourcesReport = z.infer<typeof sourcesReportSchema>;

--- a/backend/BigSet_Data_Collection_Agent/src/models/schemas.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/models/schemas.ts
@@ -1,0 +1,214 @@
+import { z } from "zod";
+import { repairDiagnosisSchema } from "../memory/types.js";
+import { qualityReportSchema, sourcesReportSchema } from "./quality.js";
+import { sourceStatusSchema } from "./source-status.js";
+
+export const columnSchema = z.object({
+  name: z.string().min(1),
+  type: z.enum(["string", "number", "boolean", "date"]),
+  description: z.string(),
+  required: z.boolean(),
+});
+
+export const datasetSpecSchema = z.object({
+  intent_summary: z.string(),
+  target_row_count: z.number().int().positive(),
+  row_grain: z.string(),
+  columns: z.array(columnSchema).min(1),
+  dedupe_keys: z.preprocess(
+    (value) => (Array.isArray(value) ? value.slice(0, 1) : value),
+    z.array(z.string()).length(1),
+  ),
+  search_queries: z.array(z.string()).min(1),
+  extraction_hints: z.string(),
+});
+
+export type ColumnDef = z.infer<typeof columnSchema>;
+export type DatasetSpec = z.infer<typeof datasetSpecSchema>;
+
+export const fieldEvidenceSchema = z.object({
+  field: z.string(),
+  url: z.string(),
+  quote: z.string(),
+});
+
+export const extractedRecordSchema = z.object({
+  row: z.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.null()])),
+  evidence: z.array(fieldEvidenceSchema),
+  source_urls: z.array(z.string()),
+  /** LLM-estimated confidence that row values are accurate (0–1). */
+  extraction_confidence: z.number().min(0).max(1).optional(),
+});
+
+export type FieldEvidence = z.infer<typeof fieldEvidenceSchema>;
+export type ExtractedRecord = z.infer<typeof extractedRecordSchema>;
+
+export const extractionResultSchema = z.object({
+  records: z.array(extractedRecordSchema),
+  notes: z.string().optional(),
+});
+
+export type ExtractionResult = z.infer<typeof extractionResultSchema>;
+
+export const sourceCandidateSchema = z.object({
+  url: z.string().url(),
+  title: z.string(),
+  snippet: z.string(),
+  site_name: z.string().optional(),
+  query: z.string(),
+  position: z.number().optional(),
+  /** Search API page (0-based) that produced this candidate. */
+  search_page: z.number().int().min(0).optional(),
+});
+
+export type SourceCandidate = z.infer<typeof sourceCandidateSchema>;
+
+export const fetchedPageSchema = z.object({
+  url: z.string(),
+  final_url: z.string(),
+  title: z.string(),
+  description: z.string().optional(),
+  text: z.string(),
+  error: z.string().optional(),
+  /** Outbound links when Fetch API was called with links: true. */
+  outbound_links: z.array(z.string()).optional(),
+});
+
+export type FetchedPage = z.infer<typeof fetchedPageSchema>;
+
+export const expectedYieldSchema = z.enum(["complete", "partial", "none"]);
+
+export const sourceTriageResultSchema = z.object({
+  url: z.string(),
+  final_url: z.string(),
+  title: z.string(),
+  status: sourceStatusSchema,
+  /** Confidence in triage classification (routing). */
+  confidence: z.number().min(0).max(1),
+  /** Expected accuracy/completeness of data if extracted from this page. */
+  source_data_confidence: z.number().min(0).max(1),
+  /** Likely yield: full rows, partial rows, or none. */
+  expected_yield: expectedYieldSchema,
+  reasoning: z.string(),
+  suggested_action: z.string().optional(),
+});
+
+export type SourceTriageResult = z.infer<typeof sourceTriageResultSchema>;
+
+export const agentGoalSchema = z.object({
+  goal: z.string(),
+  rationale: z.string(),
+});
+
+export type AgentGoal = z.infer<typeof agentGoalSchema>;
+
+export const agentRunRecordSchema = z.object({
+  url: z.string(),
+  status: sourceStatusSchema,
+  run_id: z.string().nullable(),
+  agent_status: z.string(),
+  goal: z.string(),
+  records_extracted: z.number(),
+  error: z.string().optional(),
+});
+
+export type AgentRunRecord = z.infer<typeof agentRunRecordSchema>;
+
+export const triageSummarySchema = z.object({
+  pages_triaged: z.number(),
+  by_status: z.record(z.string(), z.number()),
+  extract_now: z.number(),
+  agent_candidates: z.number(),
+  agent_dispatched: z.number(),
+  agent_deferred: z.number(),
+  agent_succeeded: z.number(),
+  agent_failed: z.number(),
+  skipped: z.number(),
+  records_from_extract: z.number(),
+  records_from_agent: z.number(),
+});
+
+export type TriageSummary = z.infer<typeof triageSummarySchema>;
+
+const phaseStatsSchema = z.object({
+  search_queries_executed: z.number(),
+  search_pages_paginated: z.number().optional(),
+  search_results_collected: z.number(),
+  unique_urls_selected: z.number(),
+  pages_fetched: z.number(),
+  pages_failed: z.number(),
+  raw_records_extracted: z.number(),
+  triage: triageSummarySchema.optional(),
+});
+
+export const llmUsageReportSchema = z.object({
+  prompt_tokens: z.number().int().nonnegative(),
+  completion_tokens: z.number().int().nonnegative(),
+  total_tokens: z.number().int().nonnegative(),
+  call_count: z.number().int().nonnegative(),
+});
+
+export const repairLoopReportSchema = z.object({
+  loop_index: z.number().int().positive(),
+  diagnosis_summary: z.string().optional(),
+  repair_queries: z.array(z.string()),
+  rationale: z.string().optional(),
+  missing_fields: z.array(z.string()),
+  records_before: z.number(),
+  records_after: z.number(),
+  fields_filled: z.record(z.string(), z.number()),
+  partial_count_before: z.number().optional(),
+  partial_count_after: z.number().optional(),
+  stats: phaseStatsSchema,
+});
+
+export type RepairLoopReport = z.infer<typeof repairLoopReportSchema>;
+
+export const repairReportSchema = z.object({
+  attempted: z.boolean(),
+  total_loops: z.number().int().nonnegative(),
+  loops: z.array(repairLoopReportSchema),
+  skipped_reason: z.string().optional(),
+  missing_fields: z.array(z.string()),
+  repair_queries: z.array(z.string()),
+  rationale: z.string().optional(),
+  records_before: z.number(),
+  records_after: z.number(),
+  fields_filled: z.record(z.string(), z.number()),
+  stats: phaseStatsSchema,
+  last_diagnosis: repairDiagnosisSchema.optional(),
+});
+
+export const runReportSchema = z.object({
+  run_id: z.string(),
+  /** Set when this run is a recurring refresh of a prior run. */
+  refreshed_from_run_id: z.string().optional(),
+  refresh_in_place: z.boolean().optional(),
+  prompt: z.string(),
+  target_rows: z.number(),
+  started_at: z.string(),
+  finished_at: z.string(),
+  duration_ms: z.number(),
+  dataset_spec: datasetSpecSchema,
+  stats: phaseStatsSchema.extend({
+    records_after_merge: z.number(),
+    visualization_records: z.number().optional(),
+  }),
+  initial: phaseStatsSchema.extend({
+    search_queries: z.array(z.string()),
+    fetched_urls: z.array(z.string()),
+    failed_urls: z.array(z.string()),
+  }),
+  repair: repairReportSchema,
+  search_queries: z.array(z.string()),
+  fetched_urls: z.array(z.string()),
+  failed_urls: z.array(z.string()),
+  errors: z.array(z.string()),
+  quality: qualityReportSchema.optional(),
+  sources: sourcesReportSchema.optional(),
+  llm_usage: llmUsageReportSchema.optional(),
+});
+
+export type RunReport = z.infer<typeof runReportSchema>;
+
+export type { QualityReport, RecordQuality, SourcesReport, SourceOutcome } from "./quality.js";

--- a/backend/BigSet_Data_Collection_Agent/src/models/source-status.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/models/source-status.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+export const sourceStatusSchema = z.enum([
+  "extract_now",
+  "requires_navigation",
+  "requires_form_submission",
+  "requires_detail_page_followup",
+  "irrelevant",
+  "duplicate",
+  "blocked",
+  "low_value",
+]);
+
+export type SourceStatus = z.infer<typeof sourceStatusSchema>;
+
+export const AGENT_STATUSES: SourceStatus[] = [
+  "requires_navigation",
+  "requires_form_submission",
+  "requires_detail_page_followup",
+];
+
+export function statusNeedsAgent(status: SourceStatus): boolean {
+  return AGENT_STATUSES.includes(status);
+}

--- a/backend/BigSet_Data_Collection_Agent/src/orchestrator/acquisition.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/orchestrator/acquisition.ts
@@ -7,6 +7,7 @@ import { getPrimaryKeyValue } from "../merge/records.js";
 import { createFetchQueue, createSearchQueue } from "../queue/pools.js";
 import {
   derivePromptSourcePolicy,
+  recordMatchesPromptSourcePolicy,
   sourceCandidatePolicyBoost,
   type PromptSourcePolicy,
 } from "../agents/source-policy.js";
@@ -237,6 +238,18 @@ export async function runAcquisitionPhase(options: {
     memory: options.memory,
     log: options.log,
   });
+  const records = sourcePolicy.requiresOfficialSource
+    ? processed.records.filter((record) =>
+        recordMatchesPromptSourcePolicy(record, options.spec, sourcePolicy),
+      )
+    : processed.records;
+  const droppedRecords = processed.records.length - records.length;
+  if (droppedRecords > 0) {
+    options.log(
+      options.label,
+      `Dropped ${droppedRecords} record(s) that lacked entity-owned source URLs`,
+    );
+  }
 
   const allFetchedUrls = [
     ...new Set([
@@ -250,7 +263,7 @@ export async function runAcquisitionPhase(options: {
     fetchedUrls: allFetchedUrls,
     failedUrls,
     fetchedPages,
-    records: processed.records,
+    records,
     pagesFetched: fetchedPages.length,
     triage: processed.summary,
     triageResults: processed.triageResults,

--- a/backend/BigSet_Data_Collection_Agent/src/orchestrator/acquisition.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/orchestrator/acquisition.ts
@@ -87,6 +87,7 @@ export async function runAcquisitionPhase(options: {
   knownEntityKeys?: string[];
   enableTriage?: boolean;
   enableTinyfishAgent?: boolean;
+  agentPollTimeoutMs?: number;
   memory?: WorkflowMemory;
   forceAgent?: boolean;
   /** Fetch outbound links from high-value pages (repair). */
@@ -222,6 +223,7 @@ export async function runAcquisitionPhase(options: {
     enableTinyfishAgent:
       options.enableTinyfishAgent ??
       (options.forceAgent ? true : config.enableTinyfishAgent),
+    agentPollTimeoutMs: options.agentPollTimeoutMs,
     memory: options.memory,
     log: options.log,
   });

--- a/backend/BigSet_Data_Collection_Agent/src/orchestrator/acquisition.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/orchestrator/acquisition.ts
@@ -5,6 +5,11 @@ import { domainMemoryBoost, type WorkflowMemory } from "../memory/index.js";
 import type { SearchPlan } from "../memory/search-pagination.js";
 import { getPrimaryKeyValue } from "../merge/records.js";
 import { createFetchQueue, createSearchQueue } from "../queue/pools.js";
+import {
+  derivePromptSourcePolicy,
+  sourceCandidatePolicyBoost,
+  type PromptSourcePolicy,
+} from "../agents/source-policy.js";
 import type {
   AgentRunRecord,
   DatasetSpec,
@@ -39,6 +44,7 @@ function rankCandidates(
   excludeUrls: Set<string>,
   limit: number,
   memory?: WorkflowMemory,
+  sourcePolicy?: PromptSourcePolicy,
 ): string[] {
   const byUrl = new Map<
     string,
@@ -55,6 +61,7 @@ function rankCandidates(
     if (candidate.title.length > 10) score += 0.5;
     if (candidate.snippet.length > 40) score += 0.5;
     if (memory) score += domainMemoryBoost(memory, domain);
+    if (sourcePolicy) score += sourceCandidatePolicyBoost(candidate, sourcePolicy);
     byUrl.set(url, { url, score, domain });
   }
 
@@ -127,15 +134,18 @@ export async function runAcquisitionPhase(options: {
     },
   );
   const candidates: SourceCandidate[] = searchBatches.flat();
+  const sourcePolicy = derivePromptSourcePolicy(options.userPrompt);
 
   const urlsToFetch = rankCandidates(
     candidates,
     options.excludeUrls,
     options.maxUrlsToFetch,
     options.memory,
+    sourcePolicy,
   );
 
-  const fetchWithLinks = options.enableLinkFollow ?? false;
+  const fetchWithLinks =
+    options.enableLinkFollow ?? sourcePolicy.requiresOfficialSource;
   const urlChunks = chunkUrls(urlsToFetch, config.fetchBatchSize);
 
   options.log(

--- a/backend/BigSet_Data_Collection_Agent/src/orchestrator/acquisition.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/orchestrator/acquisition.ts
@@ -1,0 +1,260 @@
+import { selectOutboundLinksToFollow } from "../acquisition/link-follow.js";
+import { config } from "../config.js";
+import { chunkUrls, fetchPages, searchWeb } from "../integrations/tinyfish.js";
+import { domainMemoryBoost, type WorkflowMemory } from "../memory/index.js";
+import type { SearchPlan } from "../memory/search-pagination.js";
+import { getPrimaryKeyValue } from "../merge/records.js";
+import { createFetchQueue, createSearchQueue } from "../queue/pools.js";
+import type {
+  AgentRunRecord,
+  DatasetSpec,
+  ExtractedRecord,
+  FetchedPage,
+  SourceCandidate,
+  SourceTriageResult,
+  TriageSummary,
+} from "../models/schemas.js";
+import { saveFetchedPage, type RunPaths } from "../storage/run-store.js";
+import {
+  processFetchedPages,
+  type AgentDeferredEntry,
+} from "./process-pages.js";
+import { getDomain, normalizeUrl } from "../utils/url.js";
+
+export interface AcquisitionResult {
+  candidates: SourceCandidate[];
+  fetchedUrls: string[];
+  failedUrls: string[];
+  fetchedPages: FetchedPage[];
+  records: ExtractedRecord[];
+  pagesFetched: number;
+  triage: TriageSummary;
+  triageResults: SourceTriageResult[];
+  agentRuns: AgentRunRecord[];
+  agentDeferred: AgentDeferredEntry[];
+}
+
+function rankCandidates(
+  candidates: SourceCandidate[],
+  excludeUrls: Set<string>,
+  limit: number,
+  memory?: WorkflowMemory,
+): string[] {
+  const byUrl = new Map<
+    string,
+    { url: string; score: number; domain: string }
+  >();
+
+  for (const candidate of candidates) {
+    const url = normalizeUrl(candidate.url);
+    if (excludeUrls.has(url)) continue;
+
+    const domain = getDomain(url);
+    let score = byUrl.get(url)?.score ?? 0;
+    score += 1;
+    if (candidate.title.length > 10) score += 0.5;
+    if (candidate.snippet.length > 40) score += 0.5;
+    if (memory) score += domainMemoryBoost(memory, domain);
+    byUrl.set(url, { url, score, domain });
+  }
+
+  const domainsSeen = new Set<string>();
+  return [...byUrl.values()]
+    .sort((a, b) => b.score - a.score)
+    .filter((item) => {
+      if (domainsSeen.has(item.domain)) return false;
+      domainsSeen.add(item.domain);
+      return true;
+    })
+    .map((item) => item.url)
+    .slice(0, limit);
+}
+
+export async function runAcquisitionPhase(options: {
+  label: string;
+  userPrompt: string;
+  spec: DatasetSpec;
+  queries: string[];
+  /** When set, runs Search with per-query page indices (repair pagination). */
+  searches?: SearchPlan[];
+  paths: RunPaths;
+  errors: string[];
+  excludeUrls: Set<string>;
+  maxResultsPerQuery: number;
+  maxUrlsToFetch: number;
+  pageIndexStart: number;
+  focusFields?: string[];
+  knownEntityKeys?: string[];
+  enableTriage?: boolean;
+  enableTinyfishAgent?: boolean;
+  memory?: WorkflowMemory;
+  forceAgent?: boolean;
+  /** Fetch outbound links from high-value pages (repair). */
+  enableLinkFollow?: boolean;
+  log: (stage: string, message: string) => void;
+}): Promise<AcquisitionResult> {
+  const searchQueue = createSearchQueue();
+  const fetchQueue = createFetchQueue();
+
+  const searches: SearchPlan[] =
+    options.searches ??
+    options.queries.map((query) => ({ query, page: 0 }));
+
+  options.log(
+    options.label,
+    `Running ${searches.length} searches (parallel, concurrency=${config.searchConcurrency})...`,
+  );
+
+  const searchBatches = await searchQueue.runAll(
+    searches,
+    async (plan) => {
+      try {
+        const results = await searchWeb(plan.query, plan.page);
+        return results.slice(0, options.maxResultsPerQuery).map((result) => ({
+          ...result,
+          query: plan.query,
+          search_page: plan.page,
+        }));
+      } catch (error) {
+        const msg = `Search failed for "${plan.query}" (page ${plan.page}): ${
+          error instanceof Error ? error.message : String(error)
+        }`;
+        options.errors.push(msg);
+        options.log(options.label, `WARN ${msg}`);
+        return [] as SourceCandidate[];
+      }
+    },
+  );
+  const candidates: SourceCandidate[] = searchBatches.flat();
+
+  const urlsToFetch = rankCandidates(
+    candidates,
+    options.excludeUrls,
+    options.maxUrlsToFetch,
+    options.memory,
+  );
+
+  const fetchWithLinks = options.enableLinkFollow ?? false;
+  const urlChunks = chunkUrls(urlsToFetch, config.fetchBatchSize);
+
+  options.log(
+    options.label,
+    `Fetching ${urlsToFetch.length} URLs in ${urlChunks.length} parallel batches (concurrency=${config.fetchConcurrency})${fetchWithLinks ? " with outbound links" : ""}...`,
+  );
+
+  const fetchChunk = async (chunk: string[], includeLinks: boolean) => {
+    try {
+      return await fetchPages(chunk, { includeLinks });
+    } catch (error) {
+      const msg = `Fetch batch failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`;
+      options.errors.push(msg);
+      options.log(options.label, `WARN ${msg}`);
+      return chunk.map((url) => ({
+        url,
+        final_url: url,
+        title: "",
+        text: "",
+        error: msg,
+      }));
+    }
+  };
+
+  let fetchedPages: FetchedPage[] =
+    urlChunks.length > 0
+      ? (
+          await fetchQueue.runAll(
+            urlChunks,
+            (chunk) => fetchChunk(chunk, fetchWithLinks),
+            (chunk) => chunk.map((url) => getDomain(url)),
+          )
+        ).flat()
+      : [];
+
+  if (fetchWithLinks && fetchedPages.length > 0) {
+    const linkUrls = selectOutboundLinksToFollow({
+      pages: fetchedPages,
+      excludeUrls: options.excludeUrls,
+      focusFields: options.focusFields,
+      maxTotal: config.maxRepairLinkUrls,
+      maxPerSource: config.maxLinksPerSourcePage,
+      memory: options.memory,
+    }).filter((url) => !urlsToFetch.includes(normalizeUrl(url)));
+
+    if (linkUrls.length > 0) {
+      const linkChunks = chunkUrls(linkUrls, config.fetchBatchSize);
+      options.log(
+        options.label,
+        `Following ${linkUrls.length} high-relevance outbound links...`,
+      );
+      const linkPages = (
+        await fetchQueue.runAll(
+          linkChunks,
+          (chunk) => fetchChunk(chunk, false),
+          (chunk) => chunk.map((url) => getDomain(url)),
+        )
+      ).flat();
+      fetchedPages = [...fetchedPages, ...linkPages];
+    }
+  }
+
+  let pageIndex = options.pageIndexStart;
+  for (const page of fetchedPages) {
+    await saveFetchedPage(options.paths, page, pageIndex);
+    pageIndex += 1;
+  }
+
+  const failedUrls = fetchedPages
+    .filter((page) => page.error)
+    .map((page) => page.url);
+
+  const processed = await processFetchedPages({
+    label: options.label,
+    userPrompt: options.userPrompt,
+    spec: options.spec,
+    pages: fetchedPages,
+    paths: options.paths,
+    errors: options.errors,
+    focusFields: options.focusFields,
+    knownEntityKeys: options.knownEntityKeys,
+    enableTriage: options.enableTriage,
+    enableTinyfishAgent:
+      options.enableTinyfishAgent ??
+      (options.forceAgent ? true : config.enableTinyfishAgent),
+    memory: options.memory,
+    log: options.log,
+  });
+
+  const allFetchedUrls = [
+    ...new Set([
+      ...urlsToFetch.map((url) => normalizeUrl(url)),
+      ...fetchedPages.map((page) => normalizeUrl(page.url)),
+    ]),
+  ];
+
+  return {
+    candidates,
+    fetchedUrls: allFetchedUrls,
+    failedUrls,
+    fetchedPages,
+    records: processed.records,
+    pagesFetched: fetchedPages.length,
+    triage: processed.summary,
+    triageResults: processed.triageResults,
+    agentRuns: processed.agentRuns,
+    agentDeferred: processed.agentDeferred,
+  };
+}
+
+export function entityKeysFromRecords(
+  spec: DatasetSpec,
+  records: ExtractedRecord[],
+): string[] {
+  const keys = new Set<string>();
+  for (const record of records) {
+    const pk = getPrimaryKeyValue(record, spec);
+    if (pk) keys.add(pk);
+  }
+  return [...keys];
+}

--- a/backend/BigSet_Data_Collection_Agent/src/orchestrator/pipeline.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/orchestrator/pipeline.ts
@@ -63,6 +63,8 @@ export interface PipelineOptions {
   refreshInPlace?: boolean;
   /** When refreshing, re-fetch URLs already seen in the source run. */
   refetchUrls?: boolean;
+  /** Per-run TinyFish Agent poll timeout. Defaults to vendored config. */
+  agentPollTimeoutMs?: number;
   /** Override pipeline logging (benchmark adapters should log to stderr). */
   onLog?: (stage: string, message: string) => void;
   /** Set when invoked from the dataset-agent benchmark harness. */
@@ -262,6 +264,7 @@ async function executeRunPipeline(
     pageIndexStart: pageIndex,
     enableTriage,
     enableTinyfishAgent,
+    agentPollTimeoutMs: options.agentPollTimeoutMs,
     memory: useMemory ? memory : undefined,
     log,
   });
@@ -366,6 +369,7 @@ async function executeRunPipeline(
         allFailedUrls,
         enableTriage,
         enableTinyfishAgent,
+        agentPollTimeoutMs: options.agentPollTimeoutMs,
         targetRowCap,
         log,
       },

--- a/backend/BigSet_Data_Collection_Agent/src/orchestrator/pipeline.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/orchestrator/pipeline.ts
@@ -1,0 +1,652 @@
+import { runWithLlmUsageScope, getCurrentLlmUsage, type LlmUsageTotals } from "../llm/usage.js";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+import { generateDatasetSpec } from "../agents/dataset-spec.js";
+import type { BenchmarkSpecContext } from "../agents/benchmark-spec.js";
+import {
+  analyzeCoverage,
+  type CoverageReport,
+} from "../coverage/analyze.js";
+import { assertConfig, config } from "../config.js";
+import { selectVisualizationRecords } from "../export/select-results.js";
+import {
+  qualityMapFromReport,
+  writeEvidenceJsonl,
+  writeResultsCsv,
+  writeSegmentedRecordCsvs,
+  writeUnkeyedRecordsJsonl,
+} from "../export/csv-compiler.js";
+import { mergeRecords, mergeRepairIntoExisting } from "../merge/records.js";
+import type { DatasetSpec, ExtractedRecord, RunReport } from "../models/schemas.js";
+import {
+  createWorkflowMemory,
+  loadPersistentMemory,
+  mergePersistentMemory,
+  recordCoverageGaps,
+  recordPhaseInMemory,
+  savePersistentMemory,
+  saveRunMemory,
+  snapshotExtractionSchema,
+  type WorkflowMemory,
+} from "../memory/index.js";
+import {
+  agentExtractedUrls,
+  buildQualityReport,
+  buildSourcesReport,
+  mergeSourcesReports,
+  triageByUrl,
+} from "../quality/index.js";
+import { entityKeysFromRecords, runAcquisitionPhase } from "./acquisition.js";
+import { runRepairLoops } from "./repair-loop.js";
+import { loadRunForRefresh, type LoadedRun } from "../storage/run-loader.js";
+import {
+  createRunStore,
+  saveDatasetSpec,
+  saveJson,
+  saveRunReport,
+  saveSourceCandidates,
+  type RunPaths,
+} from "../storage/run-store.js";
+import { normalizeUrl } from "../utils/url.js";
+
+export interface PipelineOptions {
+  prompt: string;
+  targetRows: number;
+  outputDir: string;
+  memoryDir?: string;
+  enableRepair?: boolean;
+  enableTriage?: boolean;
+  enableTinyfishAgent?: boolean;
+  /** Recurring refresh: baseline run to merge into (in-place by primary key). */
+  refreshFrom?: LoadedRun;
+  /** Overwrite the source run directory (same run_id). */
+  refreshInPlace?: boolean;
+  /** When refreshing, re-fetch URLs already seen in the source run. */
+  refetchUrls?: boolean;
+  /** Override pipeline logging (benchmark adapters should log to stderr). */
+  onLog?: (stage: string, message: string) => void;
+  /** Set when invoked from the dataset-agent benchmark harness. */
+  benchmark?: BenchmarkSpecContext;
+}
+
+export interface PipelineResult {
+  runId: string;
+  paths: RunPaths;
+  report: RunReport;
+  recordCount: number;
+  records: ExtractedRecord[];
+  visualizationRecords: ExtractedRecord[];
+  llmUsage: LlmUsageTotals;
+}
+
+let pipelineLog: (stage: string, message: string) => void = (stage, message) => {
+  console.log(`[${stage}] ${message}`);
+};
+
+function log(stage: string, message: string): void {
+  pipelineLog(stage, message);
+}
+
+function phaseStatsFromAcquisition(
+  acquisition: {
+    candidates: { length: number };
+    fetchedUrls: string[];
+    failedUrls: string[];
+    records: ExtractedRecord[];
+    pagesFetched: number;
+    triage: import("../models/schemas.js").TriageSummary;
+  },
+  queryCount: number,
+) {
+  return {
+    search_queries_executed: queryCount,
+    search_results_collected: acquisition.candidates.length,
+    unique_urls_selected: acquisition.fetchedUrls.length,
+    pages_fetched: acquisition.pagesFetched,
+    pages_failed: acquisition.failedUrls.length,
+    raw_records_extracted: acquisition.records.length,
+    triage: acquisition.triage,
+  };
+}
+
+function emptyRepairStats(): RunReport["repair"]["stats"] {
+  return {
+    search_queries_executed: 0,
+    search_results_collected: 0,
+    unique_urls_selected: 0,
+    pages_fetched: 0,
+    pages_failed: 0,
+    raw_records_extracted: 0,
+    triage: {
+      pages_triaged: 0,
+      by_status: {},
+      extract_now: 0,
+      agent_candidates: 0,
+      agent_dispatched: 0,
+      agent_deferred: 0,
+      agent_succeeded: 0,
+      agent_failed: 0,
+      skipped: 0,
+      records_from_extract: 0,
+      records_from_agent: 0,
+    },
+  };
+}
+
+function aggregateRepairStats(
+  loops: RunReport["repair"]["loops"],
+): RunReport["repair"]["stats"] {
+  const stats = emptyRepairStats();
+  for (const loop of loops) {
+    stats.search_queries_executed += loop.stats.search_queries_executed;
+    stats.search_results_collected += loop.stats.search_results_collected;
+    stats.unique_urls_selected += loop.stats.unique_urls_selected;
+    stats.pages_fetched += loop.stats.pages_fetched;
+    stats.pages_failed += loop.stats.pages_failed;
+    stats.raw_records_extracted += loop.stats.raw_records_extracted;
+  }
+  return stats;
+}
+
+function memoryDirFor(options: PipelineOptions): string {
+  return options.memoryDir ?? join(options.outputDir, "..", "memory");
+}
+
+export async function runPipeline(
+  options: PipelineOptions,
+): Promise<PipelineResult> {
+  const { result, usage } = await runWithLlmUsageScope(() =>
+    executeRunPipeline(options),
+  );
+  return { ...result, llmUsage: usage };
+}
+
+async function executeRunPipeline(
+  options: PipelineOptions,
+): Promise<Omit<PipelineResult, "llmUsage">> {
+  pipelineLog =
+    options.onLog ?? ((stage, message) => console.log(`[${stage}] ${message}`));
+  assertConfig();
+
+  const enableRepair = options.enableRepair ?? config.enableRepairLoop;
+  const enableTriage = options.enableTriage ?? config.enableTriage;
+  const enableTinyfishAgent =
+    options.enableTinyfishAgent ?? config.enableTinyfishAgent;
+  const useMemory = config.enableWorkflowMemory;
+  const startedAt = new Date();
+  const refreshSource = options.refreshFrom;
+  const inPlaceRefresh = Boolean(refreshSource && options.refreshInPlace);
+  const runId =
+    inPlaceRefresh && refreshSource
+      ? refreshSource.runId
+      : randomUUID().slice(0, 8);
+  const paths = await createRunStore(options.outputDir, runId);
+  const errors: string[] = [];
+  const fetchedUrlSet = new Set<string>();
+  if (refreshSource && !options.refetchUrls) {
+    for (const url of refreshSource.report.fetched_urls) {
+      fetchedUrlSet.add(normalizeUrl(url));
+    }
+  }
+  let pageIndex = 0;
+  const targetRowCap = options.targetRows * 2;
+
+  log(
+    "init",
+    refreshSource
+      ? `refresh run_id=${runId} from=${refreshSource.runId} in_place=${inPlaceRefresh} output=${paths.root}`
+      : `run_id=${runId} output=${paths.root}`,
+  );
+
+  let memory: WorkflowMemory = createWorkflowMemory(options.prompt);
+  if (refreshSource?.memory) {
+    memory = mergePersistentMemory(memory, refreshSource.memory);
+    log(
+      "memory",
+      `Loaded workflow memory from run ${refreshSource.runId} (${refreshSource.memory.query_stats.length} query stats)`,
+    );
+  }
+  if (useMemory) {
+    const prior = await loadPersistentMemory(
+      memoryDirFor(options),
+      memory.prompt_fingerprint,
+    );
+    memory = mergePersistentMemory(memory, prior);
+    if (prior && !refreshSource?.memory) {
+      log(
+        "memory",
+        `Loaded prior workflow memory (${prior.query_stats.length} query stats, ${prior.domain_stats.length} domain stats)`,
+      );
+    }
+  }
+
+  let spec: DatasetSpec;
+  let baselineRecords: ExtractedRecord[] = [];
+
+  if (refreshSource) {
+    spec = refreshSource.spec;
+    baselineRecords = refreshSource.records;
+    memory.extraction_schema = snapshotExtractionSchema(spec);
+    memory.dedupe_keys = spec.dedupe_keys;
+    memory.repair_loop_count = 0;
+    await saveDatasetSpec(paths, spec);
+    log(
+      "refresh",
+      `Baseline ${baselineRecords.length} records — new search with prior diagnostics/memory`,
+    );
+  } else {
+    log("spec", "Generating dataset specification...");
+    spec = await generateDatasetSpec(
+      options.prompt,
+      options.targetRows,
+      useMemory ? memory : null,
+      options.benchmark,
+    );
+    memory.extraction_schema = snapshotExtractionSchema(spec);
+    memory.dedupe_keys = spec.dedupe_keys;
+    await saveDatasetSpec(paths, spec);
+  }
+
+  const initialQueries = spec.search_queries.slice(0, config.maxSearchQueries);
+
+  const initialAcquisition = await runAcquisitionPhase({
+    label: refreshSource ? "refresh" : "initial",
+    userPrompt: options.prompt,
+    spec,
+    queries: initialQueries,
+    paths,
+    errors,
+    excludeUrls: fetchedUrlSet,
+    maxResultsPerQuery: config.maxResultsPerQuery,
+    maxUrlsToFetch: config.maxUrlsToFetch,
+    pageIndexStart: pageIndex,
+    enableTriage,
+    enableTinyfishAgent,
+    memory: useMemory ? memory : undefined,
+    log,
+  });
+
+  recordPhaseInMemory({
+    memory,
+    spec,
+    phase: refreshSource ? "refresh" : "initial",
+    repairLoop: 0,
+    queries: initialQueries,
+    candidates: initialAcquisition.candidates,
+    records: initialAcquisition.records,
+    failedUrls: initialAcquisition.failedUrls,
+    agentRuns: initialAcquisition.agentRuns,
+    triageResults: initialAcquisition.triageResults,
+  });
+
+  if (initialAcquisition.triage.agent_dispatched > 0) {
+    log(
+      "triage",
+      `Initial: ${initialAcquisition.triage.extract_now} extract_now, ` +
+        `${initialAcquisition.triage.agent_succeeded}/${initialAcquisition.triage.agent_dispatched} agent runs succeeded`,
+    );
+  }
+
+  for (const url of initialAcquisition.fetchedUrls) {
+    fetchedUrlSet.add(normalizeUrl(url));
+  }
+  pageIndex += initialAcquisition.pagesFetched;
+
+  await saveSourceCandidates(paths, initialAcquisition.candidates);
+
+  let mergeResult = refreshSource
+    ? mergeRepairIntoExisting(
+        spec,
+        baselineRecords,
+        initialAcquisition.records,
+      )
+    : mergeRecords(spec, initialAcquisition.records);
+  let mergedRecords = mergeResult.records.slice(0, targetRowCap);
+  let benchmarkVisualizationRecords = mergedRecords;
+  let unkeyedRecords = mergeResult.unkeyed;
+
+  let coverage: CoverageReport = analyzeCoverage(spec, mergedRecords);
+  recordCoverageGaps(memory, coverage);
+  await saveJson(join(paths.root, "coverage_initial.json"), coverage);
+
+  const writeExports = async (
+    csvPath: string,
+    evidencePath: string,
+    records: ExtractedRecord[],
+    qualityById?: ReturnType<typeof qualityMapFromReport>,
+  ) => {
+    await writeResultsCsv(csvPath, spec, records, qualityById);
+    await writeEvidenceJsonl(evidencePath, spec, records, qualityById);
+  };
+
+  log("export", `Writing init_results.csv (${mergedRecords.length} records)...`);
+  await writeExports(paths.initResultsPath, paths.initEvidencePath, mergedRecords);
+
+  const allSearchQueries = [...initialQueries];
+  const allFailedUrls = [...initialAcquisition.failedUrls];
+  const recordsBeforeRepair = mergedRecords;
+
+  let repairReport: RunReport["repair"] = {
+    attempted: false,
+    total_loops: 0,
+    loops: [],
+    missing_fields: [],
+    repair_queries: [],
+    records_before: mergedRecords.length,
+    records_after: mergedRecords.length,
+    fields_filled: {},
+    stats: emptyRepairStats(),
+  };
+
+  const repairAcquisitions: typeof initialAcquisition[] = [];
+
+  if (!enableRepair) {
+    repairReport.skipped_reason = "repair_disabled";
+    log("repair", "Skipped (disabled)");
+  } else if (!coverage.should_repair) {
+    repairReport.skipped_reason = "no_missing_required_fields";
+    log(
+      "repair",
+      `Skipped (coverage satisfied) — required=[${coverage.required_columns.join(", ")}]`,
+    );
+  } else {
+    repairReport.attempted = true;
+    repairReport.records_before = recordsBeforeRepair.length;
+    repairReport.missing_fields = coverage.field_gaps.map((gap) => gap.column);
+
+    const repairResult = await runRepairLoops({
+      ctx: {
+        userPrompt: options.prompt,
+        spec,
+        paths,
+        errors,
+        memory,
+        fetchedUrlSet,
+        allSearchQueries,
+        allFailedUrls,
+        enableTriage,
+        enableTinyfishAgent,
+        targetRowCap,
+        log,
+      },
+      recordsBeforeRepair,
+      initialCoverage: coverage,
+      pageIndexStart: pageIndex,
+    });
+
+    mergedRecords = repairResult.mergedRecords;
+    unkeyedRecords = [...unkeyedRecords, ...repairResult.unkeyedRecords];
+    coverage = repairResult.coverage;
+    repairAcquisitions.push(...repairResult.repairAcquisitions);
+
+    repairReport.total_loops = repairResult.loops.length;
+    repairReport.loops = repairResult.loops;
+    repairReport.last_diagnosis = repairResult.lastDiagnosis;
+    repairReport.records_after = mergedRecords.length;
+    repairReport.repair_queries = repairResult.loops.flatMap((loop) => loop.repair_queries);
+    repairReport.rationale = repairResult.lastDiagnosis?.summary;
+    repairReport.fields_filled = repairResult.loops.reduce(
+      (acc, loop) => {
+        for (const [key, value] of Object.entries(loop.fields_filled)) {
+          acc[key] = (acc[key] ?? 0) + value;
+        }
+        return acc;
+      },
+      {} as Record<string, number>,
+    );
+    repairReport.stats = aggregateRepairStats(repairResult.loops);
+    repairReport.missing_fields = coverage.field_gaps.map((gap) => gap.column);
+
+    if (repairResult.loops.length > 0) {
+      log(
+        "export",
+        `Writing repair_results.csv (${mergedRecords.length} records after ${repairResult.loops.length} repair loop(s))...`,
+      );
+      await writeExports(
+        paths.repairResultsPath,
+        paths.repairEvidencePath,
+        mergedRecords,
+      );
+    }
+  }
+
+  if (useMemory) {
+    await saveRunMemory(paths.root, memory);
+    await savePersistentMemory(memoryDirFor(options), memory);
+    log("memory", `Saved workflow memory (repair_loops=${memory.repair_loop_count})`);
+  }
+
+  let qualityReport: RunReport["quality"];
+  let sourcesReport: RunReport["sources"];
+
+  if (config.enableQualityScoring) {
+    log("quality", "Scoring records and building source outcomes...");
+
+    const allTriage = [
+      ...initialAcquisition.triageResults,
+      ...repairAcquisitions.flatMap((a) => a.triageResults),
+    ];
+    const allAgentRuns = [
+      ...initialAcquisition.agentRuns,
+      ...repairAcquisitions.flatMap((a) => a.agentRuns),
+    ];
+
+    const scoreContext = {
+      triageByUrl: triageByUrl(allTriage),
+      agentExtractedUrls: agentExtractedUrls(allAgentRuns),
+    };
+
+    qualityReport = buildQualityReport(
+      spec,
+      mergedRecords,
+      scoreContext,
+      unkeyedRecords.length,
+    );
+
+    const initialSources = buildSourcesReport({
+      phase: "initial",
+      fetchedPages: initialAcquisition.fetchedPages,
+      fetchedUrls: initialAcquisition.fetchedUrls,
+      triageResults: initialAcquisition.triageResults,
+      agentRuns: initialAcquisition.agentRuns,
+      agentDeferred: initialAcquisition.agentDeferred,
+    });
+
+    const repairSourcesList = repairAcquisitions.map((acquisition, index) =>
+      buildSourcesReport({
+        phase: "repair",
+        fetchedPages: acquisition.fetchedPages,
+        fetchedUrls: acquisition.fetchedUrls,
+        triageResults: acquisition.triageResults,
+        agentRuns: acquisition.agentRuns,
+        agentDeferred: acquisition.agentDeferred,
+      }),
+    );
+
+    sourcesReport = repairSourcesList.reduce(
+      (acc, report) => mergeSourcesReports(acc, report),
+      initialSources,
+    );
+
+    await saveJson(join(paths.root, "quality_report.json"), qualityReport);
+    await saveJson(join(paths.root, "sources_outcomes.json"), sourcesReport);
+
+    if (unkeyedRecords.length > 0) {
+      await writeUnkeyedRecordsJsonl(
+        join(paths.root, "records_unkeyed.jsonl"),
+        unkeyedRecords,
+      );
+    }
+
+    await writeSegmentedRecordCsvs(
+      paths.root,
+      spec,
+      mergedRecords,
+      qualityReport.records,
+    );
+
+    const qualityById = qualityMapFromReport(qualityReport.records);
+    benchmarkVisualizationRecords = config.enableSelectiveResults
+      ? selectVisualizationRecords(spec, mergedRecords, qualityById)
+      : mergedRecords;
+
+    log(
+      "quality",
+      `complete=${qualityReport.complete.count} partial=${qualityReport.partial.count} ` +
+        `low_confidence=${qualityReport.low_confidence.count} needs_review=${qualityReport.needs_review.count} ` +
+        `visualization=${benchmarkVisualizationRecords.length}`,
+    );
+
+    if (config.enableSelectiveResults) {
+      log(
+        "export",
+        `Writing results_full.csv (${mergedRecords.length} records)...`,
+      );
+      await writeExports(
+        paths.resultsFullPath,
+        paths.evidenceFullPath,
+        mergedRecords,
+        qualityById,
+      );
+      log(
+        "export",
+        `Writing results.csv (${benchmarkVisualizationRecords.length} selective records)...`,
+      );
+      await writeExports(
+        paths.resultsPath,
+        paths.evidencePath,
+        benchmarkVisualizationRecords,
+        qualityById,
+      );
+    } else {
+      log("export", `Writing results.csv (${mergedRecords.length} records)...`);
+      await writeExports(
+        paths.resultsPath,
+        paths.evidencePath,
+        mergedRecords,
+        qualityById,
+      );
+    }
+  } else {
+    log("export", `Writing results.csv (${mergedRecords.length} records)...`);
+    await writeExports(paths.resultsPath, paths.evidencePath, mergedRecords);
+  }
+
+  const finishedAt = new Date();
+  const initialStats = phaseStatsFromAcquisition(
+    initialAcquisition,
+    initialQueries.length,
+  );
+
+  const visualizationCount = benchmarkVisualizationRecords.length;
+
+  const llmUsage = getCurrentLlmUsage();
+
+  const report: RunReport = {
+    run_id: runId,
+    ...(refreshSource
+      ? {
+          refreshed_from_run_id: refreshSource.runId,
+          refresh_in_place: inPlaceRefresh,
+        }
+      : {}),
+    prompt: options.prompt,
+    target_rows: options.targetRows,
+    started_at: startedAt.toISOString(),
+    finished_at: finishedAt.toISOString(),
+    duration_ms: finishedAt.getTime() - startedAt.getTime(),
+    dataset_spec: spec,
+    stats: {
+      ...initialStats,
+      search_queries_executed:
+        initialStats.search_queries_executed +
+        repairReport.stats.search_queries_executed,
+      search_results_collected:
+        initialStats.search_results_collected +
+        repairReport.stats.search_results_collected,
+      unique_urls_selected:
+        initialStats.unique_urls_selected +
+        repairReport.stats.unique_urls_selected,
+      pages_fetched:
+        initialStats.pages_fetched + repairReport.stats.pages_fetched,
+      pages_failed:
+        initialStats.pages_failed + repairReport.stats.pages_failed,
+      raw_records_extracted:
+        initialStats.raw_records_extracted +
+        repairReport.stats.raw_records_extracted,
+      records_after_merge: mergedRecords.length,
+      visualization_records: visualizationCount,
+    },
+    initial: {
+      ...initialStats,
+      search_queries: initialQueries,
+      fetched_urls: initialAcquisition.fetchedUrls,
+      failed_urls: initialAcquisition.failedUrls,
+    },
+    repair: repairReport,
+    search_queries: allSearchQueries,
+    fetched_urls: [...fetchedUrlSet],
+    failed_urls: allFailedUrls,
+    errors,
+    quality: qualityReport,
+    sources: sourcesReport,
+    llm_usage: {
+      prompt_tokens: llmUsage.promptTokens,
+      completion_tokens: llmUsage.completionTokens,
+      total_tokens: llmUsage.totalTokens,
+      call_count: llmUsage.callCount,
+    },
+  };
+
+  await saveRunReport(paths, report);
+
+  log("done", `results → ${paths.resultsPath}`);
+  return {
+    runId,
+    paths,
+    report,
+    recordCount: mergedRecords.length,
+    records: mergedRecords,
+    visualizationRecords: benchmarkVisualizationRecords,
+  };
+}
+
+export function defaultRunsDir(): string {
+  return join(process.cwd(), "runs");
+}
+
+export function defaultMemoryDir(): string {
+  return join(process.cwd(), "memory");
+}
+
+export async function runRefreshPipeline(options: {
+  fromRunId: string;
+  outputDir: string;
+  memoryDir?: string;
+  targetRows?: number;
+  inPlace?: boolean;
+  refetchUrls?: boolean;
+  enableRepair?: boolean;
+  enableTriage?: boolean;
+  enableTinyfishAgent?: boolean;
+}): Promise<PipelineResult> {
+  const loaded = await loadRunForRefresh(options.outputDir, options.fromRunId);
+  if (loaded.records.length === 0) {
+    throw new Error(
+      `Run ${options.fromRunId} has no records in evidence.jsonl — cannot refresh`,
+    );
+  }
+
+  return runPipeline({
+    prompt: loaded.report.prompt,
+    targetRows: options.targetRows ?? loaded.report.target_rows,
+    outputDir: options.outputDir,
+    memoryDir: options.memoryDir,
+    enableRepair: options.enableRepair,
+    enableTriage: options.enableTriage,
+    enableTinyfishAgent: options.enableTinyfishAgent,
+    refreshFrom: loaded,
+    refreshInPlace: options.inPlace,
+    refetchUrls: options.refetchUrls,
+  });
+}

--- a/backend/BigSet_Data_Collection_Agent/src/orchestrator/process-pages.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/orchestrator/process-pages.ts
@@ -2,7 +2,10 @@ import { generateAgentGoal } from "../agents/agent-goal.js";
 import { extractFromAgentResult } from "../agents/extract-from-agent.js";
 import { extractFromPage } from "../agents/extract.js";
 import { triagePage } from "../agents/source-triage.js";
-import { derivePromptSourcePolicy } from "../agents/source-policy.js";
+import {
+  triageAndExtractPage,
+  type SourceTriageExtractOutcome,
+} from "../agents/triage-extract.js";
 import { config } from "../config.js";
 import { runTinyfishAgentsBatch } from "../integrations/tinyfish-agent.js";
 import type { WorkflowMemory } from "../memory/index.js";
@@ -31,12 +34,12 @@ import { join } from "node:path";
 export interface AgentDeferredEntry {
   url: string;
   status: SourceStatus;
-  reason: "agent_budget" | "agent_disabled";
 }
 
 export interface ProcessPagesResult {
   records: ExtractedRecord[];
   triageResults: SourceTriageResult[];
+  sourceOutcomes: SourceTriageExtractOutcome[];
   agentRuns: AgentRunRecord[];
   agentDeferred: AgentDeferredEntry[];
   summary: TriageSummary;
@@ -62,32 +65,471 @@ function bumpStatus(summary: TriageSummary, status: SourceStatus): void {
   summary.by_status[status] = (summary.by_status[status] ?? 0) + 1;
 }
 
-function shouldFallbackExtractOfficialNavigation(
-  url: string,
-  status: SourceStatus,
-): boolean {
-  if (
-    status !== "requires_navigation" &&
-    status !== "requires_detail_page_followup"
-  ) {
-    return false;
+function fallbackTriage(page: FetchedPage, error: unknown): SourceTriageResult {
+  const pageUrl = page.final_url || page.url;
+  return {
+    url: page.url,
+    final_url: pageUrl,
+    title: page.title,
+    status: "extract_now",
+    confidence: 0.3,
+    source_data_confidence: 0.35,
+    expected_yield: "partial",
+    reasoning: `Triage failed; falling back to direct extraction. ${
+      error instanceof Error ? error.message : String(error)
+    }`,
+  };
+}
+
+function appendRecords(
+  records: ExtractedRecord[],
+  batch: ExtractedRecord[],
+  knownKeys: Set<string>,
+  spec: DatasetSpec,
+): void {
+  for (const record of batch) {
+    records.push(record);
+    const pk = getPrimaryKeyValue(record, spec);
+    if (pk) knownKeys.add(pk);
+  }
+}
+
+async function runAgentPhase(options: {
+  label: string;
+  userPrompt: string;
+  spec: DatasetSpec;
+  agentQueue: { page: FetchedPage; triage: SourceTriageResult }[];
+  agentEnabled: boolean;
+  focusFields?: string[];
+  memory?: WorkflowMemory;
+  records: ExtractedRecord[];
+  knownKeys: Set<string>;
+  agentRuns: AgentRunRecord[];
+  summary: TriageSummary;
+  errors: string[];
+  log: (stage: string, message: string) => void;
+}): Promise<AgentDeferredEntry[]> {
+  const agentBudget = options.agentEnabled ? config.maxAgentRunsPerPhase : 0;
+  const toRun = options.agentQueue.slice(0, agentBudget);
+  const deferredEntries: AgentDeferredEntry[] = options.agentQueue
+    .slice(agentBudget)
+    .map(({ page, triage }) => ({
+      url: triage.final_url || page.url,
+      status: triage.status,
+    }));
+
+  if (deferredEntries.length > 0) {
+    options.log(
+      options.label,
+      `Agent budget: running ${toRun.length}/${options.agentQueue.length} (${deferredEntries.length} deferred)`,
+    );
   }
 
-  try {
-    const parsed = new URL(url);
-    const path = `${parsed.pathname}${parsed.search}`.toLowerCase();
-    if (
-      path === "/" ||
-      /(?:login|signin|signup|default\.aspx|home)(?:\/|$|\?)/.test(path)
-    ) {
-      return false;
-    }
-    return /(?:pricing|billing|docs|documentation|mcp|model-context-protocol|earnings|press-release|quarterly|results|news|blog)/.test(
-      path,
-    );
-  } catch {
-    return false;
+  options.summary.agent_dispatched = toRun.length;
+  options.summary.agent_deferred = deferredEntries.length;
+
+  if (toRun.length === 0) {
+    return deferredEntries;
   }
+
+  options.log(
+    options.label,
+    `Tinyfish Agent on ${toRun.length} pages (triage-only routing; extract after agent) — queue=${config.agentQueueConcurrency}, poll=${config.agentPollConcurrency}...`,
+  );
+
+  const agentGoalQueue = createAgentQueue();
+  const extractionQueue = createExtractionQueue();
+
+  const jobsWithGoals = await agentGoalQueue.runAll(
+    toRun,
+    async ({ page, triage }) => {
+      const pageUrl = triage.final_url || page.url;
+      try {
+        const agentGoal = await generateAgentGoal({
+          userPrompt: options.userPrompt,
+          spec: options.spec,
+          triage,
+          focusFields: options.focusFields,
+          memory: options.memory,
+        });
+        return { page, triage, pageUrl, goal: agentGoal.goal, goalError: null as string | null };
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        options.errors.push(`Agent goal failed for ${pageUrl}: ${msg}`);
+        return { page, triage, pageUrl, goal: "", goalError: msg };
+      }
+    },
+    ({ page }) => [getDomain(page.final_url || page.url)],
+  );
+
+  const queueJobs: { url: string; goal: string }[] = [];
+  const queueJobIndices: number[] = [];
+
+  for (let index = 0; index < jobsWithGoals.length; index++) {
+    const job = jobsWithGoals[index]!;
+    if (job.goalError) {
+      options.summary.agent_failed += 1;
+      options.agentRuns.push({
+        url: job.pageUrl,
+        status: job.triage.status,
+        run_id: null,
+        agent_status: "FAILED",
+        goal: "",
+        records_extracted: 0,
+        error: job.goalError,
+      });
+      continue;
+    }
+    queueJobs.push({ url: job.pageUrl, goal: job.goal });
+    queueJobIndices.push(index);
+  }
+
+  const agentRunResults = await runTinyfishAgentsBatch(queueJobs);
+
+  const jobsToExtract = queueJobIndices.map((jobIndex, batchIndex) => ({
+    job: jobsWithGoals[jobIndex]!,
+    run: agentRunResults[batchIndex]!,
+  }));
+
+  await extractionQueue.runAll(
+    jobsToExtract,
+    async ({ job, run }) => {
+      const pageUrl = job.pageUrl;
+
+      if (run.error || !run.result) {
+        options.summary.agent_failed += 1;
+        options.agentRuns.push({
+          url: pageUrl,
+          status: job.triage.status,
+          run_id: run.run_id,
+          agent_status: run.status,
+          goal: job.goal,
+          records_extracted: 0,
+          error: run.error ?? "No result returned",
+        });
+        options.log(
+          options.label,
+          `WARN Agent failed ${pageUrl}: ${run.error ?? "no result"}`,
+        );
+        return;
+      }
+
+      try {
+        const agentRecords = await extractFromAgentResult({
+          spec: options.spec,
+          pageUrl,
+          agentResult: run.result,
+          focusFields: options.focusFields,
+          memory: options.memory,
+        });
+
+        options.summary.agent_succeeded += 1;
+        appendRecords(options.records, agentRecords, options.knownKeys, options.spec);
+        options.summary.records_from_agent += agentRecords.length;
+
+        options.agentRuns.push({
+          url: pageUrl,
+          status: job.triage.status,
+          run_id: run.run_id,
+          agent_status: run.status,
+          goal: job.goal,
+          records_extracted: agentRecords.length,
+        });
+
+        options.log(
+          options.label,
+          `Agent OK ${pageUrl} → ${agentRecords.length} records`,
+        );
+      } catch (error) {
+        options.summary.agent_failed += 1;
+        const msg = error instanceof Error ? error.message : String(error);
+        options.errors.push(`Agent extract failed for ${pageUrl}: ${msg}`);
+        options.agentRuns.push({
+          url: pageUrl,
+          status: job.triage.status,
+          run_id: run.run_id,
+          agent_status: run.status,
+          goal: job.goal,
+          records_extracted: 0,
+          error: msg,
+        });
+      }
+    },
+    ({ job }) => [getDomain(job.pageUrl)],
+  );
+
+  return deferredEntries;
+}
+
+async function processWithSeparateTriageExtract(options: {
+  label: string;
+  userPrompt: string;
+  spec: DatasetSpec;
+  successfulPages: FetchedPage[];
+  paths: RunPaths;
+  errors: string[];
+  focusFields?: string[];
+  knownKeys: Set<string>;
+  enableTinyfishAgent: boolean;
+  memory?: WorkflowMemory;
+  log: (stage: string, message: string) => void;
+  records: ExtractedRecord[];
+  summary: TriageSummary;
+}): Promise<{
+  triageResults: SourceTriageResult[];
+  sourceOutcomes: SourceTriageExtractOutcome[];
+  agentQueue: { page: FetchedPage; triage: SourceTriageResult }[];
+}> {
+  const triageQueue = createTriageQueue();
+  const extractionQueue = createExtractionQueue();
+
+  options.log(
+    options.label,
+    `Triaging ${options.successfulPages.length} pages (legacy separate extract, concurrency=${config.triageConcurrency})...`,
+  );
+
+  const triageResults = await triageQueue.runAll(
+    options.successfulPages,
+    async (page) => {
+      try {
+        return await triagePage({
+          userPrompt: options.userPrompt,
+          spec: options.spec,
+          page,
+          knownEntityKeys: [...options.knownKeys],
+          memory: options.memory,
+        });
+      } catch (error) {
+        const pageUrl = page.final_url || page.url;
+        const msg = `Triage failed for ${pageUrl}: ${
+          error instanceof Error ? error.message : String(error)
+        }`;
+        options.errors.push(msg);
+        options.log(options.label, `WARN ${msg}`);
+        return fallbackTriage(page, error);
+      }
+    },
+    (page) => [getDomain(page.final_url || page.url)],
+  );
+
+  const sourceOutcomes: SourceTriageExtractOutcome[] = triageResults.map((triage) => ({
+    url: triage.url,
+    final_url: triage.final_url,
+    triage_results: triage,
+    extraction_results: null,
+  }));
+
+  const pageByUrl = new Map(
+    options.successfulPages.map((page) => [page.final_url || page.url, page]),
+  );
+
+  const extractPages: { page: FetchedPage; triage: SourceTriageResult }[] = [];
+  const agentQueue: { page: FetchedPage; triage: SourceTriageResult }[] = [];
+
+  for (const triage of triageResults) {
+    bumpStatus(options.summary, triage.status);
+    const page = pageByUrl.get(triage.final_url) ?? pageByUrl.get(triage.url);
+    if (!page) continue;
+
+    if (triage.status === "extract_now") {
+      options.summary.extract_now += 1;
+      extractPages.push({ page, triage });
+    } else if (statusNeedsAgent(triage.status)) {
+      options.summary.agent_candidates += 1;
+      if (options.enableTinyfishAgent) {
+        agentQueue.push({ page, triage });
+      } else {
+        options.log(
+          options.label,
+          `Agent disabled — fallback extract for ${triage.final_url} [${triage.status}]`,
+        );
+        extractPages.push({ page, triage });
+      }
+    } else {
+      options.summary.skipped += 1;
+      options.log(
+        options.label,
+        `Skip ${triage.final_url} [${triage.status}]: ${triage.reasoning.slice(0, 80)}`,
+      );
+    }
+  }
+
+  if (extractPages.length > 0) {
+    options.log(
+      options.label,
+      `Direct extraction on ${extractPages.length} pages (legacy, concurrency=${config.extractionConcurrency})...`,
+    );
+    const extracted = await extractionQueue.runAll(
+      extractPages,
+      async ({ page, triage }) => {
+        try {
+          const pageRecords = await extractFromPage(options.spec, page, {
+            focusFields: options.focusFields,
+            memory: options.memory,
+          });
+          const outcome = sourceOutcomes.find(
+            (item) => item.final_url === triage.final_url || item.url === triage.url,
+          );
+          if (outcome) {
+            outcome.extraction_results = {
+              records: pageRecords,
+            };
+          }
+          return pageRecords;
+        } catch (error) {
+          const msg = `Extraction failed for ${page.final_url || page.url}: ${
+            error instanceof Error ? error.message : String(error)
+          }`;
+          options.errors.push(msg);
+          return [] as ExtractedRecord[];
+        }
+      },
+      ({ page }) => [getDomain(page.final_url || page.url)],
+    );
+    for (const batch of extracted) {
+      appendRecords(options.records, batch, options.knownKeys, options.spec);
+    }
+    options.summary.records_from_extract = options.records.length;
+  }
+
+  return { triageResults, sourceOutcomes, agentQueue };
+}
+
+async function processWithCombinedTriageExtract(options: {
+  label: string;
+  userPrompt: string;
+  spec: DatasetSpec;
+  successfulPages: FetchedPage[];
+  errors: string[];
+  focusFields?: string[];
+  knownKeys: Set<string>;
+  enableTinyfishAgent: boolean;
+  memory?: WorkflowMemory;
+  log: (stage: string, message: string) => void;
+  records: ExtractedRecord[];
+  summary: TriageSummary;
+}): Promise<{
+  triageResults: SourceTriageResult[];
+  sourceOutcomes: SourceTriageExtractOutcome[];
+  agentQueue: { page: FetchedPage; triage: SourceTriageResult }[];
+}> {
+  const triageQueue = createTriageQueue();
+  options.log(
+    options.label,
+    `Combined triage+extract on ${options.successfulPages.length} pages (concurrency=${config.triageConcurrency}, ${config.triageExtractMaxPageChars} chars/page)...`,
+  );
+
+  const outcomes = await triageQueue.runAll(
+    options.successfulPages,
+    async (page) => {
+      try {
+        return await triageAndExtractPage({
+          userPrompt: options.userPrompt,
+          spec: options.spec,
+          page,
+          knownEntityKeys: [...options.knownKeys],
+          memory: options.memory,
+          focusFields: options.focusFields,
+        });
+      } catch (error) {
+        const pageUrl = page.final_url || page.url;
+        const msg = `Triage-extract failed for ${pageUrl}: ${
+          error instanceof Error ? error.message : String(error)
+        }`;
+        options.errors.push(msg);
+        options.log(options.label, `WARN ${msg}`);
+        const triage = fallbackTriage(page, error);
+        let records: ExtractedRecord[] = [];
+        try {
+          records = await extractFromPage(options.spec, page, {
+            focusFields: options.focusFields,
+            memory: options.memory,
+          });
+        } catch (extractError) {
+          options.errors.push(
+            `Fallback extraction failed for ${pageUrl}: ${
+              extractError instanceof Error ? extractError.message : String(extractError)
+            }`,
+          );
+        }
+        return {
+          triage,
+          records,
+          outcome: {
+            url: page.url,
+            final_url: pageUrl,
+            triage_results: triage,
+            extraction_results: records.length
+              ? { records }
+              : null,
+          },
+        };
+      }
+    },
+    (page) => [getDomain(page.final_url || page.url)],
+  );
+
+  const triageResults: SourceTriageResult[] = [];
+  const sourceOutcomes: SourceTriageExtractOutcome[] = [];
+  const agentQueue: { page: FetchedPage; triage: SourceTriageResult }[] = [];
+  const pageByUrl = new Map(
+    options.successfulPages.map((page) => [page.final_url || page.url, page]),
+  );
+
+  for (const result of outcomes) {
+    triageResults.push(result.triage);
+    sourceOutcomes.push(result.outcome);
+    bumpStatus(options.summary, result.triage.status);
+
+    const page =
+      pageByUrl.get(result.triage.final_url) ?? pageByUrl.get(result.triage.url);
+    if (!page) continue;
+
+    if (result.triage.status === "extract_now") {
+      options.summary.extract_now += 1;
+      appendRecords(options.records, result.records, options.knownKeys, options.spec);
+    } else if (statusNeedsAgent(result.triage.status)) {
+      options.summary.agent_candidates += 1;
+      if (options.enableTinyfishAgent) {
+        agentQueue.push({ page, triage: result.triage });
+      } else {
+        options.log(
+          options.label,
+          `Agent disabled — fallback extract for ${result.triage.final_url} [${result.triage.status}]`,
+        );
+        try {
+          const pageRecords = await extractFromPage(options.spec, page, {
+            focusFields: options.focusFields,
+            memory: options.memory,
+          });
+          const outcome = sourceOutcomes.find(
+            (item) =>
+              item.final_url === result.triage.final_url ||
+              item.url === result.triage.url,
+          );
+          if (outcome) {
+            outcome.extraction_results = { records: pageRecords };
+          }
+          appendRecords(options.records, pageRecords, options.knownKeys, options.spec);
+        } catch (error) {
+          const msg = `Fallback extraction failed for ${result.triage.final_url}: ${
+            error instanceof Error ? error.message : String(error)
+          }`;
+          options.errors.push(msg);
+        }
+      }
+    } else {
+      options.summary.skipped += 1;
+      options.log(
+        options.label,
+        `Skip ${result.triage.final_url} [${result.triage.status}]: ${result.triage.reasoning.slice(0, 80)}`,
+      );
+    }
+  }
+
+  options.summary.records_from_extract = options.records.length;
+
+  return { triageResults, sourceOutcomes, agentQueue };
 }
 
 export async function processFetchedPages(options: {
@@ -101,7 +543,6 @@ export async function processFetchedPages(options: {
   knownEntityKeys?: string[];
   enableTriage?: boolean;
   enableTinyfishAgent?: boolean;
-  agentPollTimeoutMs?: number;
   memory?: WorkflowMemory;
   log: (stage: string, message: string) => void;
 }): Promise<ProcessPagesResult> {
@@ -111,7 +552,6 @@ export async function processFetchedPages(options: {
   const records: ExtractedRecord[] = [];
   const agentRuns: AgentRunRecord[] = [];
   const knownKeys = new Set(options.knownEntityKeys ?? []);
-  const sourcePolicy = derivePromptSourcePolicy(options.userPrompt);
 
   const successfulPages = options.pages.filter(
     (page) => !page.error && page.text.trim().length > 0,
@@ -121,6 +561,7 @@ export async function processFetchedPages(options: {
     return {
       records: [],
       triageResults: [],
+      sourceOutcomes: [],
       agentRuns: [],
       agentDeferred: [],
       summary,
@@ -159,303 +600,60 @@ export async function processFetchedPages(options: {
     return {
       records: flat,
       triageResults: [],
+      sourceOutcomes: [],
       agentRuns: [],
       agentDeferred: [],
       summary,
     };
   }
 
-  const triageQueue = createTriageQueue();
-
-  options.log(
-    options.label,
-    `Triaging ${successfulPages.length} pages (parallel, concurrency=${config.triageConcurrency})...`,
-  );
-
-  const triageResults = await triageQueue.runAll(
+  const shared = {
+    label: options.label,
+    userPrompt: options.userPrompt,
+    spec: options.spec,
     successfulPages,
-    async (page) => {
-      try {
-        return await triagePage({
-          userPrompt: options.userPrompt,
-          spec: options.spec,
-          page,
-          knownEntityKeys: [...knownKeys],
-          memory: options.memory,
-        });
-      } catch (error) {
-        const pageUrl = page.final_url || page.url;
-        const msg = `Triage failed for ${pageUrl}: ${
-          error instanceof Error ? error.message : String(error)
-        }`;
-        options.errors.push(msg);
-        options.log(options.label, `WARN ${msg}`);
-        return {
-          url: page.url,
-          final_url: pageUrl,
-          title: page.title,
-          status: "extract_now" as const,
-          confidence: 0.3,
-          source_data_confidence: 0.35,
-          expected_yield: "partial" as const,
-          reasoning: "Triage failed; falling back to direct extraction.",
-        };
-      }
-    },
-    (page) => [getDomain(page.final_url || page.url)],
-  );
+    paths: options.paths,
+    errors: options.errors,
+    focusFields: options.focusFields,
+    knownKeys,
+    enableTinyfishAgent: agentEnabled,
+    memory: options.memory,
+    log: options.log,
+    records,
+    summary,
+  };
+
+  const { triageResults, sourceOutcomes, agentQueue } =
+    config.enableCombinedTriageExtract
+      ? await processWithCombinedTriageExtract(shared)
+      : await processWithSeparateTriageExtract(shared);
 
   summary.pages_triaged = triageResults.length;
+
   await saveJson(
     join(options.paths.root, `triage_${options.label}.json`),
     triageResults,
   );
-
-  const pageByUrl = new Map(
-    successfulPages.map((page) => [page.final_url || page.url, page]),
+  await saveJson(
+    join(options.paths.root, `source_outcomes_${options.label}.json`),
+    sourceOutcomes,
   );
 
-  const extractPages: { page: FetchedPage; triage: SourceTriageResult }[] = [];
-  const agentQueue: { page: FetchedPage; triage: SourceTriageResult }[] = [];
-  const agentDisabledDeferredEntries: AgentDeferredEntry[] = [];
-
-  for (const triage of triageResults) {
-    bumpStatus(summary, triage.status);
-
-    const page = pageByUrl.get(triage.final_url) ?? pageByUrl.get(triage.url);
-    if (!page) continue;
-
-    if (triage.status === "extract_now") {
-      summary.extract_now += 1;
-      extractPages.push({ page, triage });
-    } else if (statusNeedsAgent(triage.status)) {
-      summary.agent_candidates += 1;
-      if (agentEnabled) {
-        agentQueue.push({ page, triage });
-      } else if (
-        sourcePolicy.requiresOfficialSource &&
-        shouldFallbackExtractOfficialNavigation(triage.final_url, triage.status)
-      ) {
-        options.log(
-          options.label,
-          `Agent disabled — intent-path fallback extract for ${triage.final_url} [${triage.status}]`,
-        );
-        extractPages.push({ page, triage });
-      } else if (sourcePolicy.requiresOfficialSource) {
-        summary.skipped += 1;
-        agentDisabledDeferredEntries.push({
-          url: triage.final_url || page.url,
-          status: triage.status,
-          reason: "agent_disabled",
-        });
-        options.log(
-          options.label,
-          `Agent disabled — skip navigation-only official source ${triage.final_url} [${triage.status}]`,
-        );
-      } else {
-        options.log(
-          options.label,
-          `Agent disabled — fallback extract for ${triage.final_url} [${triage.status}]`,
-        );
-        extractPages.push({ page, triage });
-      }
-    } else {
-      summary.skipped += 1;
-      options.log(
-        options.label,
-        `Skip ${triage.final_url} [${triage.status}]: ${triage.reasoning.slice(0, 80)}`,
-      );
-    }
-  }
-
-  if (extractPages.length > 0) {
-    options.log(
-      options.label,
-      `Direct extraction on ${extractPages.length} pages (parallel, concurrency=${config.extractionConcurrency})...`,
-    );
-    const extracted = await extractionQueue.runAll(
-      extractPages,
-      async ({ page }) => {
-        try {
-          return await extractFromPage(options.spec, page, {
-            focusFields: options.focusFields,
-            memory: options.memory,
-          });
-        } catch (error) {
-          const msg = `Extraction failed for ${page.final_url || page.url}: ${
-            error instanceof Error ? error.message : String(error)
-          }`;
-          options.errors.push(msg);
-          return [] as ExtractedRecord[];
-        }
-      },
-      ({ page }) => [getDomain(page.final_url || page.url)],
-    );
-    for (const batch of extracted) {
-      for (const record of batch) {
-        records.push(record);
-        const pk = getPrimaryKeyValue(record, options.spec);
-        if (pk) knownKeys.add(pk);
-      }
-    }
-    summary.records_from_extract = records.length;
-  }
-
-  const agentBudget = agentEnabled ? config.maxAgentRunsPerPhase : 0;
-  const toRun = agentQueue.slice(0, agentBudget);
-  const deferredEntries: AgentDeferredEntry[] = [
-    ...agentDisabledDeferredEntries,
-    ...agentQueue
-      .slice(agentBudget)
-      .map(({ page, triage }) => ({
-        url: triage.final_url || page.url,
-        status: triage.status,
-        reason: "agent_budget" as const,
-      })),
-  ];
-
-  if (deferredEntries.length > 0) {
-    options.log(
-      options.label,
-      `Agent capability: running ${toRun.length}/${agentQueue.length} (${deferredEntries.length} deferred)`,
-    );
-  }
-
-  summary.agent_dispatched = toRun.length;
-  summary.agent_deferred = deferredEntries.length;
-
-  if (toRun.length > 0) {
-    options.log(
-      options.label,
-      `Tinyfish Agent on ${toRun.length} pages (async queue + poll, queue=${config.agentQueueConcurrency}, poll=${config.agentPollConcurrency})...`,
-    );
-
-    const agentGoalQueue = createAgentQueue();
-
-    const jobsWithGoals = await agentGoalQueue.runAll(
-      toRun,
-      async ({ page, triage }) => {
-        const pageUrl = triage.final_url || page.url;
-        try {
-          const agentGoal = await generateAgentGoal({
-            userPrompt: options.userPrompt,
-            spec: options.spec,
-            triage,
-            focusFields: options.focusFields,
-            memory: options.memory,
-          });
-          return { page, triage, pageUrl, goal: agentGoal.goal, goalError: null as string | null };
-        } catch (error) {
-          const msg = error instanceof Error ? error.message : String(error);
-          options.errors.push(`Agent goal failed for ${pageUrl}: ${msg}`);
-          return { page, triage, pageUrl, goal: "", goalError: msg };
-        }
-      },
-      ({ page }) => [getDomain(page.final_url || page.url)],
-    );
-
-    const queueJobs: { url: string; goal: string }[] = [];
-    const queueJobIndices: number[] = [];
-
-    for (let index = 0; index < jobsWithGoals.length; index++) {
-      const job = jobsWithGoals[index]!;
-      if (job.goalError) {
-        summary.agent_failed += 1;
-        agentRuns.push({
-          url: job.pageUrl,
-          status: job.triage.status,
-          run_id: null,
-          agent_status: "FAILED",
-          goal: "",
-          records_extracted: 0,
-          error: job.goalError,
-        });
-        continue;
-      }
-      queueJobs.push({ url: job.pageUrl, goal: job.goal });
-      queueJobIndices.push(index);
-    }
-
-    const agentRunResults = await runTinyfishAgentsBatch(queueJobs, {
-      pollTimeoutMs: options.agentPollTimeoutMs,
-    });
-
-    const jobsToExtract = queueJobIndices.map((jobIndex, batchIndex) => ({
-      job: jobsWithGoals[jobIndex]!,
-      run: agentRunResults[batchIndex]!,
-    }));
-
-    await extractionQueue.runAll(
-      jobsToExtract,
-      async ({ job, run }) => {
-        const pageUrl = job.pageUrl;
-
-        if (run.error || !run.result) {
-          summary.agent_failed += 1;
-          agentRuns.push({
-            url: pageUrl,
-            status: job.triage.status,
-            run_id: run.run_id,
-            agent_status: run.status,
-            goal: job.goal,
-            records_extracted: 0,
-            error: run.error ?? "No result returned",
-          });
-          options.log(
-            options.label,
-            `WARN Agent failed ${pageUrl}: ${run.error ?? "no result"}`,
-          );
-          return;
-        }
-
-        try {
-          const agentRecords = await extractFromAgentResult({
-            spec: options.spec,
-            pageUrl,
-            agentResult: run.result,
-            focusFields: options.focusFields,
-            memory: options.memory,
-          });
-
-          summary.agent_succeeded += 1;
-          for (const record of agentRecords) {
-            records.push(record);
-            const pk = getPrimaryKeyValue(record, options.spec);
-            if (pk) knownKeys.add(pk);
-          }
-          summary.records_from_agent += agentRecords.length;
-
-          agentRuns.push({
-            url: pageUrl,
-            status: job.triage.status,
-            run_id: run.run_id,
-            agent_status: run.status,
-            goal: job.goal,
-            records_extracted: agentRecords.length,
-          });
-
-          options.log(
-            options.label,
-            `Agent OK ${pageUrl} → ${agentRecords.length} records`,
-          );
-        } catch (error) {
-          summary.agent_failed += 1;
-          const msg = error instanceof Error ? error.message : String(error);
-          options.errors.push(`Agent extract failed for ${pageUrl}: ${msg}`);
-          agentRuns.push({
-            url: pageUrl,
-            status: job.triage.status,
-            run_id: run.run_id,
-            agent_status: run.status,
-            goal: job.goal,
-            records_extracted: 0,
-            error: msg,
-          });
-        }
-      },
-      ({ job }) => [getDomain(job.pageUrl)],
-    );
-  }
+  const deferredEntries = await runAgentPhase({
+    label: options.label,
+    userPrompt: options.userPrompt,
+    spec: options.spec,
+    agentQueue,
+    agentEnabled,
+    focusFields: options.focusFields,
+    memory: options.memory,
+    records,
+    knownKeys,
+    agentRuns,
+    summary,
+    errors: options.errors,
+    log: options.log,
+  });
 
   if (agentRuns.length > 0) {
     await saveJson(
@@ -467,6 +665,7 @@ export async function processFetchedPages(options: {
   return {
     records,
     triageResults,
+    sourceOutcomes,
     agentRuns,
     agentDeferred: deferredEntries,
     summary,

--- a/backend/BigSet_Data_Collection_Agent/src/orchestrator/process-pages.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/orchestrator/process-pages.ts
@@ -71,6 +71,7 @@ export async function processFetchedPages(options: {
   knownEntityKeys?: string[];
   enableTriage?: boolean;
   enableTinyfishAgent?: boolean;
+  agentPollTimeoutMs?: number;
   memory?: WorkflowMemory;
   log: (stage: string, message: string) => void;
 }): Promise<ProcessPagesResult> {
@@ -319,7 +320,9 @@ export async function processFetchedPages(options: {
       queueJobIndices.push(index);
     }
 
-    const agentRunResults = await runTinyfishAgentsBatch(queueJobs);
+    const agentRunResults = await runTinyfishAgentsBatch(queueJobs, {
+      pollTimeoutMs: options.agentPollTimeoutMs,
+    });
 
     const jobsToExtract = queueJobIndices.map((jobIndex, batchIndex) => ({
       job: jobsWithGoals[jobIndex]!,

--- a/backend/BigSet_Data_Collection_Agent/src/orchestrator/process-pages.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/orchestrator/process-pages.ts
@@ -31,6 +31,7 @@ import { join } from "node:path";
 export interface AgentDeferredEntry {
   url: string;
   status: SourceStatus;
+  reason: "agent_budget" | "agent_disabled";
 }
 
 export interface ProcessPagesResult {
@@ -216,6 +217,7 @@ export async function processFetchedPages(options: {
 
   const extractPages: { page: FetchedPage; triage: SourceTriageResult }[] = [];
   const agentQueue: { page: FetchedPage; triage: SourceTriageResult }[] = [];
+  const agentDisabledDeferredEntries: AgentDeferredEntry[] = [];
 
   for (const triage of triageResults) {
     bumpStatus(summary, triage.status);
@@ -241,6 +243,11 @@ export async function processFetchedPages(options: {
         extractPages.push({ page, triage });
       } else if (sourcePolicy.requiresOfficialSource) {
         summary.skipped += 1;
+        agentDisabledDeferredEntries.push({
+          url: triage.final_url || page.url,
+          status: triage.status,
+          reason: "agent_disabled",
+        });
         options.log(
           options.label,
           `Agent disabled — skip navigation-only official source ${triage.final_url} [${triage.status}]`,
@@ -296,17 +303,21 @@ export async function processFetchedPages(options: {
 
   const agentBudget = agentEnabled ? config.maxAgentRunsPerPhase : 0;
   const toRun = agentQueue.slice(0, agentBudget);
-  const deferredEntries: AgentDeferredEntry[] = agentQueue
-    .slice(agentBudget)
-    .map(({ page, triage }) => ({
-      url: triage.final_url || page.url,
-      status: triage.status,
-    }));
+  const deferredEntries: AgentDeferredEntry[] = [
+    ...agentDisabledDeferredEntries,
+    ...agentQueue
+      .slice(agentBudget)
+      .map(({ page, triage }) => ({
+        url: triage.final_url || page.url,
+        status: triage.status,
+        reason: "agent_budget" as const,
+      })),
+  ];
 
   if (deferredEntries.length > 0) {
     options.log(
       options.label,
-      `Agent budget: running ${toRun.length}/${agentQueue.length} (${deferredEntries.length} deferred)`,
+      `Agent capability: running ${toRun.length}/${agentQueue.length} (${deferredEntries.length} deferred)`,
     );
   }
 

--- a/backend/BigSet_Data_Collection_Agent/src/orchestrator/process-pages.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/orchestrator/process-pages.ts
@@ -2,6 +2,7 @@ import { generateAgentGoal } from "../agents/agent-goal.js";
 import { extractFromAgentResult } from "../agents/extract-from-agent.js";
 import { extractFromPage } from "../agents/extract.js";
 import { triagePage } from "../agents/source-triage.js";
+import { derivePromptSourcePolicy } from "../agents/source-policy.js";
 import { config } from "../config.js";
 import { runTinyfishAgentsBatch } from "../integrations/tinyfish-agent.js";
 import type { WorkflowMemory } from "../memory/index.js";
@@ -60,6 +61,34 @@ function bumpStatus(summary: TriageSummary, status: SourceStatus): void {
   summary.by_status[status] = (summary.by_status[status] ?? 0) + 1;
 }
 
+function shouldFallbackExtractOfficialNavigation(
+  url: string,
+  status: SourceStatus,
+): boolean {
+  if (
+    status !== "requires_navigation" &&
+    status !== "requires_detail_page_followup"
+  ) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(url);
+    const path = `${parsed.pathname}${parsed.search}`.toLowerCase();
+    if (
+      path === "/" ||
+      /(?:login|signin|signup|default\.aspx|home)(?:\/|$|\?)/.test(path)
+    ) {
+      return false;
+    }
+    return /(?:pricing|billing|docs|documentation|mcp|model-context-protocol|earnings|press-release|quarterly|results|news|blog)/.test(
+      path,
+    );
+  } catch {
+    return false;
+  }
+}
+
 export async function processFetchedPages(options: {
   label: string;
   userPrompt: string;
@@ -81,6 +110,7 @@ export async function processFetchedPages(options: {
   const records: ExtractedRecord[] = [];
   const agentRuns: AgentRunRecord[] = [];
   const knownKeys = new Set(options.knownEntityKeys ?? []);
+  const sourcePolicy = derivePromptSourcePolicy(options.userPrompt);
 
   const successfulPages = options.pages.filter(
     (page) => !page.error && page.text.trim().length > 0,
@@ -200,6 +230,21 @@ export async function processFetchedPages(options: {
       summary.agent_candidates += 1;
       if (agentEnabled) {
         agentQueue.push({ page, triage });
+      } else if (
+        sourcePolicy.requiresOfficialSource &&
+        shouldFallbackExtractOfficialNavigation(triage.final_url, triage.status)
+      ) {
+        options.log(
+          options.label,
+          `Agent disabled — intent-path fallback extract for ${triage.final_url} [${triage.status}]`,
+        );
+        extractPages.push({ page, triage });
+      } else if (sourcePolicy.requiresOfficialSource) {
+        summary.skipped += 1;
+        options.log(
+          options.label,
+          `Agent disabled — skip navigation-only official source ${triage.final_url} [${triage.status}]`,
+        );
       } else {
         options.log(
           options.label,

--- a/backend/BigSet_Data_Collection_Agent/src/orchestrator/process-pages.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/orchestrator/process-pages.ts
@@ -1,0 +1,415 @@
+import { generateAgentGoal } from "../agents/agent-goal.js";
+import { extractFromAgentResult } from "../agents/extract-from-agent.js";
+import { extractFromPage } from "../agents/extract.js";
+import { triagePage } from "../agents/source-triage.js";
+import { config } from "../config.js";
+import { runTinyfishAgentsBatch } from "../integrations/tinyfish-agent.js";
+import type { WorkflowMemory } from "../memory/index.js";
+import { getPrimaryKeyValue } from "../merge/records.js";
+import {
+  statusNeedsAgent,
+  type SourceStatus,
+} from "../models/source-status.js";
+import type {
+  AgentRunRecord,
+  DatasetSpec,
+  ExtractedRecord,
+  FetchedPage,
+  SourceTriageResult,
+  TriageSummary,
+} from "../models/schemas.js";
+import {
+  createAgentQueue,
+  createExtractionQueue,
+  createTriageQueue,
+} from "../queue/pools.js";
+import { saveJson, type RunPaths } from "../storage/run-store.js";
+import { getDomain } from "../utils/url.js";
+import { join } from "node:path";
+
+export interface AgentDeferredEntry {
+  url: string;
+  status: SourceStatus;
+}
+
+export interface ProcessPagesResult {
+  records: ExtractedRecord[];
+  triageResults: SourceTriageResult[];
+  agentRuns: AgentRunRecord[];
+  agentDeferred: AgentDeferredEntry[];
+  summary: TriageSummary;
+}
+
+function emptySummary(): TriageSummary {
+  return {
+    pages_triaged: 0,
+    by_status: {},
+    extract_now: 0,
+    agent_candidates: 0,
+    agent_dispatched: 0,
+    agent_deferred: 0,
+    agent_succeeded: 0,
+    agent_failed: 0,
+    skipped: 0,
+    records_from_extract: 0,
+    records_from_agent: 0,
+  };
+}
+
+function bumpStatus(summary: TriageSummary, status: SourceStatus): void {
+  summary.by_status[status] = (summary.by_status[status] ?? 0) + 1;
+}
+
+export async function processFetchedPages(options: {
+  label: string;
+  userPrompt: string;
+  spec: DatasetSpec;
+  pages: FetchedPage[];
+  paths: RunPaths;
+  errors: string[];
+  focusFields?: string[];
+  knownEntityKeys?: string[];
+  enableTriage?: boolean;
+  enableTinyfishAgent?: boolean;
+  memory?: WorkflowMemory;
+  log: (stage: string, message: string) => void;
+}): Promise<ProcessPagesResult> {
+  const triageEnabled = options.enableTriage ?? config.enableTriage;
+  const agentEnabled = options.enableTinyfishAgent ?? config.enableTinyfishAgent;
+  const summary = emptySummary();
+  const records: ExtractedRecord[] = [];
+  const agentRuns: AgentRunRecord[] = [];
+  const knownKeys = new Set(options.knownEntityKeys ?? []);
+
+  const successfulPages = options.pages.filter(
+    (page) => !page.error && page.text.trim().length > 0,
+  );
+
+  if (successfulPages.length === 0) {
+    return {
+      records: [],
+      triageResults: [],
+      agentRuns: [],
+      agentDeferred: [],
+      summary,
+    };
+  }
+
+  const extractionQueue = createExtractionQueue();
+
+  if (!triageEnabled) {
+    options.log(
+      options.label,
+      `Triage disabled — extracting all pages (parallel, concurrency=${config.extractionConcurrency})...`,
+    );
+    const extracted = await extractionQueue.runAll(
+      successfulPages,
+      async (page) => {
+        try {
+          return await extractFromPage(options.spec, page, {
+            focusFields: options.focusFields,
+            memory: options.memory,
+          });
+        } catch (error) {
+          const msg = `Extraction failed for ${page.final_url || page.url}: ${
+            error instanceof Error ? error.message : String(error)
+          }`;
+          options.errors.push(msg);
+          return [] as ExtractedRecord[];
+        }
+      },
+      (page) => [getDomain(page.final_url || page.url)],
+    );
+    const flat = extracted.flat();
+    summary.pages_triaged = successfulPages.length;
+    summary.extract_now = successfulPages.length;
+    summary.records_from_extract = flat.length;
+    return {
+      records: flat,
+      triageResults: [],
+      agentRuns: [],
+      agentDeferred: [],
+      summary,
+    };
+  }
+
+  const triageQueue = createTriageQueue();
+
+  options.log(
+    options.label,
+    `Triaging ${successfulPages.length} pages (parallel, concurrency=${config.triageConcurrency})...`,
+  );
+
+  const triageResults = await triageQueue.runAll(
+    successfulPages,
+    async (page) => {
+      try {
+        return await triagePage({
+          userPrompt: options.userPrompt,
+          spec: options.spec,
+          page,
+          knownEntityKeys: [...knownKeys],
+          memory: options.memory,
+        });
+      } catch (error) {
+        const pageUrl = page.final_url || page.url;
+        const msg = `Triage failed for ${pageUrl}: ${
+          error instanceof Error ? error.message : String(error)
+        }`;
+        options.errors.push(msg);
+        options.log(options.label, `WARN ${msg}`);
+        return {
+          url: page.url,
+          final_url: pageUrl,
+          title: page.title,
+          status: "extract_now" as const,
+          confidence: 0.3,
+          source_data_confidence: 0.35,
+          expected_yield: "partial" as const,
+          reasoning: "Triage failed; falling back to direct extraction.",
+        };
+      }
+    },
+    (page) => [getDomain(page.final_url || page.url)],
+  );
+
+  summary.pages_triaged = triageResults.length;
+  await saveJson(
+    join(options.paths.root, `triage_${options.label}.json`),
+    triageResults,
+  );
+
+  const pageByUrl = new Map(
+    successfulPages.map((page) => [page.final_url || page.url, page]),
+  );
+
+  const extractPages: { page: FetchedPage; triage: SourceTriageResult }[] = [];
+  const agentQueue: { page: FetchedPage; triage: SourceTriageResult }[] = [];
+
+  for (const triage of triageResults) {
+    bumpStatus(summary, triage.status);
+
+    const page = pageByUrl.get(triage.final_url) ?? pageByUrl.get(triage.url);
+    if (!page) continue;
+
+    if (triage.status === "extract_now") {
+      summary.extract_now += 1;
+      extractPages.push({ page, triage });
+    } else if (statusNeedsAgent(triage.status)) {
+      summary.agent_candidates += 1;
+      if (agentEnabled) {
+        agentQueue.push({ page, triage });
+      } else {
+        options.log(
+          options.label,
+          `Agent disabled — fallback extract for ${triage.final_url} [${triage.status}]`,
+        );
+        extractPages.push({ page, triage });
+      }
+    } else {
+      summary.skipped += 1;
+      options.log(
+        options.label,
+        `Skip ${triage.final_url} [${triage.status}]: ${triage.reasoning.slice(0, 80)}`,
+      );
+    }
+  }
+
+  if (extractPages.length > 0) {
+    options.log(
+      options.label,
+      `Direct extraction on ${extractPages.length} pages (parallel, concurrency=${config.extractionConcurrency})...`,
+    );
+    const extracted = await extractionQueue.runAll(
+      extractPages,
+      async ({ page }) => {
+        try {
+          return await extractFromPage(options.spec, page, {
+            focusFields: options.focusFields,
+            memory: options.memory,
+          });
+        } catch (error) {
+          const msg = `Extraction failed for ${page.final_url || page.url}: ${
+            error instanceof Error ? error.message : String(error)
+          }`;
+          options.errors.push(msg);
+          return [] as ExtractedRecord[];
+        }
+      },
+      ({ page }) => [getDomain(page.final_url || page.url)],
+    );
+    for (const batch of extracted) {
+      for (const record of batch) {
+        records.push(record);
+        const pk = getPrimaryKeyValue(record, options.spec);
+        if (pk) knownKeys.add(pk);
+      }
+    }
+    summary.records_from_extract = records.length;
+  }
+
+  const agentBudget = agentEnabled ? config.maxAgentRunsPerPhase : 0;
+  const toRun = agentQueue.slice(0, agentBudget);
+  const deferredEntries: AgentDeferredEntry[] = agentQueue
+    .slice(agentBudget)
+    .map(({ page, triage }) => ({
+      url: triage.final_url || page.url,
+      status: triage.status,
+    }));
+
+  if (deferredEntries.length > 0) {
+    options.log(
+      options.label,
+      `Agent budget: running ${toRun.length}/${agentQueue.length} (${deferredEntries.length} deferred)`,
+    );
+  }
+
+  summary.agent_dispatched = toRun.length;
+  summary.agent_deferred = deferredEntries.length;
+
+  if (toRun.length > 0) {
+    options.log(
+      options.label,
+      `Tinyfish Agent on ${toRun.length} pages (async queue + poll, queue=${config.agentQueueConcurrency}, poll=${config.agentPollConcurrency})...`,
+    );
+
+    const agentGoalQueue = createAgentQueue();
+
+    const jobsWithGoals = await agentGoalQueue.runAll(
+      toRun,
+      async ({ page, triage }) => {
+        const pageUrl = triage.final_url || page.url;
+        try {
+          const agentGoal = await generateAgentGoal({
+            userPrompt: options.userPrompt,
+            spec: options.spec,
+            triage,
+            focusFields: options.focusFields,
+            memory: options.memory,
+          });
+          return { page, triage, pageUrl, goal: agentGoal.goal, goalError: null as string | null };
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          options.errors.push(`Agent goal failed for ${pageUrl}: ${msg}`);
+          return { page, triage, pageUrl, goal: "", goalError: msg };
+        }
+      },
+      ({ page }) => [getDomain(page.final_url || page.url)],
+    );
+
+    const queueJobs: { url: string; goal: string }[] = [];
+    const queueJobIndices: number[] = [];
+
+    for (let index = 0; index < jobsWithGoals.length; index++) {
+      const job = jobsWithGoals[index]!;
+      if (job.goalError) {
+        summary.agent_failed += 1;
+        agentRuns.push({
+          url: job.pageUrl,
+          status: job.triage.status,
+          run_id: null,
+          agent_status: "FAILED",
+          goal: "",
+          records_extracted: 0,
+          error: job.goalError,
+        });
+        continue;
+      }
+      queueJobs.push({ url: job.pageUrl, goal: job.goal });
+      queueJobIndices.push(index);
+    }
+
+    const agentRunResults = await runTinyfishAgentsBatch(queueJobs);
+
+    const jobsToExtract = queueJobIndices.map((jobIndex, batchIndex) => ({
+      job: jobsWithGoals[jobIndex]!,
+      run: agentRunResults[batchIndex]!,
+    }));
+
+    await extractionQueue.runAll(
+      jobsToExtract,
+      async ({ job, run }) => {
+        const pageUrl = job.pageUrl;
+
+        if (run.error || !run.result) {
+          summary.agent_failed += 1;
+          agentRuns.push({
+            url: pageUrl,
+            status: job.triage.status,
+            run_id: run.run_id,
+            agent_status: run.status,
+            goal: job.goal,
+            records_extracted: 0,
+            error: run.error ?? "No result returned",
+          });
+          options.log(
+            options.label,
+            `WARN Agent failed ${pageUrl}: ${run.error ?? "no result"}`,
+          );
+          return;
+        }
+
+        try {
+          const agentRecords = await extractFromAgentResult({
+            spec: options.spec,
+            pageUrl,
+            agentResult: run.result,
+            focusFields: options.focusFields,
+            memory: options.memory,
+          });
+
+          summary.agent_succeeded += 1;
+          for (const record of agentRecords) {
+            records.push(record);
+            const pk = getPrimaryKeyValue(record, options.spec);
+            if (pk) knownKeys.add(pk);
+          }
+          summary.records_from_agent += agentRecords.length;
+
+          agentRuns.push({
+            url: pageUrl,
+            status: job.triage.status,
+            run_id: run.run_id,
+            agent_status: run.status,
+            goal: job.goal,
+            records_extracted: agentRecords.length,
+          });
+
+          options.log(
+            options.label,
+            `Agent OK ${pageUrl} → ${agentRecords.length} records`,
+          );
+        } catch (error) {
+          summary.agent_failed += 1;
+          const msg = error instanceof Error ? error.message : String(error);
+          options.errors.push(`Agent extract failed for ${pageUrl}: ${msg}`);
+          agentRuns.push({
+            url: pageUrl,
+            status: job.triage.status,
+            run_id: run.run_id,
+            agent_status: run.status,
+            goal: job.goal,
+            records_extracted: 0,
+            error: msg,
+          });
+        }
+      },
+      ({ job }) => [getDomain(job.pageUrl)],
+    );
+  }
+
+  if (agentRuns.length > 0) {
+    await saveJson(
+      join(options.paths.root, `agent_runs_${options.label}.json`),
+      agentRuns,
+    );
+  }
+
+  return {
+    records,
+    triageResults,
+    agentRuns,
+    agentDeferred: deferredEntries,
+    summary,
+  };
+}

--- a/backend/BigSet_Data_Collection_Agent/src/orchestrator/repair-loop.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/orchestrator/repair-loop.ts
@@ -41,6 +41,7 @@ export interface RepairLoopContext {
   allFailedUrls: string[];
   enableTriage: boolean;
   enableTinyfishAgent: boolean;
+  agentPollTimeoutMs?: number;
   targetRowCap: number;
   log: (stage: string, message: string) => void;
 }
@@ -162,6 +163,7 @@ export async function runRepairLoops(options: {
       knownEntityKeys: entityKeysFromRecords(ctx.spec, recordsBeforeLoop),
       enableTriage: ctx.enableTriage,
       enableTinyfishAgent: ctx.enableTinyfishAgent,
+      agentPollTimeoutMs: ctx.agentPollTimeoutMs,
       memory: ctx.memory,
       forceAgent: preferAgent,
       enableLinkFollow: config.enableRepairLinkFollow,

--- a/backend/BigSet_Data_Collection_Agent/src/orchestrator/repair-loop.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/orchestrator/repair-loop.ts
@@ -1,0 +1,280 @@
+import { join } from "node:path";
+import { generateRepairDiagnosis } from "../agents/repair-diagnosis.js";
+import { generateRepairQueries } from "../agents/repair-queries.js";
+import {
+  analyzeCoverage,
+  countFilledGaps,
+  type CoverageReport,
+} from "../coverage/analyze.js";
+import { config } from "../config.js";
+import type { RepairLoopReport } from "../models/schemas.js";
+import type { DatasetSpec, ExtractedRecord } from "../models/schemas.js";
+import {
+  recordCoverageGaps,
+  recordDiagnosis,
+  recordPhaseInMemory,
+  type WorkflowMemory,
+} from "../memory/index.js";
+import {
+  markSearchPagesUsed,
+  planRepairSearches,
+} from "../memory/search-pagination.js";
+import { mergeRepairIntoExisting } from "../merge/records.js";
+import type { SourcesReport } from "../models/quality.js";
+import { buildSourcesReport } from "../quality/index.js";
+import { saveJson, type RunPaths } from "../storage/run-store.js";
+import { normalizeUrl } from "../utils/url.js";
+import {
+  entityKeysFromRecords,
+  runAcquisitionPhase,
+  type AcquisitionResult,
+} from "./acquisition.js";
+
+export interface RepairLoopContext {
+  userPrompt: string;
+  spec: DatasetSpec;
+  paths: RunPaths;
+  errors: string[];
+  memory: WorkflowMemory;
+  fetchedUrlSet: Set<string>;
+  allSearchQueries: string[];
+  allFailedUrls: string[];
+  enableTriage: boolean;
+  enableTinyfishAgent: boolean;
+  targetRowCap: number;
+  log: (stage: string, message: string) => void;
+}
+
+export interface RepairLoopRunResult {
+  mergedRecords: ExtractedRecord[];
+  unkeyedRecords: ExtractedRecord[];
+  coverage: CoverageReport;
+  loops: RepairLoopReport[];
+  lastDiagnosis?: import("../memory/types.js").RepairDiagnosis;
+  repairAcquisitions: AcquisitionResult[];
+  sourcesReports: SourcesReport[];
+}
+
+export async function runRepairLoops(options: {
+  ctx: RepairLoopContext;
+  recordsBeforeRepair: ExtractedRecord[];
+  initialCoverage: CoverageReport;
+  pageIndexStart: number;
+}): Promise<RepairLoopRunResult> {
+  const { ctx } = options;
+  let mergedRecords = options.recordsBeforeRepair;
+  let unkeyedRecords: ExtractedRecord[] = [];
+  let coverage = options.initialCoverage;
+  let pageIndex = options.pageIndexStart;
+
+  const loops: RepairLoopReport[] = [];
+  const repairAcquisitions: AcquisitionResult[] = [];
+  const sourcesReports: SourcesReport[] = [];
+  let lastDiagnosis: import("../memory/types.js").RepairDiagnosis | undefined;
+
+  recordCoverageGaps(ctx.memory, coverage);
+
+  if (!coverage.should_repair) {
+    return {
+      mergedRecords,
+      unkeyedRecords,
+      coverage,
+      loops,
+      repairAcquisitions,
+      sourcesReports,
+    };
+  }
+
+  while (
+    coverage.should_repair &&
+    ctx.memory.repair_loop_count < config.maxRepairLoops
+  ) {
+    const loopIndex = ctx.memory.repair_loop_count + 1;
+    ctx.memory.repair_loop_count = loopIndex;
+
+    const recordsBeforeLoop = mergedRecords;
+    const partialBefore = coverage.partial_count;
+
+    ctx.log(
+      "repair",
+      `Loop ${loopIndex}/${config.maxRepairLoops} — missing: ${coverage.field_gaps.map((g) => g.column).join(", ")}`,
+    );
+
+    const diagnosis = await generateRepairDiagnosis({
+      userPrompt: ctx.userPrompt,
+      spec: ctx.spec,
+      coverage,
+      memory: ctx.memory,
+      repairLoop: loopIndex,
+      maxRepairLoops: config.maxRepairLoops,
+    });
+    lastDiagnosis = diagnosis;
+    recordDiagnosis(ctx.memory, loopIndex, diagnosis);
+
+    await saveJson(
+      join(ctx.paths.root, `repair_diagnosis_${loopIndex}.json`),
+      diagnosis,
+    );
+
+    const repairPlan = await generateRepairQueries({
+      userPrompt: ctx.userPrompt,
+      spec: ctx.spec,
+      coverage,
+      priorSearchQueries: ctx.allSearchQueries,
+      maxQueries: config.maxRepairQueries,
+      memory: ctx.memory,
+      diagnosis,
+      repairLoop: loopIndex,
+    });
+
+    const repairSearches = planRepairSearches(
+      ctx.memory,
+      repairPlan.repair_queries,
+    );
+    const paginatedCount = repairSearches.filter((plan) => plan.page > 0).length;
+
+    await saveJson(join(ctx.paths.root, `repair_queries_${loopIndex}.json`), {
+      ...repairPlan,
+      repair_searches: repairSearches,
+    });
+
+    ctx.log(
+      "repair",
+      `Loop ${loopIndex}: ${repairSearches.length} searches (${repairPlan.repair_queries.length} new, ${paginatedCount} paginated) — ${diagnosis.summary.slice(0, 100)}`,
+    );
+
+    const preferAgent =
+      diagnosis.prefer_tinyfish_agent && ctx.enableTinyfishAgent;
+
+    const acquisition = await runAcquisitionPhase({
+      label: `repair_${loopIndex}`,
+      userPrompt: ctx.userPrompt,
+      spec: ctx.spec,
+      queries: repairSearches.map((plan) => plan.query),
+      searches: repairSearches,
+      paths: ctx.paths,
+      errors: ctx.errors,
+      excludeUrls: ctx.fetchedUrlSet,
+      maxResultsPerQuery: config.maxRepairResultsPerQuery,
+      maxUrlsToFetch: config.maxRepairUrlsToFetch,
+      pageIndexStart: pageIndex,
+      focusFields: coverage.field_gaps.map((gap) => gap.column),
+      knownEntityKeys: entityKeysFromRecords(ctx.spec, recordsBeforeLoop),
+      enableTriage: ctx.enableTriage,
+      enableTinyfishAgent: ctx.enableTinyfishAgent,
+      memory: ctx.memory,
+      forceAgent: preferAgent,
+      enableLinkFollow: config.enableRepairLinkFollow,
+      log: ctx.log,
+    });
+
+    markSearchPagesUsed(
+      ctx.memory,
+      repairSearches,
+      `repair_${loopIndex}`,
+      loopIndex,
+    );
+
+    repairAcquisitions.push(acquisition);
+    pageIndex += acquisition.pagesFetched;
+
+    recordPhaseInMemory({
+      memory: ctx.memory,
+      spec: ctx.spec,
+      phase: `repair_${loopIndex}`,
+      repairLoop: loopIndex,
+      queries: repairSearches.map((plan) => plan.query),
+      candidates: acquisition.candidates,
+      records: acquisition.records,
+      failedUrls: acquisition.failedUrls,
+      agentRuns: acquisition.agentRuns,
+      triageResults: acquisition.triageResults,
+    });
+
+    for (const url of acquisition.fetchedUrls) {
+      ctx.fetchedUrlSet.add(normalizeUrl(url));
+    }
+    ctx.allSearchQueries.push(...repairPlan.repair_queries);
+    ctx.allFailedUrls.push(...acquisition.failedUrls);
+
+    sourcesReports.push(
+      buildSourcesReport({
+        phase: "repair",
+        fetchedPages: acquisition.fetchedPages,
+        fetchedUrls: acquisition.fetchedUrls,
+        triageResults: acquisition.triageResults,
+        agentRuns: acquisition.agentRuns,
+        agentDeferred: acquisition.agentDeferred,
+      }),
+    );
+
+    const mergeResult = mergeRepairIntoExisting(
+      ctx.spec,
+      recordsBeforeLoop,
+      acquisition.records,
+    );
+    mergedRecords = mergeResult.records.slice(0, ctx.targetRowCap);
+    unkeyedRecords = [...unkeyedRecords, ...mergeResult.unkeyed];
+
+    const coverageAfter = analyzeCoverage(ctx.spec, mergedRecords);
+    await saveJson(
+      join(ctx.paths.root, `coverage_repair_${loopIndex}.json`),
+      coverageAfter,
+    );
+
+    const fieldsFilled = countFilledGaps(
+      ctx.spec,
+      recordsBeforeLoop,
+      mergedRecords,
+      coverage.field_gaps.map((gap) => gap.column),
+    );
+
+    loops.push({
+      loop_index: loopIndex,
+      diagnosis_summary: diagnosis.summary,
+      repair_queries: repairPlan.repair_queries,
+      rationale: repairPlan.rationale,
+      missing_fields: coverage.field_gaps.map((gap) => gap.column),
+      records_before: recordsBeforeLoop.length,
+      records_after: mergedRecords.length,
+      fields_filled: fieldsFilled,
+      partial_count_before: partialBefore,
+      partial_count_after: coverageAfter.partial_count,
+      stats: {
+        search_queries_executed: repairSearches.length,
+        search_pages_paginated: paginatedCount,
+        search_results_collected: acquisition.candidates.length,
+        unique_urls_selected: acquisition.fetchedUrls.length,
+        pages_fetched: acquisition.pagesFetched,
+        pages_failed: acquisition.failedUrls.length,
+        raw_records_extracted: acquisition.records.length,
+        triage: acquisition.triage,
+      },
+    });
+
+    ctx.log(
+      "repair",
+      `Loop ${loopIndex} done — ${mergedRecords.length} records, partial ${partialBefore} → ${coverageAfter.partial_count}`,
+    );
+
+    coverage = coverageAfter;
+    recordCoverageGaps(ctx.memory, coverage);
+  }
+
+  if (coverage.should_repair && ctx.memory.repair_loop_count >= config.maxRepairLoops) {
+    ctx.log(
+      "repair",
+      `Stopped after ${config.maxRepairLoops} repair loops (gaps remain)`,
+    );
+  }
+
+  return {
+    mergedRecords,
+    unkeyedRecords,
+    coverage,
+    loops,
+    lastDiagnosis,
+    repairAcquisitions,
+    sourcesReports,
+  };
+}

--- a/backend/BigSet_Data_Collection_Agent/src/quality/build-report.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/quality/build-report.ts
@@ -1,0 +1,238 @@
+import type {
+  QualityBucket,
+  QualityReport,
+  SourceOutcome,
+  SourcesReport,
+} from "../models/quality.js";
+import type {
+  AgentRunRecord,
+  DatasetSpec,
+  ExtractedRecord,
+  FetchedPage,
+  SourceTriageResult,
+} from "../models/schemas.js";
+import { statusNeedsAgent } from "../models/source-status.js";
+import { normalizeUrl } from "../utils/url.js";
+import { scoreRecords, type ScoreRecordContext } from "./score-record.js";
+
+function bucket(recordIds: string[]): QualityBucket {
+  return { count: recordIds.length, record_ids: recordIds };
+}
+
+export function buildQualityReport(
+  spec: DatasetSpec,
+  records: ExtractedRecord[],
+  context: ScoreRecordContext,
+  unkeyedCount: number,
+): QualityReport {
+  const scored = scoreRecords(spec, records, context);
+
+  const completeIds: string[] = [];
+  const partialIds: string[] = [];
+  const lowConfidenceIds: string[] = [];
+  const reviewIds: string[] = [];
+
+  for (const quality of scored) {
+    if (quality.record_status === "complete") completeIds.push(quality.record_id);
+    if (quality.record_status === "partial") partialIds.push(quality.record_id);
+    if (quality.record_status === "low_confidence") {
+      lowConfidenceIds.push(quality.record_id);
+    }
+    if (quality.needs_review) reviewIds.push(quality.record_id);
+  }
+
+  return {
+    total_records: records.length,
+    unkeyed_records: unkeyedCount,
+    complete: bucket(completeIds),
+    partial: bucket(partialIds),
+    low_confidence: bucket(lowConfidenceIds),
+    needs_review: bucket(reviewIds),
+    records: scored,
+  };
+}
+
+export function triageByUrl(
+  triageResults: SourceTriageResult[],
+): Map<string, SourceTriageResult> {
+  const map = new Map<string, SourceTriageResult>();
+  for (const triage of triageResults) {
+    map.set(normalizeUrl(triage.final_url), triage);
+    map.set(normalizeUrl(triage.url), triage);
+  }
+  return map;
+}
+
+export function agentExtractedUrls(
+  agentRuns: AgentRunRecord[],
+): Set<string> {
+  return new Set(
+    agentRuns
+      .filter((run) => run.records_extracted > 0 && !run.error)
+      .map((run) => normalizeUrl(run.url)),
+  );
+}
+
+const SKIPPED_STATUSES = new Set([
+  "irrelevant",
+  "duplicate",
+  "blocked",
+  "low_value",
+]);
+
+export interface BuildSourcesOptions {
+  phase: "initial" | "repair";
+  fetchedPages: FetchedPage[];
+  fetchedUrls: string[];
+  triageResults: SourceTriageResult[];
+  agentRuns: AgentRunRecord[];
+  agentDeferred: { url: string; status: string }[];
+}
+
+export function buildSourcesReport(
+  options: BuildSourcesOptions,
+): SourcesReport {
+  const outcomes: SourceOutcome[] = [];
+  const triageMap = triageByUrl(options.triageResults);
+
+  for (const page of options.fetchedPages) {
+    const url = normalizeUrl(page.final_url || page.url);
+    const triage = triageMap.get(url);
+
+    if (page.error) {
+      outcomes.push({
+        url,
+        phase: options.phase,
+        outcome: "fetch_failed",
+        error: page.error,
+        triage_status: triage?.status,
+        triage_confidence: triage?.confidence,
+        source_data_confidence: triage?.source_data_confidence,
+        expected_yield: triage?.expected_yield,
+      });
+      continue;
+    }
+
+    if (triage && SKIPPED_STATUSES.has(triage.status)) {
+      outcomes.push({
+        url,
+        phase: options.phase,
+        outcome: "skipped",
+        triage_status: triage.status,
+        triage_confidence: triage.confidence,
+        source_data_confidence: triage.source_data_confidence,
+        expected_yield: triage.expected_yield,
+        error: triage.reasoning.slice(0, 200),
+      });
+    }
+  }
+
+  for (const deferred of options.agentDeferred) {
+    outcomes.push({
+      url: normalizeUrl(deferred.url),
+      phase: options.phase,
+      outcome: "agent_deferred",
+      triage_status: deferred.status,
+      error: "Exceeded MAX_AGENT_RUNS_PER_PHASE budget",
+    });
+  }
+
+  for (const run of options.agentRuns) {
+    const url = normalizeUrl(run.url);
+    if (run.error || run.agent_status === "FAILED" || run.agent_status === "TIMEOUT") {
+      outcomes.push({
+        url,
+        phase: options.phase,
+        outcome: "agent_failed",
+        triage_status: run.status,
+        error: run.error ?? run.agent_status,
+        records_extracted: run.records_extracted,
+      });
+    } else if (run.records_extracted === 0) {
+      outcomes.push({
+        url,
+        phase: options.phase,
+        outcome: "no_records",
+        triage_status: run.status,
+        records_extracted: 0,
+      });
+    } else {
+      outcomes.push({
+        url,
+        phase: options.phase,
+        outcome: "success",
+        triage_status: run.status,
+        records_extracted: run.records_extracted,
+      });
+    }
+  }
+
+  const outcomeUrls = new Set(outcomes.map((item) => item.url));
+  for (const triage of options.triageResults) {
+    const url = normalizeUrl(triage.final_url);
+    if (outcomeUrls.has(url)) continue;
+
+    if (triage.status === "extract_now") {
+      outcomes.push({
+        url,
+        phase: options.phase,
+        outcome: "success",
+        triage_status: triage.status,
+        triage_confidence: triage.confidence,
+        source_data_confidence: triage.source_data_confidence,
+        expected_yield: triage.expected_yield,
+      });
+    } else if (statusNeedsAgent(triage.status)) {
+      outcomes.push({
+        url,
+        phase: options.phase,
+        outcome: "no_records",
+        triage_status: triage.status,
+        triage_confidence: triage.confidence,
+        source_data_confidence: triage.source_data_confidence,
+        expected_yield: triage.expected_yield,
+        error: "Agent path did not yield records",
+      });
+    }
+  }
+
+  const byOutcome: Record<string, number> = {};
+  for (const item of outcomes) {
+    byOutcome[item.outcome] = (byOutcome[item.outcome] ?? 0) + 1;
+  }
+
+  const failed = outcomes.filter((item) =>
+    ["fetch_failed", "skipped", "agent_failed", "agent_deferred", "no_records"].includes(
+      item.outcome,
+    ),
+  );
+
+  return {
+    total: outcomes.length,
+    failed,
+    by_outcome: byOutcome,
+    outcomes,
+  };
+}
+
+export function mergeSourcesReports(
+  initial: SourcesReport,
+  repair: SourcesReport | null,
+): SourcesReport {
+  const outcomes = [...initial.outcomes, ...(repair?.outcomes ?? [])];
+  const byOutcome: Record<string, number> = {};
+  for (const item of outcomes) {
+    byOutcome[item.outcome] = (byOutcome[item.outcome] ?? 0) + 1;
+  }
+  const failed = outcomes.filter((item) =>
+    ["fetch_failed", "skipped", "agent_failed", "agent_deferred", "no_records"].includes(
+      item.outcome,
+    ),
+  );
+  return {
+    total: outcomes.length,
+    failed,
+    by_outcome: byOutcome,
+    outcomes,
+  };
+}

--- a/backend/BigSet_Data_Collection_Agent/src/quality/build-report.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/quality/build-report.ts
@@ -86,7 +86,11 @@ export interface BuildSourcesOptions {
   fetchedUrls: string[];
   triageResults: SourceTriageResult[];
   agentRuns: AgentRunRecord[];
-  agentDeferred: { url: string; status: string }[];
+  agentDeferred: {
+    url: string;
+    status: string;
+    reason?: "agent_budget" | "agent_disabled";
+  }[];
 }
 
 export function buildSourcesReport(
@@ -133,7 +137,9 @@ export function buildSourcesReport(
       phase: options.phase,
       outcome: "agent_deferred",
       triage_status: deferred.status,
-      error: "Exceeded MAX_AGENT_RUNS_PER_PHASE budget",
+      error: deferred.reason === "agent_disabled"
+        ? "TinyFish Agent disabled for browser/form/detail follow-up"
+        : "Exceeded MAX_AGENT_RUNS_PER_PHASE budget",
     });
   }
 

--- a/backend/BigSet_Data_Collection_Agent/src/quality/field-confidence.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/quality/field-confidence.ts
@@ -1,0 +1,72 @@
+import type { DatasetSpec, ExtractedRecord, SourceTriageResult } from "../models/schemas.js";
+import type { ScoreRecordContext } from "./score-record.js";
+
+function isEmpty(value: unknown): boolean {
+  return value === null || value === undefined || value === "";
+}
+
+/** Confidence for one populated field from its evidence URL and row-level signals. */
+export function confidenceForField(
+  fieldName: string,
+  record: ExtractedRecord,
+  context: ScoreRecordContext,
+): number {
+  const extraction = record.extraction_confidence ?? 0.85;
+  const evidenceForField = record.evidence.filter((item) => item.field === fieldName);
+
+  if (evidenceForField.length === 0) {
+    const fromAgent = record.source_urls.some((url) =>
+      context.agentExtractedUrls.has(url),
+    );
+    return Math.min(1, Math.max(0, extraction * (fromAgent ? 0.72 : 0.78)));
+  }
+
+  const urlScores = evidenceForField
+    .map((item) => {
+      const triage = context.triageByUrl.get(item.url);
+      const source = triage?.source_data_confidence ?? 0.65;
+      const routing = triage?.confidence ?? 0.7;
+      return source * 0.7 + routing * 0.15 + extraction * 0.15;
+    })
+    .filter((value) => Number.isFinite(value));
+
+  if (urlScores.length === 0) {
+    return Math.min(1, Math.max(0, extraction * 0.8));
+  }
+
+  return Math.min(
+    1,
+    Math.max(0, urlScores.reduce((sum, value) => sum + value, 0) / urlScores.length),
+  );
+}
+
+export function computeFieldConfidences(
+  spec: DatasetSpec,
+  record: ExtractedRecord,
+  context: ScoreRecordContext,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const col of spec.columns) {
+    if (isEmpty(record.row[col.name])) continue;
+    const score = confidenceForField(col.name, record, context);
+    out[col.name] = Math.round(score * 1000) / 1000;
+  }
+  return out;
+}
+
+export function aggregateRecordConfidence(
+  spec: DatasetSpec,
+  fieldConfidences: Record<string, number>,
+  requiredOnly = true,
+): number {
+  const columns = spec.columns.filter((col) =>
+    requiredOnly ? col.required : true,
+  );
+  const scores = columns
+    .map((col) => fieldConfidences[col.name])
+    .filter((value): value is number => value !== undefined);
+
+  if (scores.length === 0) return 0;
+  const mean = scores.reduce((sum, value) => sum + value, 0) / scores.length;
+  return Math.round(mean * 1000) / 1000;
+}

--- a/backend/BigSet_Data_Collection_Agent/src/quality/index.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/quality/index.ts
@@ -1,0 +1,8 @@
+export {
+  agentExtractedUrls,
+  buildQualityReport,
+  buildSourcesReport,
+  mergeSourcesReports,
+  triageByUrl,
+} from "./build-report.js";
+export { scoreRecord, scoreRecords, type ScoreRecordContext } from "./score-record.js";

--- a/backend/BigSet_Data_Collection_Agent/src/quality/score-record.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/quality/score-record.ts
@@ -1,0 +1,176 @@
+import { config } from "../config.js";
+import { canonicalRecordId } from "../merge/records.js";
+import type { RecordQuality, RecordStatus } from "../models/quality.js";
+import type { DatasetSpec, ExtractedRecord, SourceTriageResult } from "../models/schemas.js";
+import {
+  aggregateRecordConfidence,
+  computeFieldConfidences,
+} from "./field-confidence.js";
+
+export interface ScoreRecordContext {
+  triageByUrl: Map<string, SourceTriageResult>;
+  agentExtractedUrls: Set<string>;
+}
+
+function isEmpty(value: unknown): boolean {
+  return value === null || value === undefined || value === "";
+}
+
+function evidenceCoverage(
+  spec: DatasetSpec,
+  record: ExtractedRecord,
+): { ratio: number; fieldsWithoutEvidence: string[] } {
+  const nonNullFields = spec.columns.filter((col) => !isEmpty(record.row[col.name]));
+  if (nonNullFields.length === 0) {
+    return { ratio: 1, fieldsWithoutEvidence: [] };
+  }
+
+  const evidenced = new Set(record.evidence.map((item) => item.field));
+  const fieldsWithoutEvidence = nonNullFields
+    .filter((col) => !evidenced.has(col.name))
+    .map((col) => col.name);
+
+  const ratio =
+    (nonNullFields.length - fieldsWithoutEvidence.length) / nonNullFields.length;
+
+  return { ratio, fieldsWithoutEvidence };
+}
+
+function minSourceConfidence(
+  record: ExtractedRecord,
+  triageByUrl: Map<string, SourceTriageResult>,
+): number {
+  const scores = record.source_urls
+    .map((url) => triageByUrl.get(url)?.source_data_confidence)
+    .filter((value): value is number => value !== undefined);
+
+  if (scores.length === 0) return 0.65;
+  return Math.min(...scores);
+}
+
+export function scoreRecord(
+  spec: DatasetSpec,
+  record: ExtractedRecord,
+  context: ScoreRecordContext,
+  recordId: string,
+): RecordQuality {
+  const requiredColumns = spec.columns.filter((col) => col.required);
+  const optionalColumns = spec.columns.filter((col) => !col.required);
+
+  const missingRequired = requiredColumns
+    .filter((col) => isEmpty(record.row[col.name]))
+    .map((col) => col.name);
+  const missingOptional = optionalColumns
+    .filter((col) => isEmpty(record.row[col.name]))
+    .map((col) => col.name);
+
+  const filledRequired =
+    requiredColumns.length > 0
+      ? requiredColumns.length - missingRequired.length
+      : spec.columns.length;
+  const completenessPct =
+    requiredColumns.length > 0
+      ? filledRequired / requiredColumns.length
+      : spec.columns.filter((col) => !isEmpty(record.row[col.name])).length /
+          Math.max(spec.columns.length, 1);
+
+  const { ratio: evidenceRatio, fieldsWithoutEvidence } = evidenceCoverage(
+    spec,
+    record,
+  );
+  const sourceConfidence = minSourceConfidence(record, context.triageByUrl);
+  const extractionConfidence = record.extraction_confidence ?? 0.85;
+  const fieldConfidences = computeFieldConfidences(spec, record, context);
+
+  const requiredFieldConfidence = aggregateRecordConfidence(
+    spec,
+    fieldConfidences,
+    true,
+  );
+  const legacyBlend = Math.min(
+    1,
+    Math.max(
+      0,
+      completenessPct * 0.35 +
+        sourceConfidence * 0.25 +
+        extractionConfidence * 0.25 +
+        evidenceRatio * 0.15,
+    ),
+  );
+  const confidenceScore =
+    requiredColumns.length > 0 && Object.keys(fieldConfidences).length > 0
+      ? requiredFieldConfidence
+      : legacyBlend;
+
+  const reviewReasons: string[] = [];
+  if (missingRequired.length > 0) {
+    reviewReasons.push(
+      `missing required fields: ${missingRequired.join(", ")}`,
+    );
+  }
+  if (fieldsWithoutEvidence.length > 0) {
+    reviewReasons.push(
+      `fields without evidence: ${fieldsWithoutEvidence.join(", ")}`,
+    );
+  }
+  if (sourceConfidence < config.qualitySourceConfidenceThreshold) {
+    reviewReasons.push(
+      `low source data confidence (${sourceConfidence.toFixed(2)})`,
+    );
+  }
+  if (extractionConfidence < config.qualityExtractionConfidenceThreshold) {
+    reviewReasons.push(
+      `low extraction confidence (${extractionConfidence.toFixed(2)})`,
+    );
+  }
+
+  const fromAgent = record.source_urls.some((url) =>
+    context.agentExtractedUrls.has(url),
+  );
+  if (fromAgent && extractionConfidence < 0.8) {
+    reviewReasons.push("browser agent extraction — verify manually");
+  }
+
+  let recordStatus: RecordStatus;
+  if (missingRequired.length > 0) {
+    recordStatus = "partial";
+  } else if (
+    confidenceScore < config.qualityLowConfidenceThreshold ||
+    fieldsWithoutEvidence.length > 0
+  ) {
+    recordStatus = "low_confidence";
+  } else {
+    recordStatus = "complete";
+  }
+
+  const needsReview =
+    recordStatus === "partial" ||
+    recordStatus === "low_confidence" ||
+    confidenceScore < config.qualityReviewThreshold;
+
+  return {
+    record_id: recordId,
+    record_status: recordStatus,
+    needs_review: needsReview,
+    completeness_pct: Math.round(completenessPct * 1000) / 1000,
+    confidence_score: Math.round(confidenceScore * 1000) / 1000,
+    field_confidences: fieldConfidences,
+    missing_required_fields: missingRequired,
+    missing_optional_fields: missingOptional,
+    fields_without_evidence: fieldsWithoutEvidence,
+    review_reasons: reviewReasons,
+  };
+}
+
+export function scoreRecords(
+  spec: DatasetSpec,
+  records: ExtractedRecord[],
+  context: ScoreRecordContext,
+): RecordQuality[] {
+  return records.map((record) => {
+    const recordId =
+      canonicalRecordId(record, spec) ??
+      `unkeyed:${JSON.stringify(record.row).slice(0, 80)}`;
+    return scoreRecord(spec, record, context, recordId);
+  });
+}

--- a/backend/BigSet_Data_Collection_Agent/src/queue/domain-throttle.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/queue/domain-throttle.ts
@@ -1,0 +1,63 @@
+/**
+ * Limits concurrent work per domain (e.g. max 2 fetches on yelp.com at once).
+ */
+export class DomainThrottle {
+  private readonly active = new Map<string, number>();
+  private readonly waiters = new Map<string, Array<() => void>>();
+
+  constructor(private readonly maxPerDomain: number) {}
+
+  async acquire(domain: string): Promise<() => void> {
+    if (!domain) {
+      return () => undefined;
+    }
+
+    await new Promise<void>((resolve) => {
+      const tryAcquire = (): void => {
+        const count = this.active.get(domain) ?? 0;
+        if (count < this.maxPerDomain) {
+          this.active.set(domain, count + 1);
+          resolve();
+          return;
+        }
+        const queue = this.waiters.get(domain) ?? [];
+        queue.push(tryAcquire);
+        this.waiters.set(domain, queue);
+      };
+      tryAcquire();
+    });
+
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      const count = (this.active.get(domain) ?? 1) - 1;
+      if (count <= 0) {
+        this.active.delete(domain);
+      } else {
+        this.active.set(domain, count);
+      }
+      const queue = this.waiters.get(domain);
+      if (queue && queue.length > 0) {
+        const next = queue.shift()!;
+        next();
+      }
+    };
+  }
+
+  async withDomains<T>(domains: string[], fn: () => Promise<T>): Promise<T> {
+    const unique = [...new Set(domains.filter(Boolean))].sort();
+    const releases: Array<() => void> = [];
+
+    try {
+      for (const domain of unique) {
+        releases.push(await this.acquire(domain));
+      }
+      return await fn();
+    } finally {
+      for (const release of releases.reverse()) {
+        release();
+      }
+    }
+  }
+}

--- a/backend/BigSet_Data_Collection_Agent/src/queue/pools.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/queue/pools.ts
@@ -1,0 +1,73 @@
+import { config } from "../config.js";
+import { DomainThrottle } from "./domain-throttle.js";
+import { RateLimiter } from "./rate-limiter.js";
+import { TaskQueue } from "./task-queue.js";
+
+let sharedDomainThrottle: DomainThrottle | null = null;
+let openRouterLimiter: RateLimiter | null = null;
+
+export function getSharedDomainThrottle(): DomainThrottle {
+  if (!sharedDomainThrottle) {
+    sharedDomainThrottle = new DomainThrottle(config.maxConcurrentPerDomain);
+  }
+  return sharedDomainThrottle;
+}
+
+export function getOpenRouterLimiter(): RateLimiter {
+  if (!openRouterLimiter) {
+    openRouterLimiter = new RateLimiter(config.openRouterRpm, 60_000);
+  }
+  return openRouterLimiter;
+}
+
+const defaultRetry = {
+  maxRetries: config.maxRetries,
+  retryBaseDelayMs: config.retryBaseDelayMs,
+};
+
+export function createSearchQueue(): TaskQueue {
+  return new TaskQueue({
+    name: "search",
+    concurrency: config.searchConcurrency,
+    rateLimiter: new RateLimiter(config.tinyfishSearchRpm, 60_000),
+    ...defaultRetry,
+  });
+}
+
+export function createFetchQueue(): TaskQueue {
+  return new TaskQueue({
+    name: "fetch",
+    concurrency: config.fetchConcurrency,
+    rateLimiter: new RateLimiter(config.tinyfishFetchRpm, 60_000),
+    domainThrottle: getSharedDomainThrottle(),
+    ...defaultRetry,
+  });
+}
+
+export function createTriageQueue(): TaskQueue {
+  return new TaskQueue({
+    name: "triage",
+    concurrency: config.triageConcurrency,
+    rateLimiter: getOpenRouterLimiter(),
+    ...defaultRetry,
+  });
+}
+
+export function createExtractionQueue(): TaskQueue {
+  return new TaskQueue({
+    name: "extract",
+    concurrency: config.extractionConcurrency,
+    rateLimiter: getOpenRouterLimiter(),
+    ...defaultRetry,
+  });
+}
+
+export function createAgentQueue(): TaskQueue {
+  return new TaskQueue({
+    name: "agent",
+    concurrency: config.agentConcurrency,
+    rateLimiter: new RateLimiter(config.tinyfishAgentRpm, 60_000),
+    domainThrottle: getSharedDomainThrottle(),
+    ...defaultRetry,
+  });
+}

--- a/backend/BigSet_Data_Collection_Agent/src/queue/rate-limiter.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/queue/rate-limiter.ts
@@ -1,0 +1,41 @@
+import { sleep } from "./retry.js";
+
+/**
+ * Token-bucket style limiter: at most `maxRequests` starts per `intervalMs`.
+ */
+export class RateLimiter {
+  private tokens: number;
+  private lastRefillAt: number;
+
+  constructor(
+    private readonly maxRequests: number,
+    private readonly intervalMs: number,
+  ) {
+    this.tokens = maxRequests;
+    this.lastRefillAt = Date.now();
+  }
+
+  private refill(): void {
+    const now = Date.now();
+    const elapsed = now - this.lastRefillAt;
+    if (elapsed < this.intervalMs) return;
+
+    const periods = Math.floor(elapsed / this.intervalMs);
+    this.tokens = Math.min(
+      this.maxRequests,
+      this.tokens + periods * this.maxRequests,
+    );
+    this.lastRefillAt += periods * this.intervalMs;
+  }
+
+  async acquire(): Promise<void> {
+    while (true) {
+      this.refill();
+      if (this.tokens > 0) {
+        this.tokens -= 1;
+        return;
+      }
+      await sleep(Math.min(250, this.intervalMs));
+    }
+  }
+}

--- a/backend/BigSet_Data_Collection_Agent/src/queue/retry.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/queue/retry.ts
@@ -1,0 +1,55 @@
+export function isRetryableError(error: unknown): boolean {
+  if (error && typeof error === "object" && "status" in error) {
+    const status = (error as { status: number }).status;
+    if (status === 429 || status === 502 || status === 503 || status === 504) {
+      return true;
+    }
+  }
+
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : JSON.stringify(error);
+
+  return /429|502|503|504|timeout|timed out|ECONNRESET|ETIMEDOUT|rate limit|temporarily unavailable/i.test(
+    message,
+  );
+}
+
+export async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: {
+    maxRetries: number;
+    baseDelayMs: number;
+    label?: string;
+  },
+): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= options.maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (!isRetryableError(error) || attempt >= options.maxRetries) {
+        throw error;
+      }
+      const delay = options.baseDelayMs * 2 ** attempt;
+      const label = options.label ? ` (${options.label})` : "";
+      console.warn(
+        `[retry]${label} attempt ${attempt + 1}/${options.maxRetries} failed, retrying in ${delay}ms: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      await sleep(delay);
+    }
+  }
+
+  throw lastError;
+}

--- a/backend/BigSet_Data_Collection_Agent/src/queue/task-queue.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/queue/task-queue.ts
@@ -1,0 +1,79 @@
+import type { DomainThrottle } from "./domain-throttle.js";
+import type { RateLimiter } from "./rate-limiter.js";
+import { withRetry } from "./retry.js";
+
+export interface TaskQueueOptions {
+  name: string;
+  concurrency: number;
+  maxRetries?: number;
+  retryBaseDelayMs?: number;
+  rateLimiter?: RateLimiter;
+  domainThrottle?: DomainThrottle;
+}
+
+export class TaskQueue {
+  private readonly maxRetries: number;
+  private readonly retryBaseDelayMs: number;
+
+  constructor(private readonly options: TaskQueueOptions) {
+    this.maxRetries = options.maxRetries ?? 0;
+    this.retryBaseDelayMs = options.retryBaseDelayMs ?? 1000;
+  }
+
+  /**
+   * Run handler for each item with bounded concurrency, optional rate limit,
+   * per-domain throttle, and retries on transient failures.
+   */
+  async runAll<T, R>(
+    items: T[],
+    handler: (item: T, index: number) => Promise<R>,
+    getDomains?: (item: T) => string[],
+  ): Promise<R[]> {
+    if (items.length === 0) return [];
+
+    const results = new Array<R>(items.length);
+    let nextIndex = 0;
+
+    const runOne = async (index: number, item: T): Promise<void> => {
+      const execute = async (): Promise<R> => {
+        if (this.options.rateLimiter) {
+          await this.options.rateLimiter.acquire();
+        }
+
+        const runHandler = () => handler(item, index);
+
+        if (this.options.domainThrottle && getDomains) {
+          const domains = getDomains(item);
+          return this.options.domainThrottle.withDomains(domains, runHandler);
+        }
+
+        return runHandler();
+      };
+
+      const wrapped = () =>
+        withRetry(execute, {
+          maxRetries: this.maxRetries,
+          baseDelayMs: this.retryBaseDelayMs,
+          label: `${this.options.name}#${index}`,
+        });
+
+      results[index] = await wrapped();
+    };
+
+    async function worker(): Promise<void> {
+      while (true) {
+        const index = nextIndex;
+        nextIndex += 1;
+        if (index >= items.length) return;
+        await runOne(index, items[index]!);
+      }
+    }
+
+    const workers = Array.from(
+      { length: Math.min(this.options.concurrency, items.length) },
+      () => worker(),
+    );
+    await Promise.all(workers);
+    return results;
+  }
+}

--- a/backend/BigSet_Data_Collection_Agent/src/records/source-urls.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/records/source-urls.ts
@@ -1,0 +1,54 @@
+import type { DatasetSpec, ExtractedRecord } from "../models/schemas.js";
+
+function isHttpUrl(value: unknown): value is string {
+  return typeof value === "string" && /^https?:\/\//i.test(value.trim());
+}
+
+function isUrlLikeColumnName(name: string): boolean {
+  const lower = name.toLowerCase();
+  return lower === "url" || lower.endsWith("_url") || lower.includes("url");
+}
+
+export function deriveRecordSourceUrls(input: {
+  spec: DatasetSpec;
+  row: ExtractedRecord["row"];
+  evidence: ExtractedRecord["evidence"];
+  fallbackUrls?: string[];
+}): string[] {
+  const urls = new Set<string>();
+  for (const item of input.evidence) {
+    if (isHttpUrl(item.url)) {
+      urls.add(item.url.trim());
+    }
+  }
+
+  for (const column of input.spec.columns) {
+    if (!isUrlLikeColumnName(column.name)) continue;
+    const value = input.row[column.name];
+    if (isHttpUrl(value)) {
+      urls.add(value.trim());
+    }
+  }
+
+  for (const url of input.fallbackUrls ?? []) {
+    if (isHttpUrl(url)) {
+      urls.add(url.trim());
+    }
+  }
+
+  return [...urls];
+}
+
+export function scoreDocsUrlForOfficialSource(value: unknown): number {
+  if (!isHttpUrl(value)) return 0;
+  const normalized = value.toLowerCase();
+  let score = 1;
+  if (/^https:\/\/(?:docs|developers)\./.test(normalized)) score += 4;
+  if (/\/(?:docs|documentation|guides|api\/docs|agents|model-context-protocol|mcp)(?:\/|$|\?)/.test(normalized)) {
+    score += 3;
+  }
+  if (/\b(?:blog|news|course|academy|directory|skilljar)\b/.test(normalized)) {
+    score -= 4;
+  }
+  return score;
+}

--- a/backend/BigSet_Data_Collection_Agent/src/records/source-urls.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/records/source-urls.ts
@@ -1,10 +1,10 @@
 import type { DatasetSpec, ExtractedRecord } from "../models/schemas.js";
 
-function isHttpUrl(value: unknown): value is string {
+export function isHttpUrl(value: unknown): value is string {
   return typeof value === "string" && /^https?:\/\//i.test(value.trim());
 }
 
-function isUrlLikeColumnName(name: string): boolean {
+export function isUrlLikeColumnName(name: string): boolean {
   const lower = name.toLowerCase();
   return lower === "url" || lower.endsWith("_url") || lower.includes("url");
 }
@@ -49,6 +49,26 @@ export function scoreDocsUrlForOfficialSource(value: unknown): number {
   }
   if (/\b(?:blog|news|course|academy|directory|skilljar)\b/.test(normalized)) {
     score -= 4;
+  }
+  return score;
+}
+
+export function scoreUrlForCanonicalSource(value: unknown): number {
+  if (!isHttpUrl(value)) return 0;
+  const normalized = value.toLowerCase();
+  let score = scoreDocsUrlForOfficialSource(value);
+  if (/\b(?:pricing|billing)\b/.test(normalized)) score += 3;
+  if (/\b(?:earnings|press-release|financial-results|reports-.*quarter|quarter-results)\b/.test(normalized)) {
+    score += 4;
+  }
+  if (/\b(?:news|newsroom|investor|investors)\b/.test(normalized)) {
+    score += 2;
+  }
+  if (/\/(?:default|index)\.(?:aspx|html?)$/.test(normalized)) {
+    score -= 2;
+  }
+  if (/\/(?:financial-info|financial-reports|annual-reports)\/(?:default\.aspx)?$/.test(normalized)) {
+    score -= 2;
   }
   return score;
 }

--- a/backend/BigSet_Data_Collection_Agent/src/records/source-urls.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/records/source-urls.ts
@@ -6,7 +6,15 @@ export function isHttpUrl(value: unknown): value is string {
 
 export function isUrlLikeColumnName(name: string): boolean {
   const lower = name.toLowerCase();
-  return lower === "url" || lower.endsWith("_url") || lower.includes("url");
+  return (
+    lower === "url" ||
+    lower.endsWith("_url") ||
+    lower.includes("url") ||
+    lower === "website" ||
+    lower.endsWith("_website") ||
+    lower === "homepage" ||
+    lower.endsWith("_homepage")
+  );
 }
 
 export function deriveRecordSourceUrls(input: {

--- a/backend/BigSet_Data_Collection_Agent/src/storage/run-loader.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/storage/run-loader.ts
@@ -1,0 +1,90 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { workflowMemorySchema, type WorkflowMemory } from "../memory/types.js";
+import {
+  datasetSpecSchema,
+  extractedRecordSchema,
+  runReportSchema,
+  type DatasetSpec,
+  type ExtractedRecord,
+  type RunReport,
+} from "../models/schemas.js";
+
+export interface LoadedRun {
+  runId: string;
+  root: string;
+  spec: DatasetSpec;
+  report: RunReport;
+  records: ExtractedRecord[];
+  memory: WorkflowMemory | null;
+}
+
+export function runRoot(baseDir: string, runId: string): string {
+  return join(baseDir, runId);
+}
+
+export async function loadRunForRefresh(
+  baseDir: string,
+  runId: string,
+): Promise<LoadedRun> {
+  const root = runRoot(baseDir, runId);
+  const spec = datasetSpecSchema.parse(
+    JSON.parse(await readFile(join(root, "dataset_spec.json"), "utf8")),
+  );
+  const report = runReportSchema.parse(
+    JSON.parse(await readFile(join(root, "run_report.json"), "utf8")),
+  );
+
+  let memory: WorkflowMemory | null = null;
+  try {
+    memory = workflowMemorySchema.parse(
+      JSON.parse(await readFile(join(root, "workflow_memory.json"), "utf8")),
+    );
+  } catch {
+    memory = null;
+  }
+
+  const records = await loadRecordsFromEvidence(join(root, "evidence.jsonl"));
+  const fallback =
+    records.length > 0
+      ? records
+      : await loadRecordsFromEvidence(join(root, "evidence_full.jsonl"));
+
+  return {
+    runId,
+    root,
+    spec,
+    report,
+    records: fallback,
+    memory,
+  };
+}
+
+export async function loadRecordsFromEvidence(
+  path: string,
+): Promise<ExtractedRecord[]> {
+  try {
+    const raw = await readFile(path, "utf8");
+    const lines = raw.split("\n").filter((line) => line.trim().length > 0);
+    const records: ExtractedRecord[] = [];
+    for (const line of lines) {
+      const parsed = JSON.parse(line) as {
+        row: ExtractedRecord["row"];
+        evidence: ExtractedRecord["evidence"];
+        source_urls: string[];
+        extraction_confidence?: number;
+      };
+      records.push(
+        extractedRecordSchema.parse({
+          row: parsed.row,
+          evidence: parsed.evidence ?? [],
+          source_urls: parsed.source_urls ?? [],
+          extraction_confidence: parsed.extraction_confidence,
+        }),
+      );
+    }
+    return records;
+  } catch {
+    return [];
+  }
+}

--- a/backend/BigSet_Data_Collection_Agent/src/storage/run-store.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/storage/run-store.ts
@@ -1,0 +1,99 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type {
+  DatasetSpec,
+  FetchedPage,
+  RunReport,
+  SourceCandidate,
+} from "../models/schemas.js";
+
+export interface RunPaths {
+  runId: string;
+  root: string;
+  pagesDir: string;
+  specPath: string;
+  candidatesPath: string;
+  /** Final selective view (required fields only, ranked). */
+  resultsPath: string;
+  /** Full merged dataset before selective filter. */
+  resultsFullPath: string;
+  evidencePath: string;
+  evidenceFullPath: string;
+  /** Snapshot after initial search → fetch → extract → merge. */
+  initResultsPath: string;
+  initEvidencePath: string;
+  /** Snapshot after repair pass (written only when repair runs). */
+  repairResultsPath: string;
+  repairEvidencePath: string;
+  reportPath: string;
+}
+
+export async function createRunStore(
+  baseDir: string,
+  runId: string,
+): Promise<RunPaths> {
+  const root = join(baseDir, runId);
+  const pagesDir = join(root, "pages");
+  await mkdir(pagesDir, { recursive: true });
+
+  return {
+    runId,
+    root,
+    pagesDir,
+    specPath: join(root, "dataset_spec.json"),
+    candidatesPath: join(root, "source_candidates.json"),
+    resultsPath: join(root, "results.csv"),
+    resultsFullPath: join(root, "results_full.csv"),
+    evidencePath: join(root, "evidence.jsonl"),
+    evidenceFullPath: join(root, "evidence_full.jsonl"),
+    initResultsPath: join(root, "init_results.csv"),
+    initEvidencePath: join(root, "init_evidence.jsonl"),
+    repairResultsPath: join(root, "repair_results.csv"),
+    repairEvidencePath: join(root, "repair_evidence.jsonl"),
+    reportPath: join(root, "run_report.json"),
+  };
+}
+
+export async function saveJson(path: string, data: unknown): Promise<void> {
+  await writeFile(path, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+}
+
+export async function saveDatasetSpec(
+  paths: RunPaths,
+  spec: DatasetSpec,
+): Promise<void> {
+  await saveJson(paths.specPath, spec);
+}
+
+export async function saveSourceCandidates(
+  paths: RunPaths,
+  candidates: SourceCandidate[],
+): Promise<void> {
+  await saveJson(paths.candidatesPath, candidates);
+}
+
+export async function saveFetchedPage(
+  paths: RunPaths,
+  page: FetchedPage,
+  index: number,
+): Promise<void> {
+  const slug = String(index).padStart(3, "0");
+  const metaPath = join(paths.pagesDir, `${slug}.meta.json`);
+  const textPath = join(paths.pagesDir, `${slug}.md`);
+
+  await saveJson(metaPath, {
+    url: page.url,
+    final_url: page.final_url,
+    title: page.title,
+    description: page.description,
+    error: page.error,
+  });
+  await writeFile(textPath, page.text || "", "utf8");
+}
+
+export async function saveRunReport(
+  paths: RunPaths,
+  report: RunReport,
+): Promise<void> {
+  await saveJson(paths.reportPath, report);
+}

--- a/backend/BigSet_Data_Collection_Agent/src/utils/concurrency.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/utils/concurrency.ts
@@ -1,0 +1,26 @@
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (true) {
+      const index = nextIndex;
+      nextIndex += 1;
+      if (index >= items.length) return;
+      results[index] = await fn(items[index]!, index);
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    () => worker(),
+  );
+  await Promise.all(workers);
+  return results;
+}

--- a/backend/BigSet_Data_Collection_Agent/src/utils/url.ts
+++ b/backend/BigSet_Data_Collection_Agent/src/utils/url.ts
@@ -1,0 +1,20 @@
+export function normalizeUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.hash = "";
+    if (parsed.pathname.endsWith("/") && parsed.pathname.length > 1) {
+      parsed.pathname = parsed.pathname.slice(0, -1);
+    }
+    return parsed.toString();
+  } catch {
+    return url.trim();
+  }
+}
+
+export function getDomain(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -9,6 +9,7 @@ Fastify serves the backend API on :3501. Protected routes use Clerk JWT verifica
 Routes:
 - `GET /health` — public health check
 - `POST /infer-schema` — protected. Accepts `{ prompt: string }`, returns a `DatasetSchema`. Calls `inferSchema()` from the pipeline.
+- `POST /populate` — protected. Accepts a `DatasetContext` (datasetId, name, description, columns). Triggers the populate workflow which clears existing rows, then uses an AI agent to search the web and insert real data.
 
 To add a new protected route, register it inside the scoped plugin in `src/index.ts` that has `requireAuth` as a preHandler. Use `req.auth.userId` for the authenticated user — never trust user-supplied IDs in the body.
 
@@ -22,22 +23,30 @@ The pipeline is a pure function (`inferSchema(prompt) → DatasetSchema`). It is
 
 `src/mastra/` — wraps pipelines into Mastra workflows. Runs as a separate Docker service on :4111 with `mastra dev`, which provides a Studio UI for inspecting and testing workflows.
 
-- `src/mastra/index.ts` — registers workflows with the `Mastra` instance
+- `src/mastra/index.ts` — registers agents and workflows with the `Mastra` instance
 - `src/mastra/workflows/infer-schema.ts` — `inferSchemaWorkflow`, a single-step workflow wrapping `inferSchema()`
+- `src/mastra/workflows/populate.ts` — `populateWorkflow`, 3-step workflow: clear rows → build prompt → run populate agent
+- `src/mastra/agents/populate.ts` — `populateAgent`, an AI agent (Claude Sonnet 4.6 via OpenRouter) with 7 tools for database CRUD and web access
+- `src/mastra/tools/dataset-tools.ts` — 5 Convex-backed tools: `insert_row`, `list_rows`, `get_row`, `update_row`, `delete_row`
+- `src/mastra/tools/web-tools.ts` — 2 TinyFish API tools: `search_web`, `fetch_page`
+
+The populate agent uses `createStep(agent, { maxSteps: 80 })` to allow enough tool-call rounds for web research + row insertion.
+
+All tools return structured error messages (not thrown exceptions) so the agent can self-correct.
 
 Mastra uses `HOST` and `PORT` env vars for binding. In Docker, `HOST=0.0.0.0` is required.
 
 ## Convex
 
-Writes to Convex via `ConvexHttpClient` in `src/convex.ts`. Import `{ convex, api }` from `./convex.js` to call Convex mutations and queries. The `api` types are re-exported from the frontend's generated Convex code.
-
-The `tsconfig.json` includes `../frontend/convex` so TypeScript can resolve the generated types.
+Writes to Convex via `ConvexHttpClient` in `src/convex.ts`. Import `{ convex, api, internal }` from `./convex.js` to call Convex mutations and queries. Uses `anyApi` from `convex/server` as an untyped proxy — this avoids cross-project imports from the frontend's generated code, which don't work in Docker containers. Admin key is set via `setAdminAuth()` for internal mutations.
 
 ## Environment
 
 Required env vars (see `.env.example`):
 - `CONVEX_URL` — Convex instance URL
+- `CONVEX_SELF_HOSTED_ADMIN_KEY` — for system-level Convex writes (internal mutations)
 - `CLERK_SECRET_KEY`, `CLERK_PUBLISHABLE_KEY` — for JWT verification
 - `OPENROUTER_API_KEY` — for AI model calls
+- `TINYFISH_API_KEY` — for web search and fetch (populate agent). Get one at https://agent.tinyfish.ai/api-keys
 
 In Docker, these are interpolated from the root `.env` file via `docker-compose.dev.yml`.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -17,6 +17,10 @@ To add a new protected route, register it inside the scoped plugin in `src/index
 
 `src/pipeline/schema-inference.ts` — takes a natural language prompt and returns a structured `DatasetSchema` (Zod-validated, defined in `src/pipeline/types.ts`). Uses Claude Sonnet 4.6 via OpenRouter (`@openrouter/ai-sdk-provider` + Vercel AI SDK). Auto-retries once on validation failure by feeding the error back to the model.
 
+OpenRouter model defaults live in `src/openrouter-models.ts`: schema inference keeps Claude Sonnet 4.6; populate (`runPopulateRuntime`, Mastra `populateAgent`, structured row recovery, search prioritization) defaults to `google/gemini-3.1-flash-lite`. Override with `OPENROUTER_MODEL` or `OPENROUTER_POPULATE_MODEL`.
+
+`runPopulateRuntime` is a two-agent Mastra flow: (1) `populate-search-acquisition-agent` in `src/pipeline/populate-acquisition.ts` calls `inferSchema` via `resolvePopulateDataSpec` in `schema-inference.ts` for columns and seed `search_queries`, runs TinyFish search, and returns `scored_urls` (heuristic scores fill any gaps); (2) `populate-agent` fetches only prioritized URLs and inserts rows. Agent structured-output schemas live in `src/pipeline/types.ts`. Caps live in `populate-runtime-limits.ts` (`POPULATE_MAX_ROWS`, `POPULATE_MAX_SEARCH_CALLS`, `POPULATE_MAX_FETCH_CALLS` default 50). `POPULATE_MAX_FETCH_CALLS` only caps prioritized source URLs for populate — it is not exposed to agents as a fetch budget. Studio `populateWorkflow` mirrors the same acquire → populate steps.
+
 The pipeline is a pure function (`inferSchema(prompt) → DatasetSchema`). It is called by both Fastify (for the HTTP API) and Mastra (for workflow orchestration).
 
 ## Populate And Self-Healing

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -27,9 +27,11 @@ The pipeline is a pure function (`inferSchema(prompt) → DatasetSchema`). It is
 
 `src/pipeline/populate-self-healing-runner.ts` — shared route/CLI runner. HTTP populate uses a durable filesystem store and `ConvexPopulateDatasetRowWriter`; benchmark/dry-run paths can inject an in-memory store and skip row commits.
 
-`npm --silent run populate:self-heal -- --context context.json` — operator/cron-friendly dry run. It emits one JSON summary to stdout and does not persist recipe history or commit rows.
+`npm --silent run populate:self-heal -- --dataset-id <datasetId>` — operator/cron-friendly dry run. It loads live dataset context with system Convex auth, emits one JSON summary to stdout, and does not persist recipe history or commit rows.
 
-`npm --silent run populate:self-heal -- --context context.json --commit` — commits validated rows through the atomic Convex replace mutation. Requires `CONVEX_SELF_HOSTED_ADMIN_KEY`, `OPENROUTER_API_KEY`, and `TINYFISH_API_KEY`.
+`npm --silent run populate:self-heal -- --dataset-id <datasetId> --commit` — commits validated rows through the atomic Convex replace mutation. Requires `CONVEX_URL`, `CONVEX_SELF_HOSTED_ADMIN_KEY`, `OPENROUTER_API_KEY`, and `TINYFISH_API_KEY`.
+
+`npm --silent run populate:self-heal -- --context context.json` — dev harness dry run for a pasted `DatasetContext`. It uses an isolated in-memory recipe store; `--recipe-store-dir` is rejected unless `--commit` is set.
 
 ## Mastra (Workflow Orchestration)
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -9,7 +9,7 @@ Fastify serves the backend API on :3501. Protected routes use Clerk JWT verifica
 Routes:
 - `GET /health` — public health check
 - `POST /infer-schema` — protected. Accepts `{ prompt: string }`, returns a `DatasetSchema`. Calls `inferSchema()` from the pipeline.
-- `POST /populate` — protected. Accepts a `DatasetContext` (datasetId, name, description, columns). Triggers the populate workflow which clears existing rows, then uses an AI agent to search the web and insert real data.
+- `POST /populate` — protected. Accepts a `DatasetContext` (datasetId, name, description, columns). Runs the self-healing populate layer, validates the active/candidate recipe output, then atomically replaces rows only after validation passes.
 
 To add a new protected route, register it inside the scoped plugin in `src/index.ts` that has `requireAuth` as a preHandler. Use `req.auth.userId` for the authenticated user — never trust user-supplied IDs in the body.
 
@@ -19,13 +19,25 @@ To add a new protected route, register it inside the scoped plugin in `src/index
 
 The pipeline is a pure function (`inferSchema(prompt) → DatasetSchema`). It is called by both Fastify (for the HTTP API) and Mastra (for workflow orchestration).
 
+## Populate And Self-Healing
+
+`src/pipeline/populate-runtime.ts` — direct callable runtime around the Mastra populate agent. It uses in-memory row capture and returns rows, validation issues, usage, metrics, and debug artifacts without writing Convex rows.
+
+`src/pipeline/populate-self-healing.ts` — recipe runtime/service/store layer. It reruns the active recipe, generates the first recipe, repairs failed active recipes, validates candidate output, promotes healthy candidates, and rejects unsafe candidates.
+
+`src/pipeline/populate-self-healing-runner.ts` — shared route/CLI runner. HTTP populate uses a durable filesystem store and `ConvexPopulateDatasetRowWriter`; benchmark/dry-run paths can inject an in-memory store and skip row commits.
+
+`npm --silent run populate:self-heal -- --context context.json` — operator/cron-friendly dry run. It emits one JSON summary to stdout and does not persist recipe history or commit rows.
+
+`npm --silent run populate:self-heal -- --context context.json --commit` — commits validated rows through the atomic Convex replace mutation. Requires `CONVEX_SELF_HOSTED_ADMIN_KEY`, `OPENROUTER_API_KEY`, and `TINYFISH_API_KEY`.
+
 ## Mastra (Workflow Orchestration)
 
 `src/mastra/` — wraps pipelines into Mastra workflows. Runs as a separate Docker service on :4111 with `mastra dev`, which provides a Studio UI for inspecting and testing workflows.
 
 - `src/mastra/index.ts` — registers agents and workflows with the `Mastra` instance
 - `src/mastra/workflows/infer-schema.ts` — `inferSchemaWorkflow`, a single-step workflow wrapping `inferSchema()`
-- `src/mastra/workflows/populate.ts` — `populateWorkflow`, 3-step workflow: clear rows → build prompt → run populate agent
+- `src/mastra/workflows/populate.ts` — legacy Mastra workflow: clear rows → build prompt → run populate agent. HTTP `/populate` no longer uses this destructive pre-clear path.
 - `src/mastra/agents/populate.ts` — `populateAgent`, an AI agent (Claude Sonnet 4.6 via OpenRouter) with 7 tools for database CRUD and web access
 - `src/mastra/tools/dataset-tools.ts` — 5 Convex-backed tools: `insert_row`, `list_rows`, `get_row`, `update_row`, `delete_row`
 - `src/mastra/tools/web-tools.ts` — 2 TinyFish API tools: `search_web`, `fetch_page`

--- a/backend/docs/playwright-agent-integration.md
+++ b/backend/docs/playwright-agent-integration.md
@@ -1,0 +1,137 @@
+# Playwright agent integration guide (Edward)
+
+This guide explains how to plug a **Playwright-based browser agent** into Bigset's populate pipeline as a drop-in alternative to Tinyfish Agent for URLs that were previously visited by Tinyfish.
+
+## Contract (must match Tinyfish)
+
+Your agent must implement the same **job** and **result** types as Tinyfish:
+
+```typescript
+// backend/src/pipeline/populate-browser-agent.ts
+
+interface BrowserAgentJob {
+  url: string;
+  goal: string; // natural-language instructions (column hints + suggested action)
+}
+
+interface BrowserAgentRunResult {
+  run_id: string | null;
+  status: string;       // e.g. COMPLETED | FAILED | TIMEOUT
+  result: Record<string, unknown> | null;
+  error: string | null;
+}
+```
+
+Playwright receives **extra optional fields** on the job:
+
+```typescript
+interface PlaywrightAgentJob extends BrowserAgentJob {
+  emitted_process?: Record<string, unknown> | null; // from collection memory
+  prior_tinyfish_run_id?: string | null;
+  repair_loop?: number;
+}
+```
+
+The populate pipeline passes `emitted_process` when replaying a URL that already has a Tinyfish visit in memory. Your script should treat that object as the blueprint for navigation (selectors, clicks, waits) instead of re-discovering the page from scratch.
+
+After your agent returns, **`extractFromTinyfishAgentResult`** runs the same LLM extraction step used for Tinyfish—so `result` should contain whatever that extractor expects (typically page text, structured fields, or HTML snippets in a consistent JSON shape).
+
+## Where to plug in
+
+### Option A — Implement the dock file (recommended)
+
+Edit:
+
+`backend/src/pipeline/populate-playwright-agent.ts`
+
+Replace `runPlaywrightAgent` with your implementation:
+
+```typescript
+export async function runPlaywrightAgent(
+  job: PlaywrightAgentJob,
+  config: PopulatePlaywrightAgentConfig
+): Promise<BrowserAgentRunResult> {
+  const script = await compilePlaywrightScript(job.emitted_process);
+  const output = await runPlaywrightScript({ url: job.url, script, timeoutMs: config.pollTimeoutMs });
+  return {
+    run_id: output.id ?? null,
+    status: output.ok ? "COMPLETED" : "FAILED",
+    result: output.payload,
+    error: output.error ?? null,
+  };
+}
+```
+
+### Option B — Inject via test hooks / custom runner
+
+Pass a custom batch function when calling `runParallelPopulatePhase`:
+
+```typescript
+await runParallelPopulatePhase({
+  // ...
+  hooks: {
+    runPlaywrightAgentsBatch: myPlaywrightBatch,
+  },
+});
+```
+
+## When Playwright runs
+
+| `POPULATE_ENABLE_PLAYWRIGHT_AGENT` | Memory has Tinyfish `emitted_process` for URL | Behavior |
+|-----------------------------------|-----------------------------------------------|----------|
+| `false` (default) | any | Playwright **never** runs; pipeline unchanged. |
+| `true` | no | Tinyfish runs (if enabled); visit recorded to memory. |
+| `true` | yes | **Playwright** runs instead of Tinyfish for that URL. |
+
+First populate of a dataset: only Tinyfish (if triage requires agent). Second populate (with Playwright enabled): deferred URLs with saved process use your agent.
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `POPULATE_ENABLE_PLAYWRIGHT_AGENT` | `false` | Master switch. |
+| `POPULATE_MAX_PLAYWRIGHT_AGENT_RUNS` | `5` | Max Playwright jobs per populate run. |
+| `POPULATE_PLAYWRIGHT_AGENT_POLL_TIMEOUT_MS` | `480000` | Passed via config to your implementation. |
+| `POPULATE_PLAYWRIGHT_AGENT_POLL_INTERVAL_MS` | `3000` | Reserved for polling wrappers. |
+| `POPULATE_ENABLE_COLLECTION_MEMORY` | `true` | Must stay on to pass `emitted_process`. |
+| `POPULATE_COLLECTION_MEMORY_DIR` | `.bigset/collection-memory` | Where `{datasetId}.json` is stored. |
+
+## Changing inputs
+
+| What to change | Where |
+|----------------|-------|
+| Goal / column hints | `buildTinyfishAgentGoal` in `populate-tinyfish-agent.ts` (shared for both agents). |
+| When agent is required | `statusNeedsTinyfishAgent` in `populate-source-status.ts`. |
+| Agent priority / budget | `agentPriorityScore`, `maxPlaywrightAgentRuns` in `populate-parallel-config.ts`. |
+| Extra job fields | Extend `PlaywrightAgentJob` in `populate-browser-agent.ts` and map them in `populate-parallel.ts` (Playwright job builder). |
+| Extraction from agent output | `populate-extract-from-agent.ts`. |
+
+If you add fields to `PlaywrightAgentJob`, update the job builder in `populate-parallel.ts` (search for `Playwright agent budget`).
+
+## Reading memory manually
+
+```typescript
+import { loadCollectionMemory, latestTinyfishEmittedProcess } from "../src/pipeline/collection-memory/index.js";
+
+const memory = await loadCollectionMemory(".bigset/collection-memory", datasetId);
+const process = memory ? latestTinyfishEmittedProcess(memory, "https://example.com/page") : undefined;
+```
+
+Each `agent_visited_urls[]` entry includes:
+
+- `provider`: `"tinyfish"` | `"playwright"`
+- `goal`, `status`, `run_id`, `visited_at`
+- `emitted_process`: snapshot for replay
+- `triage_status`, `suggested_action`: context from triage LLM
+
+## Local dev checklist
+
+1. Run a populate with Tinyfish agent enabled → confirm `.bigset/collection-memory/{datasetId}.json` has `emitted_process` entries.
+2. Implement `runPlaywrightAgent`.
+3. Set `POPULATE_ENABLE_PLAYWRIGHT_AGENT=true`.
+4. Clear & Populate again on the same dataset → Playwright should receive `emitted_process` on matching URLs.
+
+## See also
+
+- [tinyfish-emitted-process-capture.md](./tinyfish-emitted-process-capture.md) — prompt guide for richer `emitted_process` payloads.
+- [populate-collection-architecture.md](./populate-collection-architecture.md) — full pipeline diagram.

--- a/backend/docs/populate-collection-architecture.md
+++ b/backend/docs/populate-collection-architecture.md
@@ -1,0 +1,130 @@
+# Populate collection architecture
+
+This document describes the **HTTP populate workflow** used by Bigset today (`POST /populate` → Mastra `populateWorkflow`). It is the parallel **triage + extract** pipeline in `backend/src/pipeline/`, not the vendored `BigSet_Data_Collection_Agent` CLI (which has its own repair loop and memory under `BigSet_Data_Collection_Agent/src/memory/`).
+
+## End-to-end data flow
+
+```mermaid
+flowchart TB
+  subgraph frontend [Frontend]
+    UI[Dataset page Clear and Populate]
+  end
+
+  subgraph backend [Backend Fastify]
+    HTTP[POST /populate]
+    WF[Mastra populateWorkflow]
+  end
+
+  subgraph convex [Convex]
+    DS[(datasets)]
+    DR[(datasetRows)]
+  end
+
+  subgraph phase1 [Step 1 clear-rows]
+    CLR[clearByDataset]
+  end
+
+  subgraph phase2 [Step 2 acquire-sources]
+    INF[inferSchema / dataSpec]
+    SRCH[TinyFish search]
+    SCORE[URL prioritization]
+  end
+
+  subgraph phase3 [Step 3 populate-dataset]
+    SHARD[Shard URLs across workers]
+    FETCH[TinyFish fetch per URL]
+    TRI[triageAndExtractPage LLM]
+    MERGE[mergePopulateCandidateRows]
+    AGENT{Tinyfish or Playwright agent?}
+    NORM[normalize row keys to dataset columns]
+    WRITE[replaceByDataset]
+    MEM[(collection memory JSON)]
+  end
+
+  UI --> HTTP --> WF
+  WF --> CLR --> DR
+  WF --> INF --> SRCH --> SCORE
+  SCORE --> SHARD --> FETCH --> TRI
+  TRI -->|rows| MERGE
+  TRI -->|requires browser| AGENT
+  AGENT --> MERGE
+  MERGE --> NORM --> WRITE --> DR
+  AGENT --> MEM
+  WF --> DS
+```
+
+## Workflow steps
+
+| Step | Module | What happens |
+|------|--------|----------------|
+| `clear-rows` | `mastra/workflows/populate.ts` | Deletes existing rows for the dataset. |
+| `acquire-sources` | `populate-acquisition.ts` | Resolves `dataSpec` (columns + search queries), runs TinyFish search, scores URLs, returns `prioritizedUrls`. |
+| `populate-dataset` | `populate-parallel.ts` | Fetches each prioritized URL, runs combined triage+extract LLM, optionally runs browser agents, merges/dedupes rows, normalizes keys, writes to Convex. |
+
+## Parallel worker shard
+
+For each prioritized URL:
+
+1. **Fetch** — `webTools.fetch` (TinyFish fetch API).
+2. **Triage + extract** — `triageAndExtractPage` (single LLM call) returns `PopulateSourceTriageResult` + candidate rows.
+3. **Agent deferral** — If triage status needs a browser agent (`populate-source-status.ts`), the URL is queued as an `AgentDeferredCandidate` with a **goal** string from `buildTinyfishAgentGoal`.
+
+After all shards finish:
+
+4. **Browser agents** (budget-limited):
+   - **Tinyfish** (default on): runs for candidates **without** a saved Tinyfish process in collection memory.
+   - **Playwright** (default off): runs for candidates **with** a saved `emitted_process` when `POPULATE_ENABLE_PLAYWRIGHT_AGENT=true`.
+5. **Extract from agent** — `extractFromTinyfishAgentResult` (same code path for Playwright `result` shape).
+6. **Merge** — `mergePopulateCandidateRows` by `primary_key` from extraction spec.
+7. **Key normalization** — `normalizePopulateRowCellsForDataset` maps snake_case LLM keys → dataset column display names.
+8. **Convex write** — `internal.datasetRows.replaceByDataset`.
+
+## Collection memory (central store)
+
+Path: `POPULATE_COLLECTION_MEMORY_DIR` / `{datasetId}.json` (default `.bigset/collection-memory/`).
+
+| Field | Purpose |
+|-------|---------|
+| `repair_loop` | Placeholder for a future quality repair pass (`idle` today). |
+| `agent_visited_urls` | Append-only log of Tinyfish/Playwright visits, including `emitted_process` for replay. |
+
+Loaded at the start of `populate-dataset` and saved after the parallel phase. **Does not change** triage, fetch, or merge logic unless Playwright replay is explicitly enabled.
+
+Implementation: `backend/src/pipeline/collection-memory/`.
+
+## Environment flags (populate)
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `POPULATE_ENABLE_COLLECTION_MEMORY` | `true` | Persist memory JSON per dataset. |
+| `POPULATE_COLLECTION_MEMORY_DIR` | `.bigset/collection-memory` | Memory directory. |
+| `POPULATE_ENABLE_TINYFISH_AGENT` | `true` | Run Tinyfish for agent-deferred URLs. |
+| `POPULATE_MAX_TINYFISH_AGENT_RUNS` | `5` | Cap per populate run. |
+| `POPULATE_ENABLE_PLAYWRIGHT_AGENT` | `false` | Use Playwright replay when memory has a prior Tinyfish process. |
+| `POPULATE_MAX_PLAYWRIGHT_AGENT_RUNS` | `5` | Cap per populate run. |
+| `POPULATE_URLS_PER_WORKER` | `5` | Shard size for parallel fetch/triage. |
+
+See also `backend/.env.example` and `populate-parallel-config.ts`.
+
+## Related code paths
+
+| Path | Role |
+|------|------|
+| `backend/src/index.ts` | HTTP entry, auth, starts workflow. |
+| `backend/src/mastra/workflows/populate.ts` | Workflow orchestration + memory load/save. |
+| `backend/src/pipeline/populate-parallel.ts` | Core parallel populate + agent dispatch. |
+| `backend/src/pipeline/populate-tinyfish-agent.ts` | Tinyfish Agent queue + poll. |
+| `backend/src/pipeline/populate-playwright-agent.ts` | **Dock** for Edward's Playwright agent (stub). |
+| `backend/src/pipeline/populate-normalize-dataset-keys.ts` | Convex row key alignment. |
+| `BigSet_Data_Collection_Agent/` | Standalone collection + repair loop (separate memory schema). |
+
+## Future: repair loop
+
+`repair_loop` in collection memory mirrors the collection agent's repair concept but is **not wired** into the populate workflow yet. When implemented, it should:
+
+1. Read coverage gaps from merged rows.
+2. Bump `repair_loop.current_loop`.
+3. Run additional acquisition/agent passes.
+4. Append diagnoses (similar to `BigSet_Data_Collection_Agent/src/orchestrator/repair-loop.ts`).
+
+Until then, `repair_loop.status` stays `idle`.

--- a/backend/docs/tinyfish-emitted-process-capture.md
+++ b/backend/docs/tinyfish-emitted-process-capture.md
@@ -1,0 +1,93 @@
+# Tinyfish emitted-process capture (guide prompt)
+
+Use this when configuring Tinyfish Agent goals or post-processing runs so collection memory stores a **replayable process** for Edward's Playwright agent.
+
+## Why
+
+Collection memory stores each Tinyfish visit under `agent_visited_urls[].emitted_process`. When `POPULATE_ENABLE_PLAYWRIGHT_AGENT=true`, the populate pipeline passes that object to Playwright as `job.emitted_process`.
+
+The normalizer (`extractEmittedProcessFromAgentResult`) looks for, in order:
+
+1. `result.emitted_process`
+2. `result.process`
+3. `result.steps` / `result.actions` / `result.navigation_trace`
+4. Otherwise the **entire** `result` object
+
+## Recommended goal suffix
+
+Append this block to agent goals built by `buildTinyfishAgentGoal` (or pass it in Tinyfish UI when testing):
+
+```text
+PROCESS CAPTURE (required for replay):
+When you finish, include a JSON field `emitted_process` in your final result with:
+- `version`: "1"
+- `start_url`: the URL you began from
+- `steps`: an ordered array of actions, each with:
+  - `kind`: one of "goto" | "click" | "fill" | "wait" | "scroll" | "extract"
+  - `selector`: stable CSS selector or aria role locator when applicable
+  - `value`: text filled or wait condition when applicable
+  - `note`: short human-readable reason for the step
+- `extracted_fields`: map of column name → value you believe were captured
+- `final_url`: URL after navigation
+
+Prefer stable selectors (data-testid, aria-label, role) over brittle XPath.
+Do not omit `emitted_process` even if extraction succeeded early.
+```
+
+## Example `result` shape
+
+```json
+{
+  "summary": "Extracted company profile from about page",
+  "emitted_process": {
+    "version": "1",
+    "start_url": "https://example.com",
+    "final_url": "https://example.com/about",
+    "steps": [
+      { "kind": "goto", "selector": null, "value": "https://example.com", "note": "Open homepage" },
+      { "kind": "click", "selector": "a[href='/about']", "note": "Open about page" },
+      { "kind": "extract", "selector": "main", "note": "Read main content" }
+    ],
+    "extracted_fields": {
+      "company_name": "Example Inc",
+      "official_website": "https://example.com"
+    }
+  },
+  "page_text": "..."
+}
+```
+
+## Playwright consumption (Edward)
+
+Your compiler should:
+
+1. Read `emitted_process.steps` in order.
+2. Map each `kind` to Playwright calls (`page.goto`, `locator.click`, etc.).
+3. Fall back to `goal` + `url` when a step is missing selectors.
+4. Return a `BrowserAgentRunResult` whose `result` includes at least the text/fields `extractFromTinyfishAgentResult` needs.
+
+## Verifying capture
+
+After populate:
+
+```bash
+cat .bigset/collection-memory/<datasetId>.json | jq '.agent_visited_urls[-1].emitted_process'
+```
+
+You should see a structured `steps` array, not an empty object.
+
+## Wiring into code (optional)
+
+To bake the suffix into every populate agent goal, extend `buildTinyfishAgentGoal` in `populate-tinyfish-agent.ts`:
+
+```typescript
+const PROCESS_CAPTURE_SUFFIX = `...`; // block above
+
+return `${baseGoal}\n\n${PROCESS_CAPTURE_SUFFIX}`;
+```
+
+Keep the suffix behind an env flag (e.g. `POPULATE_TINYFISH_CAPTURE_PROCESS=true`) if you want to A/B test token usage.
+
+## Relationship to repair loop
+
+When repair loop is implemented, pass `repair_loop: memory.repair_loop.current_loop` into agent goals so process snapshots are tagged by iteration. Playwright jobs already receive `repair_loop` on the extended job type.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,6 +12,7 @@
         "@fastify/cors": "^11.0.0",
         "@mastra/core": "^1.36.0",
         "@openrouter/ai-sdk-provider": "^2.9.0",
+        "@tiny-fish/sdk": "^0.0.8",
         "ai": "^6.0.0",
         "convex": "^1.39.1",
         "dotenv": "^16.4.0",
@@ -2542,6 +2543,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tiny-fish/sdk": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@tiny-fish/sdk/-/sdk-0.0.8.tgz",
+      "integrity": "sha512-GTIpIDcwYuCbtd1xcgf0JD81wbPWGY0mxiab9VepT1allNUfVvjWCKT1n8RypsrzXne39j5Ez3ILDBE4ZwlApQ==",
+      "dependencies": {
+        "p-retry": "^7.1.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@types/babel__traverse": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",
+    "test": "node --import tsx --test test/*.test.ts",
     "build": "tsc",
     "start": "node dist/index.js",
     "mastra:dev": "mastra dev"

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,8 @@
     "test": "node --import tsx --test test/*.test.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "mastra:dev": "mastra dev"
+    "mastra:dev": "mastra dev",
+    "populate:self-heal": "tsx src/pipeline/populate-self-healing-cli.ts"
   },
   "dependencies": {
     "@clerk/backend": "^3.4.11",

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "@fastify/cors": "^11.0.0",
     "@mastra/core": "^1.36.0",
     "@openrouter/ai-sdk-provider": "^2.9.0",
+    "@tiny-fish/sdk": "^0.0.8",
     "ai": "^6.0.0",
     "convex": "^1.39.1",
     "dotenv": "^16.4.0",

--- a/backend/prompts/schema-inference.txt
+++ b/backend/prompts/schema-inference.txt
@@ -4,33 +4,14 @@ Your job is to:
 
 1. Identify the universe of entities the user wants to collect. Each entity becomes one row in the dataset.
 2. Pick a clear primary key — the column whose values uniquely identify each row. This is usually a name, ID, or canonical URL. Exactly one column must have `is_primary_key: true`, and its `name` must equal `primary_key`. The primary key column must have `nullable: false` and `is_enumerable: true`.
-3. Choose useful columns. Each column captures one fact about the entity. Use snake_case names. Mark `is_enumerable: true` only on columns whose values can be used to list all rows (typically just the primary key, and occasionally one or two others when a source page lists them alongside the primary key).
-4. Set `retrieval_strategy`:
-   - `search_fetch` — the data lives on a static page or sitemap that can be fetched as HTML.
-   - `browser` — the source is a JavaScript-heavy SPA, requires scroll/click to reveal items, or paginates client-side.
-   - `hybrid` — unclear; the pipeline will try search_fetch first and fall back to browser.
-5. Set `source_hint` to a specific URL whenever possible (e.g. `https://www.ycombinator.com/companies?industry=Fintech`). Avoid vague descriptions.
-6. Write a `retrieval_hint` for each column describing where/how the value can be found later. Downstream agents will use this to fill the column for each row.
+3. Infer columns from the user prompt — include the facts they asked for as columns. Use snake_case names. Mark `is_enumerable: true` only on columns whose values can be used to list all rows (typically just the primary key, and occasionally one or two others when a source page lists them alongside the primary key).
+4. Write a short `description` for each column explaining what the column represents (not where to find the value on the web).
+5. Provide `search_queries`: diverse, non-overlapping web search strings to discover source pages for this dataset. Each query must be distinct and tailored to the user prompt and columns. Use `site:` operators when a domain is obvious.
+
+Do not set retrieval strategy or source URLs — search and fetch decisions happen later after results are available.
 
 Rules:
 
 - `dataset_name` must be snake_case.
 - All column `name` values must be snake_case and unique.
 - Prefer concrete column choices over speculative ones — better to omit a column than guess wildly.
-
-# @MMeteorL's comments/suggestions:
-# This may be too early in the agent workflow to suggest these without more
-# context. In the current agent system, the agent would first use Tinyfish
-# search to search for candidate urls and fetch those results for analysis
-# of what is the best way to retrieve.
-#
-# For the same reason, instead of source_hint, it may be helpful to generate
-# search_query_hint.
-#
-# Retrieval_hint is a great idea, however, because of the varied sources
-# that Tinyfish search would propose, this may not be the best fit. This
-# should be a decision left for downstream agent with more information.
-#
-# My recommendation is to produce: 'search_queries': generate [X number] of
-# search queries based on the user prompt and data spec. These search queries
-# should be differentiated from each other.

--- a/backend/src/convex.ts
+++ b/backend/src/convex.ts
@@ -1,4 +1,5 @@
 import { ConvexHttpClient } from "convex/browser";
+import { anyApi } from "convex/server";
 
 import { env } from "./env.js";
 
@@ -16,11 +17,12 @@ import { env } from "./env.js";
  *   ✗ NEVER use this to act "on behalf of a user". For user-initiated work,
  *     the frontend should call Convex directly with the user's Clerk JWT.
  *
- * If admin key is missing, this client can still call PUBLIC functions but
- * will fail closed on internal ones (which is the desired behavior — better
- * to error than to silently degrade).
+ * `anyApi` is an untyped proxy that resolves function references at runtime.
+ * Full types come from the frontend's generated code (included via tsconfig)
+ * and are available in the IDE, but the Docker container doesn't need them.
  */
-export { api, internal } from "../../frontend/convex/_generated/api.js";
+export const api = anyApi;
+export const internal = anyApi;
 
 export const convex = new ConvexHttpClient(env.CONVEX_URL);
 

--- a/backend/src/convex.ts
+++ b/backend/src/convex.ts
@@ -27,5 +27,7 @@ export const internal = anyApi;
 export const convex = new ConvexHttpClient(env.CONVEX_URL);
 
 if (env.CONVEX_ADMIN_KEY) {
-  convex.setAdminAuth(env.CONVEX_ADMIN_KEY);
+  (convex as unknown as {
+    setAdminAuth(adminKey: string): void;
+  }).setAdminAuth(env.CONVEX_ADMIN_KEY);
 }

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -24,4 +24,10 @@ export const env = {
   CLERK_PUBLISHABLE_KEY: process.env.CLERK_PUBLISHABLE_KEY,
 
   OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
+  TINYFISH_API_KEY: process.env.TINYFISH_API_KEY,
+
+  // Durable recipe manifests for the self-healing populate layer. In Docker
+  // dev this points at a named volume; locally it defaults under the repo.
+  POPULATE_RECIPE_STORE_DIR:
+    process.env.POPULATE_RECIPE_STORE_DIR || ".bigset/populate-recipes",
 };

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,15 +1,90 @@
+import Fastify from "fastify";
+import fastifyCors from "@fastify/cors";
+
 import { env } from "./env.js";
 import clerkAuthPlugin, { requireAuth } from "./clerk-auth.js";
-import { ConvexPopulateDatasetRowWriter } from "./pipeline/populate-convex-writer.js";
-import { convex, api } from "./convex.js";
-import { createBigSetServer } from "./server.js";
+import { inferSchema } from "./pipeline/schema-inference.js";
+import { datasetContextSchema } from "./pipeline/populate.js";
+import { populateWorkflow } from "./mastra/workflows/populate.js";
+import { convex, internal } from "./convex.js";
 
-const fastify = await createBigSetServer({
-  env,
-  authPlugin: clerkAuthPlugin,
-  authPreHandler: requireAuth,
-  getDatasetById: (datasetId) => convex.query(api.datasets.get, { id: datasetId }),
-  populateRowWriter: new ConvexPopulateDatasetRowWriter(),
+const fastify = Fastify({ logger: true });
+
+await fastify.register(fastifyCors, {
+  origin: env.CLIENT_ORIGIN,
+  methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+  allowedHeaders: ["Content-Type", "Authorization", "Cookie"],
+  credentials: true,
+  maxAge: 86400,
+});
+
+await fastify.register(clerkAuthPlugin);
+
+fastify.get("/health", async () => ({ status: "ok" }));
+
+await fastify.register(async (instance) => {
+  instance.addHook("preHandler", requireAuth);
+
+  instance.post("/infer-schema", async (req, reply) => {
+    const body = req.body as { prompt?: string };
+    if (!body?.prompt || typeof body.prompt !== "string" || !body.prompt.trim()) {
+      return reply.code(400).send({ error: "prompt is required" });
+    }
+
+    try {
+      const schema = await inferSchema(body.prompt.trim());
+      return schema;
+    } catch (err) {
+      req.log.error(err, "Schema inference failed");
+      return reply.code(502).send({ error: "Schema inference failed. Please try again." });
+    }
+  });
+
+  instance.post("/populate", async (req, reply) => {
+    const parsed = datasetContextSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.code(400).send({
+        error: "Invalid request",
+        details: parsed.error.flatten().fieldErrors,
+      });
+    }
+
+    try {
+      const dataset = await convex.query(internal.datasets.getForSystemPopulate, {
+        id: parsed.data.datasetId,
+      });
+      if (!dataset) {
+        return reply.code(404).send({ error: "Dataset not found" });
+      }
+      if (dataset.ownerId !== req.auth!.userId) {
+        return reply.code(403).send({ error: "Not authorized to populate this dataset" });
+      }
+
+      const run = await populateWorkflow.createRun();
+      const result = await run.start({ inputData: parsed.data });
+
+      req.log.info(
+        {
+          workflowStatus: result.status,
+          steps: JSON.stringify(result.steps).slice(0, 2000),
+        },
+        "Populate workflow completed"
+      );
+
+      if (result.status !== "success") {
+        throw new Error(`Workflow ended with status: ${result.status}`);
+      }
+
+      return { success: true, result: result.result };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("validator") || msg.includes("Invalid")) {
+        return reply.code(400).send({ error: "Invalid datasetId" });
+      }
+      req.log.error(err, "Populate failed");
+      return reply.code(502).send({ error: "Failed to populate dataset. Please try again." });
+    }
+  });
 });
 
 try {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -60,15 +60,15 @@ await fastify.register(async (instance) => {
       });
     }
 
-    const dataset = await convex.query(api.datasets.get, { id: parsed.data.datasetId });
-    if (!dataset) {
-      return reply.code(404).send({ error: "Dataset not found" });
-    }
-    if (dataset.ownerId !== req.auth.userId) {
-      return reply.code(403).send({ error: "Not authorized to populate this dataset" });
-    }
-
     try {
+      const dataset = await convex.query(api.datasets.get, { id: parsed.data.datasetId });
+      if (!dataset) {
+        return reply.code(404).send({ error: "Dataset not found" });
+      }
+      if (dataset.ownerId !== req.auth.userId) {
+        return reply.code(403).send({ error: "Not authorized to populate this dataset" });
+      }
+
       const run = await populateWorkflow.createRun();
       const result = await run.start({ inputData: parsed.data });
 
@@ -80,6 +80,10 @@ await fastify.register(async (instance) => {
 
       return { success: true, result: result.result };
     } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("validator") || msg.includes("Invalid")) {
+        return reply.code(400).send({ error: "Invalid datasetId" });
+      }
       req.log.error(err, "Populate failed");
       return reply.code(502).send({ error: "Failed to populate dataset. Please try again." });
     }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -6,6 +6,7 @@ import clerkAuthPlugin, { requireAuth } from "./clerk-auth.js";
 import { inferSchema } from "./pipeline/schema-inference.js";
 import { datasetContextSchema } from "./pipeline/populate.js";
 import { populateWorkflow } from "./mastra/workflows/populate.js";
+import { convex, api } from "./convex.js";
 
 const fastify = Fastify({ logger: true });
 
@@ -57,6 +58,14 @@ await fastify.register(async (instance) => {
         error: "Invalid request",
         details: parsed.error.flatten().fieldErrors,
       });
+    }
+
+    const dataset = await convex.query(api.datasets.get, { id: parsed.data.datasetId });
+    if (!dataset) {
+      return reply.code(404).send({ error: "Dataset not found" });
+    }
+    if (dataset.ownerId !== req.auth.userId) {
+      return reply.code(403).send({ error: "Not authorized to populate this dataset" });
     }
 
     try {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,126 +1,15 @@
-import Fastify from "fastify";
-import fastifyCors from "@fastify/cors";
-
 import { env } from "./env.js";
 import clerkAuthPlugin, { requireAuth } from "./clerk-auth.js";
-import { inferSchema } from "./pipeline/schema-inference.js";
-import { datasetContextSchema } from "./pipeline/populate.js";
 import { ConvexPopulateDatasetRowWriter } from "./pipeline/populate-convex-writer.js";
-import { populateRuntimePrerequisiteError } from "./pipeline/populate-runtime-prerequisites.js";
-import { runSelfHealingPopulate } from "./pipeline/populate-self-healing-runner.js";
 import { convex, api } from "./convex.js";
+import { createBigSetServer } from "./server.js";
 
-const fastify = Fastify({ logger: true });
-const populateRowWriter = new ConvexPopulateDatasetRowWriter();
-
-await fastify.register(fastifyCors, {
-  origin: env.CLIENT_ORIGIN,
-  methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-  allowedHeaders: ["Content-Type", "Authorization", "Cookie"],
-  credentials: true,
-  maxAge: 86400,
-});
-
-// Make `fastify.clerk` available and warn on missing CLERK_SECRET_KEY.
-// `requireAuth` (also exported from ./clerk-auth) is the preHandler for
-// protected routes — see the example block below.
-await fastify.register(clerkAuthPlugin);
-
-// ────────────────────────────────────────────────────────────────────────
-//  Public routes
-// ────────────────────────────────────────────────────────────────────────
-
-fastify.get("/health", async () => ({ status: "ok" }));
-
-// ────────────────────────────────────────────────────────────────────────
-//  Protected routes — gated by Clerk JWT verification
-// ────────────────────────────────────────────────────────────────────────
-
-await fastify.register(async (instance) => {
-  instance.addHook("preHandler", requireAuth);
-
-  instance.post("/infer-schema", async (req, reply) => {
-    const body = req.body as { prompt?: string };
-    if (!body?.prompt || typeof body.prompt !== "string" || !body.prompt.trim()) {
-      return reply.code(400).send({ error: "prompt is required" });
-    }
-
-    try {
-      const schema = await inferSchema(body.prompt.trim());
-      return schema;
-    } catch (err) {
-      req.log.error(err, "Schema inference failed");
-      return reply.code(502).send({ error: "Schema inference failed. Please try again." });
-    }
-  });
-
-  instance.post("/populate", async (req, reply) => {
-    const parsed = datasetContextSchema.safeParse(req.body);
-    if (!parsed.success) {
-      return reply.code(400).send({
-        error: "Invalid request",
-        details: parsed.error.flatten().fieldErrors,
-      });
-    }
-
-    try {
-      const dataset = await convex.query(api.datasets.get, { id: parsed.data.datasetId });
-      if (!dataset) {
-        return reply.code(404).send({ error: "Dataset not found" });
-      }
-      const authenticatedUserId = req.auth?.userId;
-      if (!authenticatedUserId) {
-        return reply.code(401).send({ error: "Unauthenticated" });
-      }
-      if (dataset.ownerId !== authenticatedUserId) {
-        return reply.code(403).send({ error: "Not authorized to populate this dataset" });
-      }
-      const prerequisiteError = populateRuntimePrerequisiteError({
-        convexUrl: env.CONVEX_URL,
-        convexAdminKey: env.CONVEX_ADMIN_KEY,
-        openRouterApiKey: env.OPENROUTER_API_KEY,
-        tinyFishApiKey: env.TINYFISH_API_KEY,
-      });
-      if (prerequisiteError) {
-        return reply.code(500).send({
-          error: prerequisiteError,
-        });
-      }
-
-      const result = await runSelfHealingPopulate({
-        context: parsed.data,
-        recipeStoreDirectory: env.POPULATE_RECIPE_STORE_DIR,
-        rowWriter: populateRowWriter,
-        shouldCommitRows: true,
-      });
-
-      req.log.info({
-        action: result.action,
-        datasetId: result.datasetId,
-        committedRows: result.committedRows?.insertedRowCount ?? 0,
-        validationIssues: result.validationIssues.slice(0, 5),
-      }, "Self-healing populate completed");
-
-      if (!result.success) {
-        return reply.code(422).send({
-          error: "Self-healing populate failed validation.",
-          result: responseSafePopulateResult(result),
-        });
-      }
-
-      return {
-        success: true,
-        result: responseSafePopulateResult(result),
-      };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes("validator") || msg.includes("Invalid")) {
-        return reply.code(400).send({ error: "Invalid datasetId" });
-      }
-      req.log.error(err, "Populate failed");
-      return reply.code(502).send({ error: "Failed to populate dataset. Please try again." });
-    }
-  });
+const fastify = await createBigSetServer({
+  env,
+  authPlugin: clerkAuthPlugin,
+  authPreHandler: requireAuth,
+  getDatasetById: (datasetId) => convex.query(api.datasets.get, { id: datasetId }),
+  populateRowWriter: new ConvexPopulateDatasetRowWriter(),
 });
 
 try {
@@ -128,21 +17,4 @@ try {
 } catch (err) {
   fastify.log.error(err);
   process.exit(1);
-}
-
-function responseSafePopulateResult(
-  result: Awaited<ReturnType<typeof runSelfHealingPopulate>>
-) {
-  const diagnosticRun = result.selectedRun ?? result.diagnosticRun;
-  return {
-    action: result.action,
-    datasetId: result.datasetId,
-    success: result.success,
-    committedRows: result.committedRows,
-    rejectionReasons: result.rejectionReasons,
-    validationIssues: result.validationIssues,
-    productionValidation: diagnosticRun?.productionValidation,
-    metrics: diagnosticRun?.metrics,
-    rowCount: diagnosticRun?.rows.length ?? 0,
-  };
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -76,6 +76,7 @@ await fastify.register(async (instance) => {
         return reply.code(403).send({ error: "Not authorized to populate this dataset" });
       }
       const prerequisiteError = populateRuntimePrerequisiteError({
+        convexUrl: env.CONVEX_URL,
         convexAdminKey: env.CONVEX_ADMIN_KEY,
         openRouterApiKey: env.OPENROUTER_API_KEY,
         tinyFishApiKey: env.TINYFISH_API_KEY,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -65,7 +65,11 @@ await fastify.register(async (instance) => {
       if (!dataset) {
         return reply.code(404).send({ error: "Dataset not found" });
       }
-      if (dataset.ownerId !== req.auth.userId) {
+      const authenticatedUserId = req.auth?.userId;
+      if (!authenticatedUserId) {
+        return reply.code(401).send({ error: "Unauthenticated" });
+      }
+      if (dataset.ownerId !== authenticatedUserId) {
         return reply.code(403).send({ error: "Not authorized to populate this dataset" });
       }
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,10 +5,13 @@ import { env } from "./env.js";
 import clerkAuthPlugin, { requireAuth } from "./clerk-auth.js";
 import { inferSchema } from "./pipeline/schema-inference.js";
 import { datasetContextSchema } from "./pipeline/populate.js";
-import { populateWorkflow } from "./mastra/workflows/populate.js";
+import { ConvexPopulateDatasetRowWriter } from "./pipeline/populate-convex-writer.js";
+import { populateRuntimePrerequisiteError } from "./pipeline/populate-runtime-prerequisites.js";
+import { runSelfHealingPopulate } from "./pipeline/populate-self-healing-runner.js";
 import { convex, api } from "./convex.js";
 
 const fastify = Fastify({ logger: true });
+const populateRowWriter = new ConvexPopulateDatasetRowWriter();
 
 await fastify.register(fastifyCors, {
   origin: env.CLIENT_ORIGIN,
@@ -72,17 +75,42 @@ await fastify.register(async (instance) => {
       if (dataset.ownerId !== authenticatedUserId) {
         return reply.code(403).send({ error: "Not authorized to populate this dataset" });
       }
-
-      const run = await populateWorkflow.createRun();
-      const result = await run.start({ inputData: parsed.data });
-
-      req.log.info({ workflowStatus: result.status, steps: JSON.stringify(result.steps).slice(0, 2000) }, "Populate workflow completed");
-
-      if (result.status !== "success") {
-        throw new Error(`Workflow ended with status: ${result.status}`);
+      const prerequisiteError = populateRuntimePrerequisiteError({
+        convexAdminKey: env.CONVEX_ADMIN_KEY,
+        openRouterApiKey: env.OPENROUTER_API_KEY,
+        tinyFishApiKey: env.TINYFISH_API_KEY,
+      });
+      if (prerequisiteError) {
+        return reply.code(500).send({
+          error: prerequisiteError,
+        });
       }
 
-      return { success: true, result: result.result };
+      const result = await runSelfHealingPopulate({
+        context: parsed.data,
+        recipeStoreDirectory: env.POPULATE_RECIPE_STORE_DIR,
+        rowWriter: populateRowWriter,
+        shouldCommitRows: true,
+      });
+
+      req.log.info({
+        action: result.action,
+        datasetId: result.datasetId,
+        committedRows: result.committedRows?.insertedRowCount ?? 0,
+        validationIssues: result.validationIssues.slice(0, 5),
+      }, "Self-healing populate completed");
+
+      if (!result.success) {
+        return reply.code(422).send({
+          error: "Self-healing populate failed validation.",
+          result: responseSafePopulateResult(result),
+        });
+      }
+
+      return {
+        success: true,
+        result: responseSafePopulateResult(result),
+      };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes("validator") || msg.includes("Invalid")) {
@@ -99,4 +127,21 @@ try {
 } catch (err) {
   fastify.log.error(err);
   process.exit(1);
+}
+
+function responseSafePopulateResult(
+  result: Awaited<ReturnType<typeof runSelfHealingPopulate>>
+) {
+  const diagnosticRun = result.selectedRun ?? result.diagnosticRun;
+  return {
+    action: result.action,
+    datasetId: result.datasetId,
+    success: result.success,
+    committedRows: result.committedRows,
+    rejectionReasons: result.rejectionReasons,
+    validationIssues: result.validationIssues,
+    productionValidation: diagnosticRun?.productionValidation,
+    metrics: diagnosticRun?.metrics,
+    rowCount: diagnosticRun?.rows.length ?? 0,
+  };
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,6 +4,8 @@ import fastifyCors from "@fastify/cors";
 import { env } from "./env.js";
 import clerkAuthPlugin, { requireAuth } from "./clerk-auth.js";
 import { inferSchema } from "./pipeline/schema-inference.js";
+import { datasetContextSchema } from "./pipeline/populate.js";
+import { populateWorkflow } from "./mastra/workflows/populate.js";
 
 const fastify = Fastify({ logger: true });
 
@@ -45,6 +47,32 @@ await fastify.register(async (instance) => {
     } catch (err) {
       req.log.error(err, "Schema inference failed");
       return reply.code(502).send({ error: "Schema inference failed. Please try again." });
+    }
+  });
+
+  instance.post("/populate", async (req, reply) => {
+    const parsed = datasetContextSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.code(400).send({
+        error: "Invalid request",
+        details: parsed.error.flatten().fieldErrors,
+      });
+    }
+
+    try {
+      const run = await populateWorkflow.createRun();
+      const result = await run.start({ inputData: parsed.data });
+
+      req.log.info({ workflowStatus: result.status, steps: JSON.stringify(result.steps).slice(0, 2000) }, "Populate workflow completed");
+
+      if (result.status !== "success") {
+        throw new Error(`Workflow ended with status: ${result.status}`);
+      }
+
+      return { success: true, result: result.result };
+    } catch (err) {
+      req.log.error(err, "Populate failed");
+      return reply.code(502).send({ error: "Failed to populate dataset. Please try again." });
     }
   });
 });

--- a/backend/src/mastra/agents/populate-tools.ts
+++ b/backend/src/mastra/agents/populate-tools.ts
@@ -1,0 +1,25 @@
+import { normalizeSearchResultUrl } from "../../pipeline/populate-search-prioritization.js";
+import {
+  getRowTool,
+  insertRowTool,
+  listRowsTool,
+  updateRowTool,
+  deleteRowTool,
+} from "../tools/dataset-tools.js";
+import { createFetchPageTool } from "../tools/web-tools.js";
+
+export function createPopulateAgentTools(input: {
+  allowedFetchUrls: Set<string>;
+}) {
+  return {
+    insert_row: insertRowTool,
+    list_rows: listRowsTool,
+    get_row: getRowTool,
+    update_row: updateRowTool,
+    delete_row: deleteRowTool,
+    fetch_page: createFetchPageTool({
+      allowedUrls: input.allowedFetchUrls,
+      normalizeUrl: normalizeSearchResultUrl,
+    }),
+  };
+}

--- a/backend/src/mastra/agents/populate.ts
+++ b/backend/src/mastra/agents/populate.ts
@@ -1,0 +1,36 @@
+import { Agent } from "@mastra/core/agent";
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import {
+  insertRowTool,
+  listRowsTool,
+  getRowTool,
+  updateRowTool,
+  deleteRowTool,
+} from "../tools/dataset-tools.js";
+import { searchWebTool, fetchPageTool } from "../tools/web-tools.js";
+
+const openrouter = createOpenRouter({
+  apiKey: process.env.OPENROUTER_API_KEY!,
+});
+
+export const populateAgent = new Agent({
+  id: "populate-agent",
+  name: "Dataset Populate Agent",
+  instructions: `You fill datasets with real data. Here's how:
+
+1. Search the web for data that fits the dataset topic.
+2. Fetch 1-2 pages to get details.
+3. Call insert_row for each row using what you found. Don't stop until you've inserted all the rows asked for.
+
+If you can't find enough real data, make up realistic data to fill the rest. Every row must be inserted with insert_row.`,
+  model: openrouter("anthropic/claude-sonnet-4-6"),
+  tools: {
+    insert_row: insertRowTool,
+    list_rows: listRowsTool,
+    get_row: getRowTool,
+    update_row: updateRowTool,
+    delete_row: deleteRowTool,
+    search_web: searchWebTool,
+    fetch_page: fetchPageTool,
+  },
+});

--- a/backend/src/mastra/agents/populate.ts
+++ b/backend/src/mastra/agents/populate.ts
@@ -1,14 +1,19 @@
 import { Agent } from "@mastra/core/agent";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+
 import {
+  DEFAULT_OPENROUTER_MODEL_ID,
+  requiredOpenRouterApiKey,
+} from "../../openrouter-models.js";
+import { populateAgentInstructions } from "../../pipeline/populate-prompt.js";
+import {
+  getRowTool,
   insertRowTool,
   listRowsTool,
-  getRowTool,
   updateRowTool,
   deleteRowTool,
 } from "../tools/dataset-tools.js";
-import { searchWebTool, fetchPageTool } from "../tools/web-tools.js";
-import { populateAgentInstructions } from "../../pipeline/populate-prompt.js";
+import { createFetchPageTool } from "../tools/web-tools.js";
 
 type PopulateAgentOptions = ConstructorParameters<typeof Agent>[0];
 
@@ -18,8 +23,7 @@ const defaultPopulateTools = {
   get_row: getRowTool,
   update_row: updateRowTool,
   delete_row: deleteRowTool,
-  search_web: searchWebTool,
-  fetch_page: fetchPageTool,
+  fetch_page: createFetchPageTool(),
 };
 
 export function createPopulateAgent(input: {
@@ -38,8 +42,6 @@ export function createPopulateAgent(input: {
 export const populateAgent = createPopulateAgent();
 
 function defaultPopulateModel(): PopulateAgentOptions["model"] {
-  const openrouter = createOpenRouter({
-    apiKey: process.env.OPENROUTER_API_KEY!,
-  });
-  return openrouter("anthropic/claude-sonnet-4-6");
+  const openrouter = createOpenRouter({ apiKey: requiredOpenRouterApiKey() });
+  return openrouter(DEFAULT_OPENROUTER_MODEL_ID);
 }

--- a/backend/src/mastra/agents/populate.ts
+++ b/backend/src/mastra/agents/populate.ts
@@ -8,29 +8,38 @@ import {
   deleteRowTool,
 } from "../tools/dataset-tools.js";
 import { searchWebTool, fetchPageTool } from "../tools/web-tools.js";
+import { populateAgentInstructions } from "../../pipeline/populate-prompt.js";
 
-const openrouter = createOpenRouter({
-  apiKey: process.env.OPENROUTER_API_KEY!,
-});
+type PopulateAgentOptions = ConstructorParameters<typeof Agent>[0];
 
-export const populateAgent = new Agent({
-  id: "populate-agent",
-  name: "Dataset Populate Agent",
-  instructions: `You fill datasets with real data. Here's how:
+const defaultPopulateTools = {
+  insert_row: insertRowTool,
+  list_rows: listRowsTool,
+  get_row: getRowTool,
+  update_row: updateRowTool,
+  delete_row: deleteRowTool,
+  search_web: searchWebTool,
+  fetch_page: fetchPageTool,
+};
 
-1. Search the web for data that fits the dataset topic.
-2. Fetch 1-2 pages to get details.
-3. Call insert_row only for rows supported by search or fetched page content.
+export function createPopulateAgent(input: {
+  model?: PopulateAgentOptions["model"];
+  tools?: PopulateAgentOptions["tools"];
+} = {}) {
+  return new Agent({
+    id: "populate-agent",
+    name: "Dataset Populate Agent",
+    instructions: populateAgentInstructions,
+    model: input.model ?? defaultPopulateModel(),
+    tools: input.tools ?? defaultPopulateTools,
+  });
+}
 
-Never make up rows or missing cell values. If you can't find enough real data, insert fewer rows and explain the gap in your final response.`,
-  model: openrouter("anthropic/claude-sonnet-4-6"),
-  tools: {
-    insert_row: insertRowTool,
-    list_rows: listRowsTool,
-    get_row: getRowTool,
-    update_row: updateRowTool,
-    delete_row: deleteRowTool,
-    search_web: searchWebTool,
-    fetch_page: fetchPageTool,
-  },
-});
+export const populateAgent = createPopulateAgent();
+
+function defaultPopulateModel(): PopulateAgentOptions["model"] {
+  const openrouter = createOpenRouter({
+    apiKey: process.env.OPENROUTER_API_KEY!,
+  });
+  return openrouter("anthropic/claude-sonnet-4-6");
+}

--- a/backend/src/mastra/agents/populate.ts
+++ b/backend/src/mastra/agents/populate.ts
@@ -20,9 +20,9 @@ export const populateAgent = new Agent({
 
 1. Search the web for data that fits the dataset topic.
 2. Fetch 1-2 pages to get details.
-3. Call insert_row for each row using what you found. Don't stop until you've inserted all the rows asked for.
+3. Call insert_row only for rows supported by search or fetched page content.
 
-If you can't find enough real data, make up realistic data to fill the rest. Every row must be inserted with insert_row.`,
+Never make up rows or missing cell values. If you can't find enough real data, insert fewer rows and explain the gap in your final response.`,
   model: openrouter("anthropic/claude-sonnet-4-6"),
   tools: {
     insert_row: insertRowTool,

--- a/backend/src/mastra/agents/search-acquisition.ts
+++ b/backend/src/mastra/agents/search-acquisition.ts
@@ -1,0 +1,31 @@
+import { Agent } from "@mastra/core/agent";
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+
+import { searchAcquisitionAgentInstructions } from "../../pipeline/populate-acquisition-prompt.js";
+import {
+  DEFAULT_OPENROUTER_MODEL_ID,
+  requiredOpenRouterApiKey,
+} from "../../openrouter-models.js";
+import { searchWebTool } from "../tools/web-tools.js";
+
+type SearchAcquisitionAgentOptions = ConstructorParameters<typeof Agent>[0];
+
+export function createSearchAcquisitionAgent(input: {
+  model?: SearchAcquisitionAgentOptions["model"];
+  tools?: SearchAcquisitionAgentOptions["tools"];
+} = {}) {
+  return new Agent({
+    id: "populate-search-acquisition-agent",
+    name: "Populate Search Acquisition Agent",
+    instructions: searchAcquisitionAgentInstructions,
+    model: input.model ?? defaultSearchAcquisitionModel(),
+    tools: input.tools ?? { search_web: searchWebTool },
+  });
+}
+
+export const searchAcquisitionAgent = createSearchAcquisitionAgent();
+
+function defaultSearchAcquisitionModel(): SearchAcquisitionAgentOptions["model"] {
+  const openrouter = createOpenRouter({ apiKey: requiredOpenRouterApiKey() });
+  return openrouter(DEFAULT_OPENROUTER_MODEL_ID);
+}

--- a/backend/src/mastra/index.ts
+++ b/backend/src/mastra/index.ts
@@ -1,6 +1,9 @@
 import { Mastra } from "@mastra/core/mastra";
 import { inferSchemaWorkflow } from "./workflows/infer-schema.js";
+import { populateWorkflow } from "./workflows/populate.js";
+import { populateAgent } from "./agents/populate.js";
 
 export const mastra = new Mastra({
-  workflows: { inferSchemaWorkflow },
+  agents: { populateAgent },
+  workflows: { inferSchemaWorkflow, populateWorkflow },
 });

--- a/backend/src/mastra/index.ts
+++ b/backend/src/mastra/index.ts
@@ -2,8 +2,9 @@ import { Mastra } from "@mastra/core/mastra";
 import { inferSchemaWorkflow } from "./workflows/infer-schema.js";
 import { populateWorkflow } from "./workflows/populate.js";
 import { populateAgent } from "./agents/populate.js";
+import { searchAcquisitionAgent } from "./agents/search-acquisition.js";
 
 export const mastra = new Mastra({
-  agents: { populateAgent },
+  agents: { populateAgent, searchAcquisitionAgent },
   workflows: { inferSchemaWorkflow, populateWorkflow },
 });

--- a/backend/src/mastra/tools/dataset-tools.ts
+++ b/backend/src/mastra/tools/dataset-tools.ts
@@ -30,7 +30,7 @@ export const insertRowTool = createTool({
       return { success: false, error: "data is required and must have at least one key. Pass an object like { \"Column Name\": value }." };
 
     const cleanedData = cleanDataKeys(data);
-    console.log(`[insert_row] Inserting row into ${datasetId}:`, JSON.stringify(cleanedData).slice(0, 200));
+    console.log(`[insert_row] Inserting row into ${datasetId} (${Object.keys(cleanedData).length} columns)`);
     try {
       await convex.mutation(internal.datasetRows.insert, { datasetId, data: cleanedData });
       console.log(`[insert_row] Row inserted successfully`);
@@ -115,7 +115,7 @@ export const updateRowTool = createTool({
       return { success: false, error: "data is required. Pass the full updated row data object." };
 
     const cleanedData = cleanDataKeys(data);
-    console.log(`[update_row] Updating row ${rowId}:`, JSON.stringify(cleanedData).slice(0, 200));
+    console.log(`[update_row] Updating row ${rowId} (${Object.keys(cleanedData).length} columns)`);
     try {
       await convex.mutation(internal.datasetRows.update, { id: rowId, data: cleanedData });
       console.log(`[update_row] Row updated successfully`);

--- a/backend/src/mastra/tools/dataset-tools.ts
+++ b/backend/src/mastra/tools/dataset-tools.ts
@@ -1,0 +1,161 @@
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+import { convex, api, internal } from "../../convex.js";
+
+const resultSchema = z.object({
+  success: z.boolean(),
+  error: z.string().optional(),
+});
+
+function cleanDataKeys(data: Record<string, unknown>): Record<string, unknown> {
+  const cleaned: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data)) {
+    cleaned[key.replace(/^["`]+|["`]+$/g, "")] = value;
+  }
+  return cleaned;
+}
+
+export const insertRowTool = createTool({
+  id: "insert_row",
+  description:
+    "Insert a single row into the dataset. Call this each time you have a row ready — don't wait to batch them.",
+  inputSchema: z.object({
+    datasetId: z.string(),
+    data: z.record(z.string(), z.any()),
+  }),
+  outputSchema: resultSchema,
+  execute: async ({ datasetId, data }) => {
+    if (!datasetId) return { success: false, error: "datasetId is required." };
+    if (!data || Object.keys(data).length === 0)
+      return { success: false, error: "data is required and must have at least one key. Pass an object like { \"Column Name\": value }." };
+
+    const cleanedData = cleanDataKeys(data);
+    console.log(`[insert_row] Inserting row into ${datasetId}:`, JSON.stringify(cleanedData).slice(0, 200));
+    try {
+      await convex.mutation(internal.datasetRows.insert, { datasetId, data: cleanedData });
+      console.log(`[insert_row] Row inserted successfully`);
+      return { success: true };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[insert_row] Failed:`, msg);
+      if (msg.includes("not found"))
+        return { success: false, error: `Dataset "${datasetId}" not found. Check the datasetId is correct.` };
+      if (msg.includes("validator"))
+        return { success: false, error: `Data validation failed: ${msg}. Check that your data keys are plain strings and values match expected types.` };
+      return { success: false, error: `Insert failed: ${msg}` };
+    }
+  },
+});
+
+export const listRowsTool = createTool({
+  id: "list_rows",
+  description:
+    "Read all rows in the dataset. Returns an array of row objects, each with _id and data fields.",
+  inputSchema: z.object({
+    datasetId: z.string(),
+  }),
+  outputSchema: z.object({ rows: z.array(z.any()).optional(), error: z.string().optional() }),
+  execute: async ({ datasetId }) => {
+    if (!datasetId) return { error: "datasetId is required." };
+
+    console.log(`[list_rows] Reading all rows for dataset ${datasetId}`);
+    try {
+      const rows = await convex.query(api.datasetRows.listByDataset, { datasetId });
+      console.log(`[list_rows] Found ${rows.length} rows`);
+      return { rows };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[list_rows] Failed:`, msg);
+      if (msg.includes("not found"))
+        return { error: `Dataset "${datasetId}" not found. Check the datasetId.` };
+      return { error: `List rows failed: ${msg}` };
+    }
+  },
+});
+
+export const getRowTool = createTool({
+  id: "get_row",
+  description:
+    "Read a single row by its ID. Returns the row object with _id and data fields, or an error if not found.",
+  inputSchema: z.object({
+    rowId: z.string(),
+  }),
+  outputSchema: z.object({ row: z.any().optional(), error: z.string().optional() }),
+  execute: async ({ rowId }) => {
+    if (!rowId) return { error: "rowId is required." };
+
+    console.log(`[get_row] Reading row ${rowId}`);
+    try {
+      const row = await convex.query(internal.datasetRows.get, { id: rowId });
+      if (!row) return { error: `Row "${rowId}" not found. It may have been deleted.` };
+      console.log(`[get_row] Found`);
+      return { row };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[get_row] Failed:`, msg);
+      if (msg.includes("validator") || msg.includes("Invalid"))
+        return { error: `Invalid row ID format: "${rowId}". Row IDs look like "jd7..." — they are Convex document IDs.` };
+      return { error: `Get row failed: ${msg}` };
+    }
+  },
+});
+
+export const updateRowTool = createTool({
+  id: "update_row",
+  description:
+    "Update an existing row by its ID. Pass the full updated data object. Changes are tracked in history.",
+  inputSchema: z.object({
+    rowId: z.string(),
+    data: z.record(z.string(), z.any()),
+  }),
+  outputSchema: resultSchema,
+  execute: async ({ rowId, data }) => {
+    if (!rowId) return { success: false, error: "rowId is required." };
+    if (!data || Object.keys(data).length === 0)
+      return { success: false, error: "data is required. Pass the full updated row data object." };
+
+    const cleanedData = cleanDataKeys(data);
+    console.log(`[update_row] Updating row ${rowId}:`, JSON.stringify(cleanedData).slice(0, 200));
+    try {
+      await convex.mutation(internal.datasetRows.update, { id: rowId, data: cleanedData });
+      console.log(`[update_row] Row updated successfully`);
+      return { success: true };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[update_row] Failed:`, msg);
+      if (msg.includes("Row not found") || msg.includes("not found"))
+        return { success: false, error: `Row "${rowId}" not found. Use list_rows to see existing row IDs.` };
+      if (msg.includes("validator") || msg.includes("Invalid"))
+        return { success: false, error: `Invalid input: ${msg}. Check that rowId is a valid Convex ID and data keys are plain strings.` };
+      return { success: false, error: `Update failed: ${msg}` };
+    }
+  },
+});
+
+export const deleteRowTool = createTool({
+  id: "delete_row",
+  description:
+    "Delete a single row by its ID. This is permanent.",
+  inputSchema: z.object({
+    rowId: z.string(),
+  }),
+  outputSchema: resultSchema,
+  execute: async ({ rowId }) => {
+    if (!rowId) return { success: false, error: "rowId is required." };
+
+    console.log(`[delete_row] Deleting row ${rowId}`);
+    try {
+      await convex.mutation(internal.datasetRows.remove, { id: rowId });
+      console.log(`[delete_row] Row deleted successfully`);
+      return { success: true };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[delete_row] Failed:`, msg);
+      if (msg.includes("not found"))
+        return { success: false, error: `Row "${rowId}" not found. It may have already been deleted.` };
+      if (msg.includes("validator") || msg.includes("Invalid"))
+        return { success: false, error: `Invalid row ID format: "${rowId}". Use list_rows to find valid row IDs.` };
+      return { success: false, error: `Delete failed: ${msg}` };
+    }
+  },
+});

--- a/backend/src/mastra/tools/web-tools.ts
+++ b/backend/src/mastra/tools/web-tools.ts
@@ -72,19 +72,49 @@ export const searchWebTool = createTool({
   },
 });
 
-export const fetchPageTool = createTool({
-  id: "fetch_page",
-  description:
-    "Fetch a web page and extract its content as clean markdown text. Use this after search_web to read the full content of a page.",
-  inputSchema: z.object({
-    url: z.string().describe("The URL to fetch"),
-  }),
-  outputSchema: z.object({
-    title: z.string().optional(),
-    text: z.string().optional(),
-    error: z.string().optional(),
-  }),
-  execute: async ({ url: targetUrl }) => {
+export function createFetchPageTool(input?: {
+  allowedUrls?: Set<string>;
+  normalizeUrl?: (url: string) => string;
+  onFetchAttempt?: () => string | undefined;
+}) {
+  const normalizeUrl = input?.normalizeUrl ?? ((url: string) => url.trim());
+
+  return createTool({
+    id: "fetch_page",
+    description:
+      "Fetch a web page and extract its content as clean markdown text. Use only on source URLs listed in the prompt.",
+    inputSchema: z.object({
+      url: z.string().describe("The URL to fetch"),
+    }),
+    outputSchema: z.object({
+      title: z.string().optional(),
+      text: z.string().optional(),
+      error: z.string().optional(),
+    }),
+    execute: async ({ url: targetUrl }) => {
+      const limitMessage = input?.onFetchAttempt?.();
+      if (limitMessage) {
+        return { error: limitMessage };
+      }
+
+      if (input?.allowedUrls && input.allowedUrls.size > 0) {
+        const normalized = normalizeUrl(targetUrl);
+        if (!input.allowedUrls.has(normalized)) {
+          return {
+            error:
+              "URL is not in the source URL list for this run. Use fetch_page only on URLs listed in the prompt.",
+          };
+        }
+      }
+
+      return executeFetchPage(targetUrl);
+    },
+  });
+}
+
+export const fetchPageTool = createFetchPageTool();
+
+async function executeFetchPage(targetUrl: string) {
     if (!targetUrl?.trim())
       return { error: "url is required and cannot be empty." };
     if (!targetUrl.startsWith("http://") && !targetUrl.startsWith("https://"))
@@ -158,5 +188,4 @@ export const fetchPageTool = createTool({
       console.error(`[fetch_page] Failed:`, msg);
       return { error: `Fetch failed: ${msg}. Use data from search snippets instead.` };
     }
-  },
-});
+}

--- a/backend/src/mastra/tools/web-tools.ts
+++ b/backend/src/mastra/tools/web-tools.ts
@@ -1,6 +1,8 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 
+const FETCH_TIMEOUT_MS = 30_000;
+
 const searchResultSchema = z.object({
   title: z.string(),
   snippet: z.string(),
@@ -29,10 +31,14 @@ export const searchWebTool = createTool({
     const url = `https://api.search.tinyfish.ai?query=${encodeURIComponent(query)}`;
     console.log(`[search_web] Searching: "${query}"`);
 
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
     try {
       const res = await fetch(url, {
         headers: { "X-API-Key": apiKey },
+        signal: controller.signal,
       });
+      clearTimeout(timeout);
 
       if (!res.ok) {
         const body = await res.text();
@@ -56,6 +62,9 @@ export const searchWebTool = createTool({
         return { results: [], error: "No results found for this query. Try a broader search or use synthetic data." };
       return { results };
     } catch (err) {
+      clearTimeout(timeout);
+      if (err instanceof Error && err.name === "AbortError")
+        return { error: "Search timed out. Skip web search and use synthetic data." };
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[search_web] Failed:`, msg);
       return { error: `Search failed: ${msg}. Skip web search and use synthetic data.` };
@@ -87,6 +96,8 @@ export const fetchPageTool = createTool({
 
     console.log(`[fetch_page] Fetching: ${targetUrl}`);
 
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
     try {
       const res = await fetch("https://api.fetch.tinyfish.ai", {
         method: "POST",
@@ -95,7 +106,9 @@ export const fetchPageTool = createTool({
           "X-API-Key": apiKey,
         },
         body: JSON.stringify({ urls: [targetUrl], format: "markdown" }),
+        signal: controller.signal,
       });
+      clearTimeout(timeout);
 
       if (!res.ok) {
         const body = await res.text();
@@ -138,6 +151,9 @@ export const fetchPageTool = createTool({
         text,
       };
     } catch (err) {
+      clearTimeout(timeout);
+      if (err instanceof Error && err.name === "AbortError")
+        return { error: "Page fetch timed out. Try a different URL or use search snippet data." };
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[fetch_page] Failed:`, msg);
       return { error: `Fetch failed: ${msg}. Use data from search snippets instead.` };

--- a/backend/src/mastra/tools/web-tools.ts
+++ b/backend/src/mastra/tools/web-tools.ts
@@ -1,0 +1,146 @@
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+
+const searchResultSchema = z.object({
+  title: z.string(),
+  snippet: z.string(),
+  url: z.string(),
+});
+
+export const searchWebTool = createTool({
+  id: "search_web",
+  description:
+    "Search the web for information. Returns a list of results with titles, snippets, and URLs. Use this to find real data for the dataset.",
+  inputSchema: z.object({
+    query: z.string().describe("The search query"),
+  }),
+  outputSchema: z.object({
+    results: z.array(searchResultSchema).optional(),
+    error: z.string().optional(),
+  }),
+  execute: async ({ query }) => {
+    if (!query?.trim())
+      return { error: "query is required and cannot be empty." };
+
+    const apiKey = process.env.TINYFISH_API_KEY;
+    if (!apiKey)
+      return { error: "TINYFISH_API_KEY is not configured. Web search is unavailable — use synthetic data instead." };
+
+    const url = `https://api.search.tinyfish.ai?query=${encodeURIComponent(query)}`;
+    console.log(`[search_web] Searching: "${query}"`);
+
+    try {
+      const res = await fetch(url, {
+        headers: { "X-API-Key": apiKey },
+      });
+
+      if (!res.ok) {
+        const body = await res.text();
+        console.error(`[search_web] API error ${res.status}:`, body.slice(0, 200));
+        if (res.status === 429)
+          return { error: "Search rate limit hit. Wait a moment, or skip web search and use synthetic data." };
+        if (res.status === 401)
+          return { error: "Invalid TINYFISH_API_KEY. Web search unavailable — use synthetic data." };
+        return { error: `Search API returned HTTP ${res.status}. Try a different query or use synthetic data.` };
+      }
+
+      const data = await res.json();
+      const results = (data.results ?? []).map((r: Record<string, unknown>) => ({
+        title: r.title as string,
+        snippet: r.snippet as string,
+        url: r.url as string,
+      }));
+
+      console.log(`[search_web] Got ${results.length} results`);
+      if (results.length === 0)
+        return { results: [], error: "No results found for this query. Try a broader search or use synthetic data." };
+      return { results };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[search_web] Failed:`, msg);
+      return { error: `Search failed: ${msg}. Skip web search and use synthetic data.` };
+    }
+  },
+});
+
+export const fetchPageTool = createTool({
+  id: "fetch_page",
+  description:
+    "Fetch a web page and extract its content as clean markdown text. Use this after search_web to read the full content of a page.",
+  inputSchema: z.object({
+    url: z.string().describe("The URL to fetch"),
+  }),
+  outputSchema: z.object({
+    title: z.string().optional(),
+    text: z.string().optional(),
+    error: z.string().optional(),
+  }),
+  execute: async ({ url: targetUrl }) => {
+    if (!targetUrl?.trim())
+      return { error: "url is required and cannot be empty." };
+    if (!targetUrl.startsWith("http://") && !targetUrl.startsWith("https://"))
+      return { error: `Invalid URL "${targetUrl}". Must start with http:// or https://.` };
+
+    const apiKey = process.env.TINYFISH_API_KEY;
+    if (!apiKey)
+      return { error: "TINYFISH_API_KEY is not configured. Page fetch is unavailable — use data from search snippets instead." };
+
+    console.log(`[fetch_page] Fetching: ${targetUrl}`);
+
+    try {
+      const res = await fetch("https://api.fetch.tinyfish.ai", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-API-Key": apiKey,
+        },
+        body: JSON.stringify({ urls: [targetUrl], format: "markdown" }),
+      });
+
+      if (!res.ok) {
+        const body = await res.text();
+        console.error(`[fetch_page] API error ${res.status}:`, body.slice(0, 200));
+        if (res.status === 429)
+          return { error: "Fetch rate limit hit. Use data from search snippets instead." };
+        if (res.status === 401)
+          return { error: "Invalid TINYFISH_API_KEY. Page fetch unavailable." };
+        return { error: `Fetch API returned HTTP ${res.status}. Try a different URL or use search snippet data.` };
+      }
+
+      const data = await res.json();
+
+      if (data.errors?.length > 0) {
+        const err = data.errors[0];
+        console.log(`[fetch_page] Failed: ${err.error}`);
+        const hints: Record<string, string> = {
+          bot_blocked: "This site blocks automated access. Use the search snippet data instead.",
+          timeout: "Page took too long to load. Try a different URL.",
+          target_unreachable: "Could not connect to this site. Try a different URL.",
+          page_not_found: "Page not found (404). The URL may be outdated. Try a different one.",
+          target_http_error: `Site returned HTTP ${err.status ?? "error"}. Try a different URL.`,
+        };
+        return { error: hints[err.error] ?? `Fetch failed: ${err.error}. Try a different URL.` };
+      }
+
+      const page = data.results?.[0];
+      if (!page?.text)
+        return { error: "Page loaded but had no extractable text content. Try a different URL." };
+
+      let text = page.text as string;
+      const MAX_CHARS = 15000;
+      if (text.length > MAX_CHARS) {
+        text = text.slice(0, MAX_CHARS) + `\n\n[Truncated — showing first ${MAX_CHARS} of ${page.text.length} chars]`;
+      }
+
+      console.log(`[fetch_page] Got ${(page.text as string).length} chars from "${page.title}" (returning ${text.length})`);
+      return {
+        title: page.title as string | undefined,
+        text,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[fetch_page] Failed:`, msg);
+      return { error: `Fetch failed: ${msg}. Use data from search snippets instead.` };
+    }
+  },
+});

--- a/backend/src/mastra/tools/web-tools.ts
+++ b/backend/src/mastra/tools/web-tools.ts
@@ -26,7 +26,7 @@ export const searchWebTool = createTool({
 
     const apiKey = process.env.TINYFISH_API_KEY;
     if (!apiKey)
-      return { error: "TINYFISH_API_KEY is not configured. Web search is unavailable — use synthetic data instead." };
+      return { error: "TINYFISH_API_KEY is not configured. Web search is unavailable; insert only rows supported by available sources." };
 
     const url = `https://api.search.tinyfish.ai?query=${encodeURIComponent(query)}`;
     console.log(`[search_web] Searching: "${query}"`);
@@ -44,10 +44,10 @@ export const searchWebTool = createTool({
         const body = await res.text();
         console.error(`[search_web] API error ${res.status}:`, body.slice(0, 200));
         if (res.status === 429)
-          return { error: "Search rate limit hit. Wait a moment, or skip web search and use synthetic data." };
+          return { error: "Search rate limit hit. Wait a moment, or insert only rows supported by already available sources." };
         if (res.status === 401)
-          return { error: "Invalid TINYFISH_API_KEY. Web search unavailable — use synthetic data." };
-        return { error: `Search API returned HTTP ${res.status}. Try a different query or use synthetic data.` };
+          return { error: "Invalid TINYFISH_API_KEY. Web search unavailable." };
+        return { error: `Search API returned HTTP ${res.status}. Try a different query.` };
       }
 
       const data = await res.json();
@@ -59,15 +59,15 @@ export const searchWebTool = createTool({
 
       console.log(`[search_web] Got ${results.length} results`);
       if (results.length === 0)
-        return { results: [], error: "No results found for this query. Try a broader search or use synthetic data." };
+        return { results: [], error: "No results found for this query. Try a broader search." };
       return { results };
     } catch (err) {
       clearTimeout(timeout);
       if (err instanceof Error && err.name === "AbortError")
-        return { error: "Search timed out. Skip web search and use synthetic data." };
+        return { error: "Search timed out. Try a narrower query or use already available sources only." };
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[search_web] Failed:`, msg);
-      return { error: `Search failed: ${msg}. Skip web search and use synthetic data.` };
+      return { error: `Search failed: ${msg}. Use already available sources only.` };
     }
   },
 });
@@ -92,7 +92,7 @@ export const fetchPageTool = createTool({
 
     const apiKey = process.env.TINYFISH_API_KEY;
     if (!apiKey)
-      return { error: "TINYFISH_API_KEY is not configured. Page fetch is unavailable — use data from search snippets instead." };
+      return { error: "TINYFISH_API_KEY is not configured. Page fetch is unavailable; use source-backed search snippets only." };
 
     console.log(`[fetch_page] Fetching: ${targetUrl}`);
 
@@ -114,7 +114,7 @@ export const fetchPageTool = createTool({
         const body = await res.text();
         console.error(`[fetch_page] API error ${res.status}:`, body.slice(0, 200));
         if (res.status === 429)
-          return { error: "Fetch rate limit hit. Use data from search snippets instead." };
+          return { error: "Fetch rate limit hit. Use source-backed search snippets only." };
         if (res.status === 401)
           return { error: "Invalid TINYFISH_API_KEY. Page fetch unavailable." };
         return { error: `Fetch API returned HTTP ${res.status}. Try a different URL or use search snippet data.` };

--- a/backend/src/mastra/workflows/populate.ts
+++ b/backend/src/mastra/workflows/populate.ts
@@ -1,0 +1,64 @@
+import { createStep, createWorkflow } from "@mastra/core/workflows";
+import { z } from "zod";
+import { datasetContextSchema } from "../../pipeline/populate.js";
+import { convex, internal } from "../../convex.js";
+import { populateAgent } from "../agents/populate.js";
+
+const clearRowsStep = createStep({
+  id: "clear-rows",
+  inputSchema: datasetContextSchema,
+  outputSchema: datasetContextSchema,
+  execute: async ({ inputData }) => {
+    console.log(`[clear-rows] Clearing rows for dataset ${inputData.datasetId}`);
+    await convex.mutation(internal.datasetRows.clearByDataset, {
+      datasetId: inputData.datasetId,
+    });
+    console.log(`[clear-rows] Done`);
+    return inputData;
+  },
+});
+
+const buildPromptStep = createStep({
+  id: "build-prompt",
+  inputSchema: datasetContextSchema,
+  outputSchema: z.object({ prompt: z.string() }),
+  execute: async ({ inputData }) => {
+    const columnNames = inputData.columns.map((c) => c.name);
+    const columnsDesc = inputData.columns
+      .map(
+        (c) =>
+          `- "${c.name}" (${c.type})${c.description ? `: ${c.description}` : ""}`,
+      )
+      .join("\n");
+
+    const prompt = `Dataset ID: ${inputData.datasetId}
+Dataset: ${inputData.datasetName}
+Description: ${inputData.description}
+
+Columns:
+${columnsDesc}
+
+When calling insert_row, the data object keys MUST be exactly these strings (no backticks, no extra quotes):
+${JSON.stringify(columnNames)}
+
+Example insert_row call:
+insert_row({ datasetId: "${inputData.datasetId}", data: { ${columnNames.map((n) => `"${n}": <value>`).join(", ")} } })
+
+Search the web for real data about this topic. Then call insert_row to fill in 10 rows. Use real data from your search. Fill in any gaps with realistic fake data.`;
+
+    console.log(`[build-prompt] Built prompt for ${inputData.datasetName} (${inputData.columns.length} columns)`);
+    return { prompt };
+  },
+});
+
+const agentStep = createStep(populateAgent, { maxSteps: 80 });
+
+export const populateWorkflow = createWorkflow({
+  id: "populate-workflow",
+  inputSchema: datasetContextSchema,
+  outputSchema: z.object({ text: z.string() }),
+})
+  .then(clearRowsStep)
+  .then(buildPromptStep)
+  .then(agentStep)
+  .commit();

--- a/backend/src/mastra/workflows/populate.ts
+++ b/backend/src/mastra/workflows/populate.ts
@@ -1,6 +1,7 @@
 import { createStep, createWorkflow } from "@mastra/core/workflows";
 import { z } from "zod";
 import { datasetContextSchema } from "../../pipeline/populate.js";
+import { buildPopulatePrompt } from "../../pipeline/populate-prompt.js";
 import { convex, internal } from "../../convex.js";
 import { populateAgent } from "../agents/populate.js";
 
@@ -23,28 +24,7 @@ const buildPromptStep = createStep({
   inputSchema: datasetContextSchema,
   outputSchema: z.object({ prompt: z.string() }),
   execute: async ({ inputData }) => {
-    const columnNames = inputData.columns.map((c) => c.name);
-    const columnsDesc = inputData.columns
-      .map(
-        (c) =>
-          `- "${c.name}" (${c.type})${c.description ? `: ${c.description}` : ""}`,
-      )
-      .join("\n");
-
-    const prompt = `Dataset ID: ${inputData.datasetId}
-Dataset: ${inputData.datasetName}
-Description: ${inputData.description}
-
-Columns:
-${columnsDesc}
-
-When calling insert_row, the data object keys MUST be exactly these strings (no backticks, no extra quotes):
-${JSON.stringify(columnNames)}
-
-Example insert_row call:
-insert_row({ datasetId: "${inputData.datasetId}", data: { ${columnNames.map((n) => `"${n}": <value>`).join(", ")} } })
-
-Search the web for real data about this topic. Then call insert_row for up to 10 source-backed rows. Never invent rows or cell values. If sources only support fewer than 10 rows, insert only the verified rows and explain what was missing.`;
+    const prompt = buildPopulatePrompt(inputData);
 
     console.log(`[build-prompt] Built prompt for ${inputData.datasetName} (${inputData.columns.length} columns)`);
     return { prompt };

--- a/backend/src/mastra/workflows/populate.ts
+++ b/backend/src/mastra/workflows/populate.ts
@@ -1,15 +1,28 @@
 import { createStep, createWorkflow } from "@mastra/core/workflows";
 import { z } from "zod";
 import { datasetContextSchema } from "../../pipeline/populate.js";
-import { buildPopulatePrompt } from "../../pipeline/populate-prompt.js";
-import { convex, internal } from "../../convex.js";
-import { populateAgent } from "../agents/populate.js";
+import {
+  finalizeAcquisitionResult,
+  runSearchAcquisitionPhase,
+} from "../../pipeline/populate-acquisition.js";
+import { PopulateCollectionMemoryService } from "../../pipeline/collection-memory/index.js";
+import { resolvePopulateCollectionMemoryConfig } from "../../pipeline/populate-collection-memory-config.js";
+import { runParallelPopulatePhase } from "../../pipeline/populate-parallel.js";
+import {
+  buildPopulateColumnKeyAliases,
+  normalizePopulateRowCellsForDataset,
+} from "../../pipeline/populate-normalize-dataset-keys.js";
+import { resolvePopulateRuntimeLimits } from "../../pipeline/populate-runtime-limits.js";
+import type { DatasetSchema } from "../../pipeline/types.js";
+import { createTinyFishWebTools } from "../../pipeline/populate-runtime.js";
+import { populateAcquisitionResultSchema } from "../../pipeline/populate-acquisition.js";
 
 const clearRowsStep = createStep({
   id: "clear-rows",
   inputSchema: datasetContextSchema,
   outputSchema: datasetContextSchema,
   execute: async ({ inputData }) => {
+    const { convex, internal } = await import("../../convex.js");
     console.log(`[clear-rows] Clearing rows for dataset ${inputData.datasetId}`);
     await convex.mutation(internal.datasetRows.clearByDataset, {
       datasetId: inputData.datasetId,
@@ -19,19 +32,126 @@ const clearRowsStep = createStep({
   },
 });
 
-const buildPromptStep = createStep({
-  id: "build-prompt",
+const acquireSourcesStep = createStep({
+  id: "acquire-sources",
   inputSchema: datasetContextSchema,
-  outputSchema: z.object({ prompt: z.string() }),
+  outputSchema: z.object({
+    context: datasetContextSchema,
+    acquisition: populateAcquisitionResultSchema,
+    dataSpec: z.any(),
+  }),
   execute: async ({ inputData }) => {
-    const prompt = buildPopulatePrompt(inputData);
-
-    console.log(`[build-prompt] Built prompt for ${inputData.datasetName} (${inputData.columns.length} columns)`);
-    return { prompt };
+    const limits = resolvePopulateRuntimeLimits();
+    const metrics = {
+      searchCalls: 0,
+      fetchCalls: 0,
+      browserCalls: 0,
+      agentRuns: 0,
+      agentSteps: 0,
+    };
+    const validationIssues: string[] = [];
+    const debugNotes: string[] = [];
+    const acquisitionPhase = await runSearchAcquisitionPhase({
+      context: inputData,
+      maxSearchCalls: limits.maxSearchCalls,
+      webTools: createTinyFishWebTools(),
+      metrics,
+      validationIssues,
+      debugNotes,
+    });
+    const acquisition = finalizeAcquisitionResult(
+      acquisitionPhase,
+      limits.maxFetchCalls
+    );
+    console.log(
+      `[acquire-sources] ${acquisition.prioritizedUrls.length} prioritized URL(s) from ${metrics.searchCalls} search(es)`
+    );
+    return {
+      context: inputData,
+      acquisition,
+      dataSpec: acquisitionPhase.dataSpec,
+    };
   },
 });
 
-const agentStep = createStep(populateAgent, { maxSteps: 80 });
+const populateStep = createStep({
+  id: "populate-dataset",
+  inputSchema: z.object({
+    context: datasetContextSchema,
+    acquisition: populateAcquisitionResultSchema,
+    dataSpec: z.any(),
+  }),
+  outputSchema: z.object({ text: z.string() }),
+  execute: async ({ inputData }) => {
+    const limits = resolvePopulateRuntimeLimits();
+    const metrics = {
+      searchCalls: 0,
+      fetchCalls: 0,
+      browserCalls: 0,
+      agentRuns: 0,
+      agentSteps: 0,
+    };
+    const validationIssues: string[] = [];
+    const debugNotes: string[] = [];
+
+    const memoryConfig = resolvePopulateCollectionMemoryConfig();
+    const collectionMemory = memoryConfig.enabled
+      ? new PopulateCollectionMemoryService({
+          datasetId: inputData.context.datasetId,
+          userPrompt: inputData.context.description,
+          memoryDir: memoryConfig.memoryDir,
+        })
+      : undefined;
+    if (collectionMemory) {
+      await collectionMemory.load();
+      debugNotes.push(
+        `Collection memory loaded (${collectionMemory.snapshot?.agent_visited_urls.length ?? 0} prior agent visit(s)).`
+      );
+    }
+
+    const result = await runParallelPopulatePhase({
+      context: inputData.context,
+      dataSpec: inputData.dataSpec,
+      acquisition: inputData.acquisition,
+      limits,
+      webTools: createTinyFishWebTools(),
+      metrics,
+      validationIssues,
+      debugNotes,
+      collectionMemory,
+    });
+
+    if (collectionMemory) {
+      await collectionMemory.save();
+      debugNotes.push("Collection memory saved.");
+    }
+
+    const { convex, internal } = await import("../../convex.js");
+    const columnKeyAliases = buildPopulateColumnKeyAliases(
+      inputData.dataSpec as DatasetSchema,
+      inputData.context
+    );
+    const replacement = await convex.mutation(internal.datasetRows.replaceByDataset, {
+      datasetId: inputData.context.datasetId,
+      rows: result.rows.map((row) => ({
+        data: normalizePopulateRowCellsForDataset(row.cells, columnKeyAliases),
+        sources: row.sourceUrls,
+      })),
+    });
+    console.log(
+      `[populate-dataset] Wrote ${replacement.insertedRowCount} row(s) to Convex (${result.validationIssues.length} validation note(s))`
+    );
+
+    return {
+      text: JSON.stringify({
+        rows: result.rows,
+        validationIssues: result.validationIssues,
+        metrics,
+        insertedRowCount: replacement.insertedRowCount,
+      }),
+    };
+  },
+});
 
 export const populateWorkflow = createWorkflow({
   id: "populate-workflow",
@@ -39,6 +159,6 @@ export const populateWorkflow = createWorkflow({
   outputSchema: z.object({ text: z.string() }),
 })
   .then(clearRowsStep)
-  .then(buildPromptStep)
-  .then(agentStep)
+  .then(acquireSourcesStep)
+  .then(populateStep)
   .commit();

--- a/backend/src/mastra/workflows/populate.ts
+++ b/backend/src/mastra/workflows/populate.ts
@@ -44,7 +44,7 @@ ${JSON.stringify(columnNames)}
 Example insert_row call:
 insert_row({ datasetId: "${inputData.datasetId}", data: { ${columnNames.map((n) => `"${n}": <value>`).join(", ")} } })
 
-Search the web for real data about this topic. Then call insert_row to fill in 10 rows. Use real data from your search. Fill in any gaps with realistic fake data.`;
+Search the web for real data about this topic. Then call insert_row for up to 10 source-backed rows. Never invent rows or cell values. If sources only support fewer than 10 rows, insert only the verified rows and explain what was missing.`;
 
     console.log(`[build-prompt] Built prompt for ${inputData.datasetName} (${inputData.columns.length} columns)`);
     return { prompt };

--- a/backend/src/mastra/workflows/populate.ts
+++ b/backend/src/mastra/workflows/populate.ts
@@ -121,11 +121,6 @@ const populateStep = createStep({
       collectionMemory,
     });
 
-    if (collectionMemory) {
-      await collectionMemory.save();
-      debugNotes.push("Collection memory saved.");
-    }
-
     const { convex, internal } = await import("../../convex.js");
     const columnKeyAliases = buildPopulateColumnKeyAliases(
       inputData.dataSpec as DatasetSchema,
@@ -141,6 +136,13 @@ const populateStep = createStep({
     console.log(
       `[populate-dataset] Wrote ${replacement.insertedRowCount} row(s) to Convex (${result.validationIssues.length} validation note(s))`
     );
+
+    if (collectionMemory) {
+      const saved = await collectionMemory.save();
+      debugNotes.push(
+        saved ? "Collection memory saved." : "Collection memory not persisted (see server log)."
+      );
+    }
 
     return {
       text: JSON.stringify({

--- a/backend/src/openrouter-models.ts
+++ b/backend/src/openrouter-models.ts
@@ -1,0 +1,16 @@
+/** Schema inference keeps the higher-quality default. */
+export const SCHEMA_INFERENCE_OPENROUTER_MODEL_ID = "anthropic/claude-sonnet-4-6";
+
+/** Populate, structured recovery, and other non-inference LLM tasks. */
+export const DEFAULT_OPENROUTER_MODEL_ID =
+  process.env.OPENROUTER_POPULATE_MODEL ??
+  process.env.OPENROUTER_MODEL ??
+  "google/gemini-3.1-flash-lite";
+
+export function requiredOpenRouterApiKey(): string {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) {
+    throw new Error("Missing required environment variable: OPENROUTER_API_KEY");
+  }
+  return apiKey;
+}

--- a/backend/src/pipeline/collection-agent-runner.ts
+++ b/backend/src/pipeline/collection-agent-runner.ts
@@ -24,6 +24,7 @@ interface CollectionPipelineOptions {
   enableRepair?: boolean;
   enableTriage?: boolean;
   enableTinyfishAgent?: boolean;
+  agentPollTimeoutMs?: number;
   benchmark?: {
     promptId?: string;
     promptQuality?: string;
@@ -97,7 +98,6 @@ export const runCollectionPopulatePipeline: CollectionPopulatePipelineRunner =
   async (input) => {
     const outputDir = await mkdtemp(join(tmpdir(), "bigset-collection-"));
     const enableTinyfishAgent = boolEnv("COLLECTION_AGENT_ENABLE_AGENT", false);
-    applyCollectionAgentRuntimeDefaults({ enableTinyfishAgent });
     const pipeline = await loadCollectionPipelineModule();
     const result = await pipeline.runPipeline({
       prompt: input.prompt,
@@ -107,6 +107,9 @@ export const runCollectionPopulatePipeline: CollectionPopulatePipelineRunner =
       enableRepair: boolEnv("COLLECTION_AGENT_ENABLE_REPAIR", false),
       enableTriage: boolEnv("COLLECTION_AGENT_ENABLE_TRIAGE", true),
       enableTinyfishAgent,
+      agentPollTimeoutMs: enableTinyfishAgent
+        ? collectionAgentPollTimeoutMs()
+        : undefined,
       benchmark: benchmarkContextFromInput(input),
       onLog: (stage, message) => {
         console.error(`[collection:${stage}] ${message}`);
@@ -312,21 +315,6 @@ function boolEnv(name: string, fallback: boolean): boolean {
   return ["1", "true", "yes", "on"].includes(raw.toLowerCase());
 }
 
-function applyCollectionAgentRuntimeDefaults(input: {
-  enableTinyfishAgent: boolean;
-}): void {
-  if (!input.enableTinyfishAgent || process.env.AGENT_POLL_TIMEOUT_MS) {
-    return;
-  }
-
-  process.env.AGENT_POLL_TIMEOUT_MS = String(
-    intEnv(
-      "COLLECTION_AGENT_POLL_TIMEOUT_MS",
-      DEFAULT_COLLECTION_AGENT_POLL_TIMEOUT_MS
-    )
-  );
-}
-
 function intEnv(name: string, fallback: number): number {
   const raw = process.env[name];
   if (raw === undefined || raw === "") {
@@ -337,4 +325,24 @@ function intEnv(name: string, fallback: number): number {
     throw new Error(`Invalid ${name}: expected positive integer, got "${raw}"`);
   }
   return value;
+}
+
+function optionalIntEnv(name: string): number | undefined {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") {
+    return undefined;
+  }
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`Invalid ${name}: expected positive integer, got "${raw}"`);
+  }
+  return value;
+}
+
+function collectionAgentPollTimeoutMs(): number {
+  return optionalIntEnv("AGENT_POLL_TIMEOUT_MS") ??
+    intEnv(
+      "COLLECTION_AGENT_POLL_TIMEOUT_MS",
+      DEFAULT_COLLECTION_AGENT_POLL_TIMEOUT_MS
+    );
 }

--- a/backend/src/pipeline/collection-agent-runner.ts
+++ b/backend/src/pipeline/collection-agent-runner.ts
@@ -1,0 +1,311 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import type {
+  CollectionPopulatePipelineInput,
+  CollectionPopulatePipelineRunner,
+} from "./populate-collection-runtime.js";
+import type {
+  PopulateCellValue,
+  PopulateRuntimeResult,
+} from "./populate-runtime.js";
+
+type CollectionPipelineModule = {
+  runPipeline(input: CollectionPipelineOptions): Promise<CollectionPipelineResult>;
+};
+
+interface CollectionPipelineOptions {
+  prompt: string;
+  targetRows: number;
+  outputDir: string;
+  memoryDir?: string;
+  enableRepair?: boolean;
+  enableTriage?: boolean;
+  enableTinyfishAgent?: boolean;
+  benchmark?: {
+    promptId?: string;
+    promptQuality?: string;
+    persona?: string;
+    expectedStress?: string;
+    requiredColumns: string[];
+  };
+  onLog?: (stage: string, message: string) => void;
+}
+
+interface CollectionPipelineResult {
+  report: {
+    errors?: string[];
+    dataset_spec?: CollectionDatasetSpec;
+    stats?: CollectionPhaseStats;
+    initial?: CollectionPhaseStats;
+    repair?: {
+      stats?: CollectionPhaseStats;
+    };
+    quality?: {
+      records?: CollectionRecordQuality[];
+    };
+    llm_usage?: {
+      prompt_tokens?: number;
+      completion_tokens?: number;
+      total_tokens?: number;
+    };
+  };
+  records?: CollectionExtractedRecord[];
+  visualizationRecords?: CollectionExtractedRecord[];
+  llmUsage?: {
+    promptTokens?: number;
+    completionTokens?: number;
+    totalTokens?: number;
+  };
+}
+
+interface CollectionDatasetSpec {
+  columns?: Array<{ name: string }>;
+  dedupe_keys?: string[];
+}
+
+interface CollectionPhaseStats {
+  search_queries_executed?: number;
+  pages_fetched?: number;
+  triage?: {
+    agent_dispatched?: number;
+    agent_succeeded?: number;
+    agent_failed?: number;
+  };
+}
+
+interface CollectionExtractedRecord {
+  row?: Record<string, PopulateCellValue>;
+  source_urls?: string[];
+  evidence?: Array<{
+    field?: string;
+    url?: string;
+    quote?: string;
+  }>;
+}
+
+interface CollectionRecordQuality {
+  record_id?: string;
+  needs_review?: boolean;
+}
+
+export const runCollectionPopulatePipeline: CollectionPopulatePipelineRunner =
+  async (input) => {
+    const outputDir = await mkdtemp(join(tmpdir(), "bigset-collection-"));
+    const pipeline = await loadCollectionPipelineModule();
+    const result = await pipeline.runPipeline({
+      prompt: input.prompt,
+      targetRows: input.targetRows,
+      outputDir,
+      memoryDir: join(outputDir, "memory"),
+      enableRepair: boolEnv("COLLECTION_AGENT_ENABLE_REPAIR", false),
+      enableTriage: boolEnv("COLLECTION_AGENT_ENABLE_TRIAGE", true),
+      enableTinyfishAgent: boolEnv("COLLECTION_AGENT_ENABLE_AGENT", true),
+      benchmark: benchmarkContextFromInput(input),
+      onLog: (stage, message) => {
+        console.error(`[collection:${stage}] ${message}`);
+      },
+    });
+
+    return collectionPipelineResultToPopulateRuntimeResult({
+      pipeline: result,
+      requiredColumns: input.requiredColumns,
+    });
+  };
+
+async function loadCollectionPipelineModule(): Promise<CollectionPipelineModule> {
+  const moduleSpecifier =
+    process.env.COLLECTION_AGENT_PIPELINE_MODULE ??
+    new URL(
+      "../../BigSet_Data_Collection_Agent/src/orchestrator/pipeline.ts",
+      import.meta.url
+    ).href;
+  const moduleUrl = moduleSpecifier.startsWith(".") || moduleSpecifier.startsWith("/")
+    ? pathToFileURL(resolve(moduleSpecifier)).href
+    : moduleSpecifier;
+  const loadedModule = await import(moduleUrl);
+  if (typeof loadedModule.runPipeline !== "function") {
+    throw new Error(
+      `${moduleSpecifier} must export runPipeline(options).`
+    );
+  }
+  return loadedModule as CollectionPipelineModule;
+}
+
+function benchmarkContextFromInput(input: CollectionPopulatePipelineInput) {
+  if (input.requiredColumns.length === 0) {
+    return undefined;
+  }
+  return {
+    promptId: input.promptId,
+    promptQuality: input.promptQuality,
+    persona: input.persona,
+    expectedStress: input.expectedStress,
+    requiredColumns: input.requiredColumns,
+  };
+}
+
+function collectionPipelineResultToPopulateRuntimeResult(input: {
+  pipeline: CollectionPipelineResult;
+  requiredColumns: string[];
+}): PopulateRuntimeResult {
+  const records = selectOutputRecords(input.pipeline);
+  const qualityById = qualityByRecordId(input.pipeline.report.quality?.records);
+  const rows = records.map((record) =>
+    collectionRecordToPopulateRow({
+      record,
+      spec: input.pipeline.report.dataset_spec,
+      requiredColumns: input.requiredColumns,
+      qualityById,
+    })
+  );
+
+  return {
+    rows,
+    validationIssues: [
+      ...(input.pipeline.report.errors ?? []),
+      ...(rows.length === 0 ? ["No rows returned from collection pipeline."] : []),
+    ],
+    usage: usageFromPipeline(input.pipeline),
+    metrics: metricsFromReport(input.pipeline.report),
+  };
+}
+
+function selectOutputRecords(
+  pipeline: CollectionPipelineResult
+): CollectionExtractedRecord[] {
+  if (pipeline.visualizationRecords && pipeline.visualizationRecords.length > 0) {
+    return pipeline.visualizationRecords;
+  }
+  return pipeline.records ?? [];
+}
+
+function collectionRecordToPopulateRow(input: {
+  record: CollectionExtractedRecord;
+  spec?: CollectionDatasetSpec;
+  requiredColumns: string[];
+  qualityById: Map<string, CollectionRecordQuality>;
+}) {
+  const cells: Record<string, PopulateCellValue> = {
+    ...(input.record.row ?? {}),
+  };
+  for (const columnName of input.requiredColumns) {
+    if (cells[columnName] === undefined) {
+      cells[columnName] = null;
+    }
+  }
+
+  const sourceUrls = uniqueHttpUrls(input.record.source_urls ?? []);
+  const evidence = (input.record.evidence ?? [])
+    .map((item) => ({
+      columnName: item.field ?? "",
+      sourceUrl: item.url || sourceUrls[0] || "",
+      quote: item.quote ?? "",
+    }))
+    .filter((item) => item.columnName && item.quote);
+  const recordId = canonicalRecordId(input.record, input.spec);
+  const quality = recordId ? input.qualityById.get(recordId) : undefined;
+
+  return {
+    cells,
+    sourceUrls,
+    evidence,
+    needsReview: quality?.needs_review ?? false,
+  };
+}
+
+function qualityByRecordId(
+  records: CollectionRecordQuality[] = []
+): Map<string, CollectionRecordQuality> {
+  return new Map(
+    records
+      .filter((record) => record.record_id)
+      .map((record) => [record.record_id as string, record])
+  );
+}
+
+function canonicalRecordId(
+  record: CollectionExtractedRecord,
+  spec?: CollectionDatasetSpec
+): string | undefined {
+  const primaryKey =
+    spec?.dedupe_keys?.[0] ??
+    spec?.columns?.find((column) =>
+      /(name|title|company|organization|entity)/i.test(column.name)
+    )?.name ??
+    spec?.columns?.[0]?.name;
+  if (!primaryKey) {
+    return undefined;
+  }
+  const value = normalizePrimaryKey(record.row?.[primaryKey]);
+  return value ? `pk:${value}` : undefined;
+}
+
+function usageFromPipeline(pipeline: CollectionPipelineResult) {
+  const scopedUsage = pipeline.llmUsage;
+  if (scopedUsage?.totalTokens) {
+    return {
+      promptTokens: scopedUsage.promptTokens ?? 0,
+      completionTokens: scopedUsage.completionTokens ?? 0,
+      totalTokens: scopedUsage.totalTokens ?? 0,
+    };
+  }
+  const reportUsage = pipeline.report.llm_usage;
+  return {
+    promptTokens: reportUsage?.prompt_tokens ?? 0,
+    completionTokens: reportUsage?.completion_tokens ?? 0,
+    totalTokens: reportUsage?.total_tokens ?? 0,
+  };
+}
+
+function metricsFromReport(report: CollectionPipelineResult["report"]) {
+  const stats = report.stats ?? {};
+  const initialTriage = report.initial?.triage ?? {};
+  const statsTriage = stats.triage ?? {};
+  const repairTriage = report.repair?.stats?.triage ?? {};
+  const agentDispatched =
+    numberValue(statsTriage.agent_dispatched) ||
+    numberValue(initialTriage.agent_dispatched) +
+      numberValue(repairTriage.agent_dispatched);
+
+  return {
+    searchCalls: numberValue(stats.search_queries_executed),
+    fetchCalls: numberValue(stats.pages_fetched),
+    browserCalls: agentDispatched,
+    agentRuns: agentDispatched > 0 ? agentDispatched : 1,
+    agentSteps:
+      numberValue(statsTriage.agent_succeeded) +
+      numberValue(statsTriage.agent_failed) +
+      numberValue(repairTriage.agent_succeeded) +
+      numberValue(repairTriage.agent_failed),
+  };
+}
+
+function uniqueHttpUrls(urls: string[]): string[] {
+  return Array.from(
+    new Set(
+      urls.filter((url) => typeof url === "string" && /^https?:\/\//i.test(url))
+    )
+  );
+}
+
+function normalizePrimaryKey(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  return String(value).trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function numberValue(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function boolEnv(name: string, fallback: boolean): boolean {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") {
+    return fallback;
+  }
+  return ["1", "true", "yes", "on"].includes(raw.toLowerCase());
+}

--- a/backend/src/pipeline/collection-agent-runner.ts
+++ b/backend/src/pipeline/collection-agent-runner.ts
@@ -91,9 +91,13 @@ interface CollectionRecordQuality {
   needs_review?: boolean;
 }
 
+const DEFAULT_COLLECTION_AGENT_POLL_TIMEOUT_MS = 480_000;
+
 export const runCollectionPopulatePipeline: CollectionPopulatePipelineRunner =
   async (input) => {
     const outputDir = await mkdtemp(join(tmpdir(), "bigset-collection-"));
+    const enableTinyfishAgent = boolEnv("COLLECTION_AGENT_ENABLE_AGENT", false);
+    applyCollectionAgentRuntimeDefaults({ enableTinyfishAgent });
     const pipeline = await loadCollectionPipelineModule();
     const result = await pipeline.runPipeline({
       prompt: input.prompt,
@@ -102,7 +106,7 @@ export const runCollectionPopulatePipeline: CollectionPopulatePipelineRunner =
       memoryDir: join(outputDir, "memory"),
       enableRepair: boolEnv("COLLECTION_AGENT_ENABLE_REPAIR", false),
       enableTriage: boolEnv("COLLECTION_AGENT_ENABLE_TRIAGE", true),
-      enableTinyfishAgent: boolEnv("COLLECTION_AGENT_ENABLE_AGENT", true),
+      enableTinyfishAgent,
       benchmark: benchmarkContextFromInput(input),
       onLog: (stage, message) => {
         console.error(`[collection:${stage}] ${message}`);
@@ -306,4 +310,31 @@ function boolEnv(name: string, fallback: boolean): boolean {
     return fallback;
   }
   return ["1", "true", "yes", "on"].includes(raw.toLowerCase());
+}
+
+function applyCollectionAgentRuntimeDefaults(input: {
+  enableTinyfishAgent: boolean;
+}): void {
+  if (!input.enableTinyfishAgent || process.env.AGENT_POLL_TIMEOUT_MS) {
+    return;
+  }
+
+  process.env.AGENT_POLL_TIMEOUT_MS = String(
+    intEnv(
+      "COLLECTION_AGENT_POLL_TIMEOUT_MS",
+      DEFAULT_COLLECTION_AGENT_POLL_TIMEOUT_MS
+    )
+  );
+}
+
+function intEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") {
+    return fallback;
+  }
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`Invalid ${name}: expected positive integer, got "${raw}"`);
+  }
+  return value;
 }

--- a/backend/src/pipeline/collection-agent-runner.ts
+++ b/backend/src/pipeline/collection-agent-runner.ts
@@ -116,12 +116,12 @@ export const runCollectionPopulatePipeline: CollectionPopulatePipelineRunner =
   };
 
 async function loadCollectionPipelineModule(): Promise<CollectionPipelineModule> {
-  const moduleSpecifier =
-    process.env.COLLECTION_AGENT_PIPELINE_MODULE ??
-    new URL(
-      "../../BigSet_Data_Collection_Agent/src/orchestrator/pipeline.ts",
-      import.meta.url
-    ).href;
+  const moduleSpecifier = process.env.COLLECTION_AGENT_PIPELINE_MODULE;
+  if (!moduleSpecifier) {
+    throw new Error(
+      "COLLECTION_AGENT_PIPELINE_MODULE must point to the collection pipeline module exporting runPipeline(options)."
+    );
+  }
   const moduleUrl = moduleSpecifier.startsWith(".") || moduleSpecifier.startsWith("/")
     ? pathToFileURL(resolve(moduleSpecifier)).href
     : moduleSpecifier;
@@ -263,10 +263,8 @@ function usageFromPipeline(pipeline: CollectionPipelineResult) {
 function metricsFromReport(report: CollectionPipelineResult["report"]) {
   const stats = report.stats ?? {};
   const initialTriage = report.initial?.triage ?? {};
-  const statsTriage = stats.triage ?? {};
   const repairTriage = report.repair?.stats?.triage ?? {};
   const agentDispatched =
-    numberValue(statsTriage.agent_dispatched) ||
     numberValue(initialTriage.agent_dispatched) +
       numberValue(repairTriage.agent_dispatched);
 
@@ -274,10 +272,10 @@ function metricsFromReport(report: CollectionPipelineResult["report"]) {
     searchCalls: numberValue(stats.search_queries_executed),
     fetchCalls: numberValue(stats.pages_fetched),
     browserCalls: agentDispatched,
-    agentRuns: agentDispatched > 0 ? agentDispatched : 1,
+    agentRuns: agentDispatched,
     agentSteps:
-      numberValue(statsTriage.agent_succeeded) +
-      numberValue(statsTriage.agent_failed) +
+      numberValue(initialTriage.agent_succeeded) +
+      numberValue(initialTriage.agent_failed) +
       numberValue(repairTriage.agent_succeeded) +
       numberValue(repairTriage.agent_failed),
   };

--- a/backend/src/pipeline/collection-agent-runner.ts
+++ b/backend/src/pipeline/collection-agent-runner.ts
@@ -47,6 +47,7 @@ interface CollectionPipelineResult {
     quality?: {
       records?: CollectionRecordQuality[];
     };
+    sources?: CollectionSourcesReport;
     llm_usage?: {
       prompt_tokens?: number;
       completion_tokens?: number;
@@ -92,6 +93,21 @@ interface CollectionRecordQuality {
   needs_review?: boolean;
 }
 
+interface CollectionSourcesReport {
+  outcomes?: CollectionSourceOutcome[];
+}
+
+interface CollectionSourceOutcome {
+  outcome?: string;
+  triage_status?: string;
+}
+
+const AGENT_REQUIRED_TRIAGE_STATUSES = new Set([
+  "requires_navigation",
+  "requires_form_submission",
+  "requires_detail_page_followup",
+]);
+
 const DEFAULT_COLLECTION_AGENT_POLL_TIMEOUT_MS = 480_000;
 
 export const runCollectionPopulatePipeline: CollectionPopulatePipelineRunner =
@@ -119,6 +135,7 @@ export const runCollectionPopulatePipeline: CollectionPopulatePipelineRunner =
     return collectionPipelineResultToPopulateRuntimeResult({
       pipeline: result,
       requiredColumns: input.requiredColumns,
+      enableTinyfishAgent,
     });
   };
 
@@ -157,6 +174,7 @@ function benchmarkContextFromInput(input: CollectionPopulatePipelineInput) {
 function collectionPipelineResultToPopulateRuntimeResult(input: {
   pipeline: CollectionPipelineResult;
   requiredColumns: string[];
+  enableTinyfishAgent: boolean;
 }): PopulateRuntimeResult {
   const records = selectOutputRecords(input.pipeline);
   const qualityById = qualityByRecordId(input.pipeline.report.quality?.records);
@@ -168,16 +186,57 @@ function collectionPipelineResultToPopulateRuntimeResult(input: {
       qualityById,
     })
   );
+  const capabilityDiagnostics = capabilityDiagnosticsFromReport({
+    report: input.pipeline.report,
+    enableTinyfishAgent: input.enableTinyfishAgent,
+  });
 
   return {
     rows,
     validationIssues: [
       ...(input.pipeline.report.errors ?? []),
+      ...capabilityDiagnostics,
       ...(rows.length === 0 ? ["No rows returned from collection pipeline."] : []),
     ],
     usage: usageFromPipeline(input.pipeline),
     metrics: metricsFromReport(input.pipeline.report),
   };
+}
+
+function capabilityDiagnosticsFromReport(input: {
+  report: CollectionPipelineResult["report"];
+  enableTinyfishAgent: boolean;
+}): string[] {
+  if (input.enableTinyfishAgent) {
+    return [];
+  }
+  const agentRequiredOutcomes = (input.report.sources?.outcomes ?? []).filter(
+    isAgentRequiredSourceOutcome
+  );
+  if (agentRequiredOutcomes.length === 0) {
+    return [];
+  }
+
+  const statusCounts = new Map<string, number>();
+  for (const outcome of agentRequiredOutcomes) {
+    const status = outcome.triage_status as string;
+    statusCounts.set(status, (statusCounts.get(status) ?? 0) + 1);
+  }
+  const statusSummary = Array.from(statusCounts.entries())
+    .map(([status, count]) => `${status}=${count}`)
+    .join(", ");
+
+  return [
+    `Capability diagnostic: TinyFish Agent disabled; triage requested browser/form/detail follow-up for ${agentRequiredOutcomes.length} page(s) (${statusSummary}). Enable COLLECTION_AGENT_ENABLE_AGENT=true for live navigation.`,
+  ];
+}
+
+function isAgentRequiredSourceOutcome(outcome: CollectionSourceOutcome): boolean {
+  return (
+    typeof outcome.triage_status === "string" &&
+    AGENT_REQUIRED_TRIAGE_STATUSES.has(outcome.triage_status) &&
+    outcome.outcome !== "success"
+  );
 }
 
 function selectOutputRecords(

--- a/backend/src/pipeline/collection-memory/fingerprint.ts
+++ b/backend/src/pipeline/collection-memory/fingerprint.ts
@@ -1,0 +1,6 @@
+import { createHash } from "node:crypto";
+
+export function promptFingerprint(prompt: string): string {
+  const normalized = prompt.trim().toLowerCase().replace(/\s+/g, " ");
+  return createHash("sha256").update(normalized).digest("hex").slice(0, 16);
+}

--- a/backend/src/pipeline/collection-memory/index.ts
+++ b/backend/src/pipeline/collection-memory/index.ts
@@ -1,0 +1,27 @@
+export { promptFingerprint } from "./fingerprint.js";
+export {
+  createEmptyCollectionMemory,
+  collectionMemoryPath,
+  findLatestAgentVisit,
+  latestTinyfishEmittedProcess,
+  loadCollectionMemory,
+  saveCollectionMemory,
+} from "./store.js";
+export {
+  markRepairLoopPending,
+  patchRepairLoopState,
+  recordAgentVisitedUrl,
+} from "./mutations.js";
+export { PopulateCollectionMemoryService } from "./service.js";
+export {
+  agentVisitedUrlEntrySchema,
+  browserAgentProviderSchema,
+  populateCollectionMemorySchema,
+  repairLoopStateSchema,
+} from "./types.js";
+export type {
+  AgentVisitedUrlEntry,
+  BrowserAgentProvider,
+  PopulateCollectionMemory,
+  RepairLoopState,
+} from "./types.js";

--- a/backend/src/pipeline/collection-memory/mutations.ts
+++ b/backend/src/pipeline/collection-memory/mutations.ts
@@ -1,0 +1,80 @@
+import type { PopulateSourceTriageResult } from "../types.js";
+import { extractEmittedProcessFromAgentResult } from "../populate-browser-agent.js";
+import type { BrowserAgentRunResult } from "../populate-browser-agent.js";
+import type {
+  AgentVisitedUrlEntry,
+  BrowserAgentProvider,
+  PopulateCollectionMemory,
+  RepairLoopState,
+} from "./types.js";
+
+export function recordAgentVisitedUrl(
+  memory: PopulateCollectionMemory,
+  input: {
+    url: string;
+    finalUrl?: string;
+    provider: BrowserAgentProvider;
+    goal: string;
+    run: BrowserAgentRunResult;
+    repairLoop?: number;
+    triage?: PopulateSourceTriageResult;
+  }
+): PopulateCollectionMemory {
+  const emittedProcess =
+    input.provider === "tinyfish"
+      ? extractEmittedProcessFromAgentResult(input.run.result)
+      : input.run.result
+        ? extractEmittedProcessFromAgentResult(input.run.result)
+        : undefined;
+
+  const entry: AgentVisitedUrlEntry = {
+    url: input.url,
+    final_url: input.finalUrl,
+    repair_loop: input.repairLoop ?? memory.repair_loop.current_loop,
+    provider: input.provider,
+    goal: input.goal,
+    run_id: input.run.run_id,
+    status: input.run.status,
+    visited_at: new Date().toISOString(),
+    error: input.run.error,
+    emitted_process: emittedProcess,
+    triage_status: input.triage?.status,
+    suggested_action: input.triage?.suggested_action,
+  };
+
+  return {
+    ...memory,
+    agent_visited_urls: [...memory.agent_visited_urls, entry],
+    updated_at: new Date().toISOString(),
+  };
+}
+
+/** Reserved for the future repair loop — updates metadata only. */
+export function markRepairLoopPending(memory: PopulateCollectionMemory): PopulateCollectionMemory {
+  return {
+    ...memory,
+    repair_loop: {
+      ...memory.repair_loop,
+      status: "pending",
+      notes: [
+        ...memory.repair_loop.notes,
+        "Repair loop scheduled (not implemented in populate pipeline yet).",
+      ],
+    },
+    updated_at: new Date().toISOString(),
+  };
+}
+
+export function patchRepairLoopState(
+  memory: PopulateCollectionMemory,
+  patch: Partial<RepairLoopState>
+): PopulateCollectionMemory {
+  return {
+    ...memory,
+    repair_loop: {
+      ...memory.repair_loop,
+      ...patch,
+    },
+    updated_at: new Date().toISOString(),
+  };
+}

--- a/backend/src/pipeline/collection-memory/mutations.ts
+++ b/backend/src/pipeline/collection-memory/mutations.ts
@@ -27,9 +27,12 @@ export function recordAgentVisitedUrl(
         ? extractEmittedProcessFromAgentResult(input.run.result)
         : undefined;
 
+  const finalUrl =
+    input.finalUrl && input.finalUrl !== input.url ? input.finalUrl : undefined;
+
   const entry: AgentVisitedUrlEntry = {
     url: input.url,
-    final_url: input.finalUrl,
+    final_url: finalUrl,
     repair_loop: input.repairLoop ?? memory.repair_loop.current_loop,
     provider: input.provider,
     goal: input.goal,
@@ -37,7 +40,7 @@ export function recordAgentVisitedUrl(
     status: input.run.status,
     visited_at: new Date().toISOString(),
     error: input.run.error,
-    emitted_process: emittedProcess,
+    emitted_process: cloneJsonRecord(emittedProcess),
     triage_status: input.triage?.status,
     suggested_action: input.triage?.suggested_action,
   };
@@ -63,6 +66,19 @@ export function markRepairLoopPending(memory: PopulateCollectionMemory): Populat
     },
     updated_at: new Date().toISOString(),
   };
+}
+
+function cloneJsonRecord(
+  value: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (!value) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+  } catch {
+    return { capture_error: "non_serializable_emitted_process" };
+  }
 }
 
 export function patchRepairLoopState(

--- a/backend/src/pipeline/collection-memory/service.ts
+++ b/backend/src/pipeline/collection-memory/service.ts
@@ -1,0 +1,64 @@
+import {
+  createEmptyCollectionMemory,
+  loadCollectionMemory,
+  saveCollectionMemory,
+} from "./store.js";
+import { recordAgentVisitedUrl } from "./mutations.js";
+import type { PopulateCollectionMemory } from "./types.js";
+import type { PopulateSourceTriageResult } from "../types.js";
+import type { BrowserAgentRunResult } from "../populate-browser-agent.js";
+import type { BrowserAgentProvider } from "./types.js";
+import { resolvePopulateCollectionMemoryConfig } from "../populate-collection-memory-config.js";
+
+export class PopulateCollectionMemoryService {
+  private memory: PopulateCollectionMemory | null = null;
+
+  constructor(
+    private readonly input: {
+      datasetId: string;
+      userPrompt: string;
+      memoryDir?: string;
+    }
+  ) {}
+
+  get snapshot(): PopulateCollectionMemory | null {
+    return this.memory;
+  }
+
+  async load(): Promise<PopulateCollectionMemory> {
+    const config = resolvePopulateCollectionMemoryConfig();
+    const memoryDir = this.input.memoryDir ?? config.memoryDir;
+    const existing = await loadCollectionMemory(memoryDir, this.input.datasetId);
+    this.memory =
+      existing ??
+      createEmptyCollectionMemory({
+        datasetId: this.input.datasetId,
+        userPrompt: this.input.userPrompt,
+        maxRepairLoops: config.maxRepairLoops,
+      });
+    return this.memory;
+  }
+
+  async save(): Promise<void> {
+    if (!this.memory) {
+      return;
+    }
+    const config = resolvePopulateCollectionMemoryConfig();
+    const memoryDir = this.input.memoryDir ?? config.memoryDir;
+    await saveCollectionMemory(memoryDir, this.memory);
+  }
+
+  recordAgentVisit(input: {
+    url: string;
+    finalUrl?: string;
+    provider: BrowserAgentProvider;
+    goal: string;
+    run: BrowserAgentRunResult;
+    triage?: PopulateSourceTriageResult;
+  }): void {
+    if (!this.memory) {
+      throw new Error("PopulateCollectionMemoryService.load() must be called first");
+    }
+    this.memory = recordAgentVisitedUrl(this.memory, input);
+  }
+}

--- a/backend/src/pipeline/collection-memory/service.ts
+++ b/backend/src/pipeline/collection-memory/service.ts
@@ -39,13 +39,23 @@ export class PopulateCollectionMemoryService {
     return this.memory;
   }
 
-  async save(): Promise<void> {
+  /** Best-effort persistence — populate must succeed even if disk is unavailable. */
+  async save(): Promise<boolean> {
     if (!this.memory) {
-      return;
+      return false;
     }
     const config = resolvePopulateCollectionMemoryConfig();
     const memoryDir = this.input.memoryDir ?? config.memoryDir;
-    await saveCollectionMemory(memoryDir, this.memory);
+    try {
+      await saveCollectionMemory(memoryDir, this.memory);
+      return true;
+    } catch (error) {
+      console.warn(
+        `[collection-memory] Failed to persist memory for dataset ${this.input.datasetId}:`,
+        error instanceof Error ? error.message : error
+      );
+      return false;
+    }
   }
 
   recordAgentVisit(input: {

--- a/backend/src/pipeline/collection-memory/store.ts
+++ b/backend/src/pipeline/collection-memory/store.ts
@@ -1,0 +1,90 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { promptFingerprint } from "./fingerprint.js";
+import {
+  populateCollectionMemorySchema,
+  repairLoopStateSchema,
+  type AgentVisitedUrlEntry,
+  type PopulateCollectionMemory,
+  type RepairLoopState,
+} from "./types.js";
+
+export function collectionMemoryPath(memoryDir: string, datasetId: string): string {
+  return join(memoryDir, `${datasetId}.json`);
+}
+
+export function createEmptyCollectionMemory(input: {
+  datasetId: string;
+  userPrompt: string;
+  maxRepairLoops?: number;
+}): PopulateCollectionMemory {
+  const now = new Date().toISOString();
+  return populateCollectionMemorySchema.parse({
+    version: 1,
+    dataset_id: input.datasetId,
+    prompt_fingerprint: promptFingerprint(input.userPrompt),
+    user_prompt: input.userPrompt,
+    repair_loop: repairLoopStateSchema.parse({
+      current_loop: 0,
+      max_loops: input.maxRepairLoops ?? 3,
+      status: "idle",
+      notes: [],
+    }),
+    agent_visited_urls: [],
+    updated_at: now,
+  });
+}
+
+export async function loadCollectionMemory(
+  memoryDir: string,
+  datasetId: string
+): Promise<PopulateCollectionMemory | null> {
+  try {
+    const raw = JSON.parse(
+      await readFile(collectionMemoryPath(memoryDir, datasetId), "utf8")
+    ) as unknown;
+    return populateCollectionMemorySchema.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+export async function saveCollectionMemory(
+  memoryDir: string,
+  memory: PopulateCollectionMemory
+): Promise<void> {
+  await mkdir(memoryDir, { recursive: true });
+  const payload: PopulateCollectionMemory = {
+    ...memory,
+    updated_at: new Date().toISOString(),
+  };
+  await writeFile(
+    collectionMemoryPath(memoryDir, memory.dataset_id),
+    `${JSON.stringify(payload, null, 2)}\n`,
+    "utf8"
+  );
+}
+
+export function findLatestAgentVisit(
+  memory: PopulateCollectionMemory,
+  url: string,
+  provider?: AgentVisitedUrlEntry["provider"]
+): AgentVisitedUrlEntry | undefined {
+  const normalized = url.trim();
+  const matches = memory.agent_visited_urls.filter((entry) => {
+    if (provider && entry.provider !== provider) {
+      return false;
+    }
+    return entry.url === normalized || entry.final_url === normalized;
+  });
+  return matches.at(-1);
+}
+
+export function latestTinyfishEmittedProcess(
+  memory: PopulateCollectionMemory,
+  url: string
+): Record<string, unknown> | undefined {
+  const visit = findLatestAgentVisit(memory, url, "tinyfish");
+  return visit?.emitted_process;
+}

--- a/backend/src/pipeline/collection-memory/types.ts
+++ b/backend/src/pipeline/collection-memory/types.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+/** Placeholder for a future quality-driven repair pass (not executed yet). */
+export const repairLoopStateSchema = z.object({
+  current_loop: z.number().int().nonnegative(),
+  max_loops: z.number().int().positive(),
+  status: z.enum(["idle", "pending", "running", "completed"]),
+  last_started_at: z.string().datetime().optional(),
+  last_completed_at: z.string().datetime().optional(),
+  notes: z.array(z.string()).default([]),
+});
+
+export type RepairLoopState = z.infer<typeof repairLoopStateSchema>;
+
+export const browserAgentProviderSchema = z.enum(["tinyfish", "playwright"]);
+
+export type BrowserAgentProvider = z.infer<typeof browserAgentProviderSchema>;
+
+/** One browser-agent visit (Tinyfish today; Playwright when plugged in). */
+export const agentVisitedUrlEntrySchema = z.object({
+  url: z.string().url(),
+  final_url: z.string().url().optional(),
+  repair_loop: z.number().int().nonnegative(),
+  provider: browserAgentProviderSchema,
+  goal: z.string(),
+  run_id: z.string().nullable().optional(),
+  status: z.string(),
+  visited_at: z.string().datetime(),
+  error: z.string().nullable().optional(),
+  /** Raw Tinyfish run payload or normalized process steps for Playwright replay. */
+  emitted_process: z.record(z.string(), z.unknown()).optional(),
+  triage_status: z.string().optional(),
+  suggested_action: z.string().optional(),
+});
+
+export type AgentVisitedUrlEntry = z.infer<typeof agentVisitedUrlEntrySchema>;
+
+export const populateCollectionMemorySchema = z.object({
+  version: z.literal(1),
+  dataset_id: z.string().min(1),
+  prompt_fingerprint: z.string().min(1),
+  user_prompt: z.string(),
+  repair_loop: repairLoopStateSchema,
+  agent_visited_urls: z.array(agentVisitedUrlEntrySchema),
+  updated_at: z.string().datetime(),
+});
+
+export type PopulateCollectionMemory = z.infer<typeof populateCollectionMemorySchema>;

--- a/backend/src/pipeline/llm-usage.ts
+++ b/backend/src/pipeline/llm-usage.ts
@@ -1,0 +1,75 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { LanguageModelUsage } from "ai";
+
+/** Internal LLM usage totals (benchmarking / diagnostics only). */
+export interface LlmUsageTotals {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  callCount: number;
+}
+
+const storage = new AsyncLocalStorage<LlmUsageTotals>();
+
+export function emptyLlmUsage(): LlmUsageTotals {
+  return {
+    promptTokens: 0,
+    completionTokens: 0,
+    totalTokens: 0,
+    callCount: 0,
+  };
+}
+
+export async function runWithLlmUsageScope<T>(
+  fn: () => Promise<T>
+): Promise<{ result: T; usage: LlmUsageTotals }> {
+  const usage = emptyLlmUsage();
+  const result = await storage.run(usage, fn);
+  return { result, usage: { ...usage } };
+}
+
+export function getCurrentLlmUsage(): LlmUsageTotals {
+  return storage.getStore() ?? emptyLlmUsage();
+}
+
+export function recordLanguageModelUsage(usage: LanguageModelUsage | undefined): void {
+  const totals = storage.getStore();
+  if (!totals || !usage) {
+    return;
+  }
+
+  const promptTokens = usage.inputTokens ?? 0;
+  const completionTokens = usage.outputTokens ?? 0;
+  totals.promptTokens += promptTokens;
+  totals.completionTokens += completionTokens;
+  totals.totalTokens += usage.totalTokens ?? promptTokens + completionTokens;
+  totals.callCount += 1;
+}
+
+export function recordAgentGenerationUsage(agentOutput: unknown): void {
+  if (typeof agentOutput !== "object" || agentOutput === null) {
+    return;
+  }
+
+  const record = agentOutput as Record<string, unknown>;
+  const directUsage = record.usage;
+  if (directUsage && typeof directUsage === "object") {
+    recordLanguageModelUsage(directUsage as LanguageModelUsage);
+    return;
+  }
+
+  const totalUsage = record.totalUsage;
+  if (totalUsage && typeof totalUsage === "object") {
+    recordLanguageModelUsage(totalUsage as LanguageModelUsage);
+  }
+}
+
+export function toPopulateRuntimeUsage(
+  usage: LlmUsageTotals
+): { promptTokens: number; completionTokens: number; totalTokens: number } {
+  return {
+    promptTokens: usage.promptTokens,
+    completionTokens: usage.completionTokens,
+    totalTokens: usage.totalTokens,
+  };
+}

--- a/backend/src/pipeline/populate-acquisition-prompt.ts
+++ b/backend/src/pipeline/populate-acquisition-prompt.ts
@@ -1,0 +1,143 @@
+import type { DatasetContext } from "./populate.js";
+import type { DatasetSchema } from "./types.js";
+
+export const EXPECTATION_SCORE_RUBRIC = `expectation_score rubric (integer 1-5):
+
+5 — Very likely this page directly answers the user prompt and can supply concrete values for the dataset columns (e.g. official careers/pricing/docs page, product catalog, structured list). A researcher would open this first.
+
+4 — Likely useful: strong topical match; snippet/title suggests several column facts or an enumerable list is probably on the page.
+
+3 — Possible but uncertain: related to the topic, but unclear from title/snippet alone whether the page has extractable facts for the columns.
+
+2 — Weak match: tangential, news commentary, generic overview, Q&A thread, or aggregator with little structured data.
+
+1 — Very unlikely: unrelated, error/empty page, login wall, or private/ephemeral social posts (Instagram, X/Twitter, Facebook posts, TikTok, etc.) that are poor sources for a stable dataset.
+
+Score using only site_name, title, and snippet from search_web. Never invent URLs.`;
+
+export const searchAcquisitionAgentInstructions = `You are a research librarian gathering source pages for a structured dataset.
+
+Think like a researcher scanning search results before reading full pages: for each link, judge how likely it is to contain facts that answer the user prompt and fill the dataset columns.
+
+Rules:
+- Use search_web only. Never fetch pages.
+- Run the suggested initial queries, then keep searching with new keywords inspired by promising snippets (site:domain filters, entity aliases, column-specific terms) until the search budget is exhausted or coverage is strong.
+- Use as many search_web calls as the budget allows — more diverse searches produce better scored URLs.
+- Score every unique URL returned by search_web, using site_name, title, and snippet only.
+- Match the user prompt first, then each column's purpose in the data spec.
+- Return scored_urls with url and expectation_score for every unique URL you collected.
+- Do not rank, filter, omit URLs, or choose which links get fetched — the runtime applies limits after you return.
+
+Structured output (strict):
+- Follow the output schema exactly. Do not omit fields or leave values blank.
+- scored_urls must include one entry per unique URL from your search_web results; every url and expectation_score is required.
+- Use expectation_score 1–5 for each URL (never null or omitted).`;
+
+const LOW_TRUST_HOSTS = new Set([
+  "instagram.com",
+  "x.com",
+  "twitter.com",
+  "facebook.com",
+  "tiktok.com",
+  "threads.net",
+]);
+
+export function isLowTrustSourceUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.replace(/^www\./, "").toLowerCase();
+    if (LOW_TRUST_HOSTS.has(host)) {
+      return true;
+    }
+    return /\/(?:p|reel|status|posts)\//i.test(parsed.pathname);
+  } catch {
+    return false;
+  }
+}
+
+export function formatUserPromptBlock(context: DatasetContext): string {
+  return `User prompt (primary — score relevance to this first):
+${context.description.trim()}`;
+}
+
+export function formatDataSpecBlock(
+  context: DatasetContext,
+  dataSpec?: DatasetSchema
+): string {
+  if (dataSpec) {
+    const lines = [
+      `Dataset name: ${dataSpec.dataset_name}`,
+      `Spec description: ${dataSpec.description}`,
+      `Primary key column: ${dataSpec.primary_key}`,
+      "",
+      "Initial search queries (run all, then search more within the search budget):",
+      ...dataSpec.search_queries.map((query) => `- ${query}`),
+      "",
+      "Columns (what each field should capture on a page):",
+    ];
+
+    for (const column of dataSpec.columns) {
+      const pk = column.is_primary_key ? " [primary key]" : "";
+      const nullable = column.nullable ? "" : " [required]";
+      lines.push(
+        `- ${column.name} (${column.type}) — ${column.display_name}${pk}${nullable}`,
+        `  Description: ${column.description}`
+      );
+    }
+
+    return lines.join("\n");
+  }
+
+  const lines = [
+    `Dataset: ${context.datasetName}`,
+    "Columns (what each field should capture):",
+  ];
+
+  for (const column of context.columns) {
+    const desc = column.description?.trim();
+    lines.push(
+      `- ${column.name} (${column.type})${desc ? `: ${desc}` : ""}`
+    );
+  }
+
+  return lines.join("\n");
+}
+
+export function formatPopulateTaskForScoring(
+  context: DatasetContext,
+  dataSpec?: DatasetSchema
+): string {
+  return [
+    formatUserPromptBlock(context),
+    "",
+    formatDataSpecBlock(context, dataSpec),
+  ].join("\n");
+}
+
+export function buildSearchAcquisitionPrompt(
+  context: DatasetContext,
+  initialQueries: string[],
+  maxSearchCalls: number,
+  dataSpec?: DatasetSchema
+): string {
+  const taskBlock = formatPopulateTaskForScoring(context, dataSpec);
+
+  return `${taskBlock}
+
+Search budget: up to ${maxSearchCalls} search_web calls for this run.
+
+Workflow:
+1. Run every suggested initial query below (do not stop after only those).
+2. Review snippets from each batch, then issue follow-up searches with refined keywords (official domains, column-specific terms, alternate entity spellings) until the budget is exhausted or you have strong coverage.
+3. Score every unique URL from your search_web results before returning (one scored_urls entry per URL).
+
+Suggested initial queries (exactly ${initialQueries.length} — run all, then search more within the budget):
+${initialQueries.map((query) => `- ${query}`).join("\n")}
+
+Follow-up search ideas (use when snippets suggest gaps):
+- site: promising-domain.com + task keywords
+- "{entity}" + column-specific terms from the data spec
+- Alternate phrasing from strong snippets (product names, page types, fiscal periods)
+
+${EXPECTATION_SCORE_RUBRIC}`;
+}

--- a/backend/src/pipeline/populate-acquisition.ts
+++ b/backend/src/pipeline/populate-acquisition.ts
@@ -1,0 +1,338 @@
+import { createTool } from "@mastra/core/tools";
+import { Agent } from "@mastra/core/agent";
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import { z } from "zod";
+
+import { recordAgentGenerationUsage } from "./llm-usage.js";
+import { DEFAULT_OPENROUTER_MODEL_ID, requiredOpenRouterApiKey } from "../openrouter-models.js";
+import {
+  buildSearchAcquisitionPrompt,
+  searchAcquisitionAgentInstructions,
+} from "./populate-acquisition-prompt.js";
+import {
+  inferSchema,
+  resolvePopulateDataSpec,
+} from "./schema-inference.js";
+import type { DatasetContext } from "./populate.js";
+import {
+  acquisitionScoredUrlSchema,
+  populateAcquisitionResultSchema,
+  searchAcquisitionCompletionSchema,
+  type AcquisitionScoredUrl,
+  type AgentSearchScore,
+  type DatasetSchema,
+  type PopulateAcquisitionResult,
+} from "./types.js";
+import {
+  finalizePrioritizedSearchResults,
+  normalizeSearchResultUrl,
+  siteNameFromUrl,
+} from "./populate-search-prioritization.js";
+import type { PopulateRuntimeResult } from "./populate-runtime.js";
+import type {
+  PopulateRuntimeCapturedSource,
+  PopulateRuntimeWebTools,
+  PopulateWebSearchResult,
+} from "./populate-web-types.js";
+
+export type {
+  AcquisitionScoredUrl,
+  PopulateAcquisitionResult,
+} from "./types.js";
+export {
+  acquisitionScoredUrlSchema,
+  populateAcquisitionResultSchema,
+} from "./types.js";
+
+export type SearchAcquisitionPhaseResult = Pick<
+  PopulateAcquisitionResult,
+  "scoredUrls" | "initialQueries" | "validationIssues"
+> & {
+  dataSpec: DatasetSchema;
+  searchPoolResults: Array<{
+    title: string;
+    snippet?: string;
+    url: string;
+    site_name?: string;
+    search_query: string;
+  }>;
+};
+
+/** URLs the populate agent may fetch — capped fetch list, not the full acquisition pool. */
+export type PopulateFetchPlan = {
+  fetchUrls: AcquisitionScoredUrl[];
+};
+
+export function buildPopulateFetchPlan(
+  acquisition: PopulateAcquisitionResult
+): PopulateFetchPlan {
+  const scoreByUrl = new Map(
+    acquisition.scoredUrls.map((entry) => [
+      normalizeSearchResultUrl(entry.url),
+      entry,
+    ])
+  );
+
+  return {
+    fetchUrls: acquisition.prioritizedUrls.map((url) => {
+      const normalized = normalizeSearchResultUrl(url);
+      return (
+        scoreByUrl.get(normalized) ?? {
+          url: normalized,
+          expectation_score: 1,
+          search_query: "",
+        }
+      );
+    }),
+  };
+}
+
+interface PooledSearchResult extends PopulateWebSearchResult {
+  search_query: string;
+}
+
+export type SearchAcquisitionAgentRunner = (input: {
+  prompt: string;
+  tools: Record<string, unknown>;
+}) => Promise<unknown>;
+
+export function sortAcquisitionScoredUrls(
+  scoredUrls: AcquisitionScoredUrl[]
+): AcquisitionScoredUrl[] {
+  return [...scoredUrls].sort((a, b) => {
+    if (b.expectation_score !== a.expectation_score) {
+      return b.expectation_score - a.expectation_score;
+    }
+    return a.url.localeCompare(b.url);
+  });
+}
+
+export function buildPrioritizedFetchUrls(
+  scoredUrls: AcquisitionScoredUrl[],
+  fetchLimit: number
+): string[] {
+  return sortAcquisitionScoredUrls(scoredUrls)
+    .slice(0, fetchLimit)
+    .map((entry) => normalizeSearchResultUrl(entry.url));
+}
+
+export function captureScoredUrlsAsSources(
+  scoredUrls: AcquisitionScoredUrl[]
+): PopulateRuntimeCapturedSource[] {
+  return scoredUrls.map((entry) => ({
+    url: normalizeSearchResultUrl(entry.url),
+    text: [
+      `expectation_score: ${entry.expectation_score}`,
+      `search_query: ${entry.search_query}`,
+    ].join("\n"),
+  }));
+}
+
+export function finalizeAcquisitionResult(
+  phase: SearchAcquisitionPhaseResult,
+  fetchLimit: number
+): PopulateAcquisitionResult {
+  const scoredUrls = sortAcquisitionScoredUrls(phase.scoredUrls);
+  return {
+    initialQueries: phase.initialQueries,
+    validationIssues: phase.validationIssues,
+    scoredUrls,
+    prioritizedUrls: buildPrioritizedFetchUrls(scoredUrls, fetchLimit),
+  };
+}
+
+export function normalizePopulateAcquisitionResult(
+  acquisition: PopulateAcquisitionResult,
+  fetchLimit: number
+): PopulateAcquisitionResult {
+  return finalizeAcquisitionResult(acquisition, fetchLimit);
+}
+
+export async function runSearchAcquisitionPhase(input: {
+  context: DatasetContext;
+  dataSpec?: DatasetSchema;
+  maxSearchCalls: number;
+  webTools: PopulateRuntimeWebTools;
+  metrics: PopulateRuntimeResult["metrics"];
+  validationIssues: string[];
+  debugNotes: string[];
+  searchAcquisitionRunner?: SearchAcquisitionAgentRunner;
+  inferSchemaFn?: typeof inferSchema;
+}): Promise<SearchAcquisitionPhaseResult> {
+  const { dataSpec, initialQueries } = await resolvePopulateDataSpec({
+    prompt: input.context.description,
+    dataSpec: input.dataSpec,
+    maxSearchCalls: input.maxSearchCalls,
+    inferSchemaFn: input.inferSchemaFn,
+  });
+  const searchPool = new Map<string, PooledSearchResult>();
+  const tools = createSearchAcquisitionTools({
+    maxSearchCalls: input.maxSearchCalls,
+    webTools: input.webTools,
+    metrics: input.metrics,
+    validationIssues: input.validationIssues,
+    searchPool,
+  });
+  const prompt = buildSearchAcquisitionPrompt(
+    input.context,
+    initialQueries,
+    input.maxSearchCalls,
+    dataSpec
+  );
+
+  let agentOutput: unknown;
+  if (input.searchAcquisitionRunner) {
+    agentOutput = await input.searchAcquisitionRunner({ prompt, tools });
+    recordAgentGenerationUsage(agentOutput);
+    input.metrics.agentRuns += 1;
+  } else {
+    const agent = createSearchAcquisitionAgent({ tools });
+    agentOutput = await agent.generate(prompt, {
+      structuredOutput: {
+        schema: searchAcquisitionCompletionSchema,
+        jsonPromptInjection: true,
+        errorStrategy: "fallback",
+        fallbackValue: { scored_urls: [], validation_issues: [] },
+      },
+    });
+    recordAgentGenerationUsage(agentOutput);
+    input.metrics.agentRuns += 1;
+  }
+
+  const completion = searchAcquisitionCompletionSchema.parse(
+    structuredAcquisitionFromAgentResult(agentOutput)
+  );
+  completion.validation_issues.forEach((issue) => {
+    input.validationIssues.push(`Search acquisition agent: ${issue}`);
+  });
+
+  const pooledResults = [...searchPool.values()];
+  const pooledUrlSet = new Set(
+    pooledResults.map((result) => normalizeSearchResultUrl(result.url))
+  );
+  const agentScores: AgentSearchScore[] = completion.scored_urls.filter((score) =>
+    pooledUrlSet.has(normalizeSearchResultUrl(score.url))
+  );
+  const rankedForScoring = finalizePrioritizedSearchResults({
+    context: input.context,
+    dataSpec,
+    results: pooledResults,
+    agentScores,
+  });
+
+  const searchQueryByUrl = new Map(
+    pooledResults.map((result) => [
+      normalizeSearchResultUrl(result.url),
+      result.search_query,
+    ])
+  );
+  const scoredUrls = rankedForScoring.map((result) => ({
+    url: normalizeSearchResultUrl(result.url),
+    expectation_score: result.expectation_score,
+    search_query: searchQueryByUrl.get(normalizeSearchResultUrl(result.url)) ?? "",
+  }));
+  const sortedScoredUrls = sortAcquisitionScoredUrls(scoredUrls);
+  input.debugNotes.push(
+    `Search acquisition: ${input.metrics.searchCalls}/${input.maxSearchCalls} search call(s), ${initialQueries.length} initial query seed(s), ${pooledResults.length} unique result(s), ${sortedScoredUrls.length} scored URL(s).`
+  );
+
+  return {
+    scoredUrls: sortedScoredUrls,
+    initialQueries,
+    validationIssues: completion.validation_issues,
+    dataSpec,
+    searchPoolResults: pooledResults.map((result) => ({
+      title: result.title,
+      snippet: result.snippet,
+      url: result.url,
+      site_name: result.site_name,
+      search_query: result.search_query,
+    })),
+  };
+}
+
+function createSearchAcquisitionAgent(input: { tools: Record<string, unknown> }) {
+  const openrouter = createOpenRouter({ apiKey: requiredOpenRouterApiKey() });
+
+  return new Agent({
+    id: "populate-search-acquisition-agent",
+    name: "Populate Search Acquisition Agent",
+    instructions: searchAcquisitionAgentInstructions,
+    model: openrouter(DEFAULT_OPENROUTER_MODEL_ID),
+    tools: input.tools as ConstructorParameters<typeof Agent>[0]["tools"],
+  });
+}
+
+function createSearchAcquisitionTools(input: {
+  maxSearchCalls: number;
+  webTools: PopulateRuntimeWebTools;
+  metrics: PopulateRuntimeResult["metrics"];
+  validationIssues: string[];
+  searchPool: Map<string, PooledSearchResult>;
+}) {
+  return {
+    search_web: createTool({
+      id: "search_web",
+      description: "Search the web for candidate source pages.",
+      inputSchema: z.object({ query: z.string() }),
+      outputSchema: z.object({
+        results: z.array(z.object({
+          title: z.string(),
+          snippet: z.string().optional(),
+          url: z.string(),
+          site_name: z.string().optional(),
+        })).optional(),
+        error: z.string().optional(),
+      }),
+      execute: async ({ query }) => {
+        if (input.metrics.searchCalls >= input.maxSearchCalls) {
+          return {
+            error: `Search budget exhausted (${input.maxSearchCalls} search_web calls). Score every URL collected so far and return.`,
+          };
+        }
+
+        input.metrics.searchCalls += 1;
+        try {
+          const results = normalizeSearchResults(
+            await input.webTools.search({ query })
+          );
+          for (const result of results) {
+            const key = normalizeSearchResultUrl(result.url);
+            if (!input.searchPool.has(key)) {
+              input.searchPool.set(key, { ...result, search_query: query });
+            }
+          }
+          return { results };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          input.validationIssues.push(`search_web failed: ${message}`);
+          return { error: message };
+        }
+      },
+    }),
+  };
+}
+
+function normalizeSearchResults(
+  results: PopulateWebSearchResult[]
+): PopulateWebSearchResult[] {
+  return results.map((result) => ({
+    ...result,
+    site_name: result.site_name ?? siteNameFromUrl(result.url),
+  }));
+}
+
+function structuredAcquisitionFromAgentResult(agentOutput: unknown): unknown {
+  if (!agentOutput || typeof agentOutput !== "object") {
+    return { scored_urls: [], validation_issues: [] };
+  }
+
+  const record = agentOutput as Record<string, unknown>;
+  if (record.object && typeof record.object === "object") {
+    return record.object;
+  }
+  if (Array.isArray(record.scored_urls)) {
+    return record;
+  }
+  return { scored_urls: [], validation_issues: [] };
+}

--- a/backend/src/pipeline/populate-benchmark-debug.ts
+++ b/backend/src/pipeline/populate-benchmark-debug.ts
@@ -1,0 +1,165 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { PopulateAcquisitionResult } from "./populate-acquisition.js";
+import type { DatasetContext } from "./populate.js";
+import type { PopulateRuntimeLimits } from "./populate-runtime-limits.js";
+import type {
+  PopulateRuntimeCapturedInsertedRow,
+  PopulateRuntimeCapturedSource,
+} from "./populate-web-types.js";
+import type { DatasetSchema } from "./types.js";
+
+export interface PopulateBenchmarkSearchPoolEntry {
+  search_query: string;
+  title: string;
+  snippet?: string;
+  url: string;
+  site_name?: string;
+}
+
+export interface PopulateBenchmarkDebugSnapshot {
+  runAt: string;
+  context: DatasetContext;
+  limits: PopulateRuntimeLimits;
+  dataSpec?: DatasetSchema;
+  initialQueries?: string[];
+  searchPool: PopulateBenchmarkSearchPoolEntry[];
+  acquisition?: PopulateAcquisitionResult;
+  populatePromptUrlCount: number;
+  capturedSources: PopulateRuntimeCapturedSource[];
+  capturedRows: PopulateRuntimeCapturedInsertedRow[];
+  validationIssues: string[];
+  metrics: {
+    searchCalls: number;
+    fetchCalls: number;
+    browserCalls: number;
+    agentRuns: number;
+    agentSteps: number;
+  };
+  notes: string[];
+}
+
+const TRUTHY = new Set(["1", "true", "yes", "on"]);
+
+export function isPopulateBenchmarkDebugEnabled(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  const raw = env.POPULATE_BENCHMARK_DEBUG?.trim().toLowerCase();
+  return raw !== undefined && TRUTHY.has(raw);
+}
+
+export function populateBenchmarkArtifactDirectory(
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
+  const dir = env.BIGSET_BENCHMARK_ARTIFACT_DIR?.trim();
+  return dir || undefined;
+}
+
+export async function writePopulateBenchmarkDebugArtifacts(
+  artifactDirectory: string,
+  snapshot: PopulateBenchmarkDebugSnapshot
+): Promise<void> {
+  const debugDir = join(artifactDirectory, "debug");
+  await mkdir(debugDir, { recursive: true });
+
+  const scoredCount = snapshot.acquisition?.scoredUrls.length ?? 0;
+  const prioritizedCount = snapshot.acquisition?.prioritizedUrls.length ?? 0;
+  const fetchedCount = snapshot.capturedSources.filter((source) =>
+    isFetchedPageContent(source.text)
+  ).length;
+
+  await Promise.all([
+    writeJson(join(debugDir, "run_report.json"), {
+      runAt: snapshot.runAt,
+      datasetId: snapshot.context.datasetId,
+      description: snapshot.context.description,
+      limits: snapshot.limits,
+      metrics: snapshot.metrics,
+      counts: {
+        searchPool: snapshot.searchPool.length,
+        scoredUrls: scoredCount,
+        prioritizedUrls: prioritizedCount,
+        populatePromptUrls: snapshot.populatePromptUrlCount,
+        capturedSources: snapshot.capturedSources.length,
+        fetchedPagesWithContent: fetchedCount,
+        capturedRows: snapshot.capturedRows.length,
+        outputRows: snapshot.capturedRows.length,
+      },
+      validationIssues: snapshot.validationIssues,
+      notes: snapshot.notes,
+    }),
+    writeJson(join(debugDir, "dataset_spec.json"), snapshot.dataSpec ?? null),
+    writeJson(join(debugDir, "initial_queries.json"), snapshot.initialQueries ?? []),
+    writeJson(join(debugDir, "search_pool.json"), snapshot.searchPool),
+    writeJson(
+      join(debugDir, "source_candidates.json"),
+      snapshot.acquisition?.scoredUrls ?? []
+    ),
+    writeJson(
+      join(debugDir, "prioritized_urls.json"),
+      snapshot.acquisition?.prioritizedUrls ?? []
+    ),
+    writeJson(join(debugDir, "captured_sources.json"), snapshot.capturedSources),
+    writeJson(join(debugDir, "captured_rows.json"), snapshot.capturedRows),
+    writeJson(join(debugDir, "acquisition.json"), snapshot.acquisition ?? null),
+    writeCsv(join(debugDir, "prioritized_urls.csv"), prioritizedUrlsCsv(snapshot)),
+    writeCsv(join(debugDir, "source_candidates.csv"), sourceCandidatesCsv(snapshot)),
+  ]);
+}
+
+function prioritizedUrlsCsv(snapshot: PopulateBenchmarkDebugSnapshot): string {
+  const scoreByUrl = new Map(
+    (snapshot.acquisition?.scoredUrls ?? []).map((entry) => [entry.url, entry])
+  );
+  const lines = ["rank,url,expectation_score,search_query"];
+  for (const [index, url] of (snapshot.acquisition?.prioritizedUrls ?? []).entries()) {
+    const scored = scoreByUrl.get(url);
+    lines.push(
+      csvRow([
+        String(index + 1),
+        url,
+        String(scored?.expectation_score ?? ""),
+        scored?.search_query ?? "",
+      ])
+    );
+  }
+  return lines.join("\n");
+}
+
+function sourceCandidatesCsv(snapshot: PopulateBenchmarkDebugSnapshot): string {
+  const lines = ["url,expectation_score,search_query"];
+  for (const entry of snapshot.acquisition?.scoredUrls ?? []) {
+    lines.push(
+      csvRow([entry.url, String(entry.expectation_score), entry.search_query ?? ""])
+    );
+  }
+  return lines.join("\n");
+}
+
+function csvRow(values: string[]): string {
+  return values.map(csvEscape).join(",");
+}
+
+function csvEscape(value: string): string {
+  if (/[",\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+async function writeCsv(path: string, content: string): Promise<void> {
+  await writeFile(path, `${content}\n`, "utf8");
+}
+
+function isFetchedPageContent(text: string | undefined): boolean {
+  const trimmed = text?.trim() ?? "";
+  if (!trimmed) {
+    return false;
+  }
+  return !trimmed.startsWith("expectation_score:");
+}

--- a/backend/src/pipeline/populate-browser-agent.ts
+++ b/backend/src/pipeline/populate-browser-agent.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared contract for browser agents (Tinyfish + optional Playwright).
+ * Edward's Playwright agent should accept the same job shape and return this result.
+ */
+
+export interface BrowserAgentJob {
+  url: string;
+  goal: string;
+}
+
+export interface BrowserAgentRunResult {
+  run_id: string | null;
+  status: string;
+  result: Record<string, unknown> | null;
+  error: string | null;
+}
+
+/** Extra inputs Playwright can use when replaying a prior Tinyfish visit from memory. */
+export interface PlaywrightAgentJob extends BrowserAgentJob {
+  emitted_process?: Record<string, unknown> | null;
+  prior_tinyfish_run_id?: string | null;
+  repair_loop?: number;
+}
+
+/** Normalize Tinyfish (or Playwright) payloads into memory-friendly process snapshots. */
+export function extractEmittedProcessFromAgentResult(
+  result: Record<string, unknown> | null
+): Record<string, unknown> | undefined {
+  if (!result) {
+    return undefined;
+  }
+
+  const candidates = [
+    result.emitted_process,
+    result.process,
+    result.steps,
+    result.actions,
+    result.navigation_trace,
+  ];
+
+  for (const candidate of candidates) {
+    if (candidate && typeof candidate === "object" && !Array.isArray(candidate)) {
+      return candidate as Record<string, unknown>;
+    }
+    if (Array.isArray(candidate) && candidate.length > 0) {
+      return { steps: candidate };
+    }
+  }
+
+  return result;
+}

--- a/backend/src/pipeline/populate-collection-memory-config.ts
+++ b/backend/src/pipeline/populate-collection-memory-config.ts
@@ -1,0 +1,39 @@
+const TRUTHY = new Set(["1", "true", "yes", "on"]);
+
+function readPositiveInt(raw: string | undefined, fallback: number): number {
+  if (!raw?.trim()) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return fallback;
+  }
+  return parsed;
+}
+
+function readBoolean(raw: string | undefined, fallback: boolean): boolean {
+  if (raw === undefined) {
+    return fallback;
+  }
+  return TRUTHY.has(raw.trim().toLowerCase());
+}
+
+const DEFAULT_MEMORY_DIR = ".bigset/collection-memory";
+const DEFAULT_MAX_REPAIR_LOOPS = 3;
+const DEFAULT_ENABLE_COLLECTION_MEMORY = true;
+
+export interface PopulateCollectionMemoryConfig {
+  memoryDir: string;
+  enabled: boolean;
+  maxRepairLoops: number;
+}
+
+export function resolvePopulateCollectionMemoryConfig(
+  env: NodeJS.ProcessEnv = process.env
+): PopulateCollectionMemoryConfig {
+  return {
+    memoryDir: env.POPULATE_COLLECTION_MEMORY_DIR?.trim() || DEFAULT_MEMORY_DIR,
+    enabled: readBoolean(env.POPULATE_ENABLE_COLLECTION_MEMORY, DEFAULT_ENABLE_COLLECTION_MEMORY),
+    maxRepairLoops: readPositiveInt(env.POPULATE_MAX_REPAIR_LOOPS, DEFAULT_MAX_REPAIR_LOOPS),
+  };
+}

--- a/backend/src/pipeline/populate-collection-memory-config.ts
+++ b/backend/src/pipeline/populate-collection-memory-config.ts
@@ -1,3 +1,5 @@
+import { dirname, join } from "node:path";
+
 const TRUTHY = new Set(["1", "true", "yes", "on"]);
 
 function readPositiveInt(raw: string | undefined, fallback: number): number {
@@ -28,11 +30,20 @@ export interface PopulateCollectionMemoryConfig {
   maxRepairLoops: number;
 }
 
+function resolveDefaultMemoryDir(env: NodeJS.ProcessEnv): string {
+  const recipeStoreDir = env.POPULATE_RECIPE_STORE_DIR?.trim();
+  if (recipeStoreDir) {
+    return join(dirname(recipeStoreDir), "collection-memory");
+  }
+  return DEFAULT_MEMORY_DIR;
+}
+
 export function resolvePopulateCollectionMemoryConfig(
   env: NodeJS.ProcessEnv = process.env
 ): PopulateCollectionMemoryConfig {
   return {
-    memoryDir: env.POPULATE_COLLECTION_MEMORY_DIR?.trim() || DEFAULT_MEMORY_DIR,
+    memoryDir:
+      env.POPULATE_COLLECTION_MEMORY_DIR?.trim() || resolveDefaultMemoryDir(env),
     enabled: readBoolean(env.POPULATE_ENABLE_COLLECTION_MEMORY, DEFAULT_ENABLE_COLLECTION_MEMORY),
     maxRepairLoops: readPositiveInt(env.POPULATE_MAX_REPAIR_LOOPS, DEFAULT_MAX_REPAIR_LOOPS),
   };

--- a/backend/src/pipeline/populate-collection-runtime.ts
+++ b/backend/src/pipeline/populate-collection-runtime.ts
@@ -14,7 +14,15 @@ export interface CollectionPopulatePipelineColumn {
   description?: string;
 }
 
-export interface CollectionPopulatePipelineInput {
+export interface CollectionPopulateBenchmarkMetadata {
+  promptId?: string;
+  promptQuality?: string;
+  persona?: string;
+  expectedStress?: string;
+}
+
+export interface CollectionPopulatePipelineInput
+  extends CollectionPopulateBenchmarkMetadata {
   datasetId: string;
   datasetName: string;
   description: string;
@@ -32,6 +40,7 @@ export type CollectionPopulatePipelineRunner = (
 export interface CollectionPopulateRecipeRuntimeOptions {
   runPipeline: CollectionPopulatePipelineRunner;
   targetRows?: number;
+  benchmarkMetadata?: CollectionPopulateBenchmarkMetadata;
 }
 
 export class CollectionPopulateRecipeRuntime implements PopulateRecipeRuntime {
@@ -52,6 +61,7 @@ export class CollectionPopulateRecipeRuntime implements PopulateRecipeRuntime {
           recipe: input.recipe,
           context: input.context,
           targetRows: this.input.targetRows ?? 10,
+          benchmarkMetadata: this.input.benchmarkMetadata,
         })
       );
     } catch (error) {
@@ -74,9 +84,11 @@ export function collectionPipelineInputFromRecipe(input: {
   recipe: PopulateRecipe;
   context: DatasetContext;
   targetRows: number;
+  benchmarkMetadata?: CollectionPopulateBenchmarkMetadata;
 }): CollectionPopulatePipelineInput {
   const recipeInstructions = input.recipe.runtimeInstructions.trim();
   return {
+    ...input.benchmarkMetadata,
     datasetId: input.context.datasetId,
     datasetName: input.context.datasetName,
     description: input.context.description,

--- a/backend/src/pipeline/populate-collection-runtime.ts
+++ b/backend/src/pipeline/populate-collection-runtime.ts
@@ -1,0 +1,123 @@
+import type { DatasetContext, PopulateColumn } from "./populate.js";
+import type { PopulateRuntimeResult } from "./populate-runtime.js";
+import {
+  emptyPopulateRuntimeResult,
+  populateRecipeRunResultFromRuntimeResult,
+  type PopulateRecipe,
+  type PopulateRecipeRunResult,
+  type PopulateRecipeRuntime,
+} from "./populate-self-healing.js";
+
+export interface CollectionPopulatePipelineColumn {
+  name: string;
+  type: PopulateColumn["type"];
+  description?: string;
+}
+
+export interface CollectionPopulatePipelineInput {
+  datasetId: string;
+  datasetName: string;
+  description: string;
+  columns: CollectionPopulatePipelineColumn[];
+  requiredColumns: string[];
+  prompt: string;
+  recipeInstructions: string;
+  targetRows: number;
+}
+
+export type CollectionPopulatePipelineRunner = (
+  input: CollectionPopulatePipelineInput
+) => Promise<PopulateRuntimeResult>;
+
+export interface CollectionPopulateRecipeRuntimeOptions {
+  runPipeline: CollectionPopulatePipelineRunner;
+  targetRows?: number;
+}
+
+export class CollectionPopulateRecipeRuntime implements PopulateRecipeRuntime {
+  constructor(private readonly input: CollectionPopulateRecipeRuntimeOptions) {}
+
+  async runRecipe(input: {
+    recipe: PopulateRecipe;
+    context: DatasetContext;
+  }): Promise<PopulateRecipeRunResult> {
+    const startedAtMs = Date.now();
+    const startedAt = new Date(startedAtMs).toISOString();
+    let result: PopulateRuntimeResult;
+    let failureMessage: string | undefined;
+
+    try {
+      result = await this.input.runPipeline(
+        collectionPipelineInputFromRecipe({
+          recipe: input.recipe,
+          context: input.context,
+          targetRows: this.input.targetRows ?? 10,
+        })
+      );
+    } catch (error) {
+      failureMessage = error instanceof Error ? error.message : String(error);
+      result = emptyPopulateRuntimeResult([failureMessage]);
+    }
+
+    return populateRecipeRunResultFromRuntimeResult({
+      recipe: input.recipe,
+      context: input.context,
+      result,
+      failureMessage,
+      startedAt,
+      startedAtMs,
+    });
+  }
+}
+
+export function collectionPipelineInputFromRecipe(input: {
+  recipe: PopulateRecipe;
+  context: DatasetContext;
+  targetRows: number;
+}): CollectionPopulatePipelineInput {
+  const recipeInstructions = input.recipe.runtimeInstructions.trim();
+  return {
+    datasetId: input.context.datasetId,
+    datasetName: input.context.datasetName,
+    description: input.context.description,
+    columns: input.context.columns.map((column) => ({
+      name: column.name,
+      type: column.type,
+      description: column.description,
+    })),
+    requiredColumns: input.context.columns.map((column) => column.name),
+    prompt: buildCollectionPopulatePrompt({
+      context: input.context,
+      recipeInstructions,
+    }),
+    recipeInstructions,
+    targetRows: input.targetRows,
+  };
+}
+
+function buildCollectionPopulatePrompt(input: {
+  context: DatasetContext;
+  recipeInstructions: string;
+}): string {
+  const columnLines = input.context.columns.map((column) => {
+    const description = column.description ? ` - ${column.description}` : "";
+    return `- ${column.name} (${column.type})${description}`;
+  });
+  const parts = [
+    `Dataset: ${input.context.datasetName}`,
+    `Task: ${input.context.description}`,
+    "",
+    "Requested columns:",
+    ...columnLines,
+  ];
+
+  if (input.recipeInstructions) {
+    parts.push(
+      "",
+      "Durable recipe instructions:",
+      input.recipeInstructions
+    );
+  }
+
+  return parts.join("\n");
+}

--- a/backend/src/pipeline/populate-convex-writer.ts
+++ b/backend/src/pipeline/populate-convex-writer.ts
@@ -1,0 +1,71 @@
+import { env } from "../env.js";
+import { convex, internal } from "../convex.js";
+import type {
+  PopulateDatasetRowWriter,
+  PopulateDatasetWriteResult,
+} from "./populate-self-healing-runner.js";
+
+interface ConvexMutationClient {
+  mutation(functionReference: unknown, args: unknown): Promise<unknown>;
+}
+
+export class ConvexPopulateDatasetRowWriter implements PopulateDatasetRowWriter {
+  constructor(
+    private readonly input: {
+      convexClient?: ConvexMutationClient;
+      internalApi?: typeof internal;
+    } = {}
+  ) {}
+
+  async replaceRows(input: Parameters<PopulateDatasetRowWriter["replaceRows"]>[0]):
+    Promise<PopulateDatasetWriteResult> {
+    if (!env.CONVEX_ADMIN_KEY) {
+      throw new Error(
+        "CONVEX_SELF_HOSTED_ADMIN_KEY is required to commit self-healed populate rows."
+      );
+    }
+
+    const convexClient = this.input.convexClient ?? convex;
+    const internalApi = this.input.internalApi ?? internal;
+    const replacement = await convexClient.mutation(
+      internalApi.datasetRows.replaceByDataset,
+      {
+        datasetId: input.datasetId,
+        rows: input.rows.map((row) => ({
+          data: row.cells,
+          sources: row.sourceUrls,
+        })),
+      }
+    );
+
+    return normalizeReplacementResult(replacement, input.rows.length);
+  }
+}
+
+function normalizeReplacementResult(
+  value: unknown,
+  fallbackInsertedRowCount: number
+): PopulateDatasetWriteResult {
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "insertedRowCount" in value
+  ) {
+    const replacement = value as {
+      clearedRowCount?: unknown;
+      insertedRowCount?: unknown;
+    };
+    return {
+      clearedRowCount: typeof replacement.clearedRowCount === "number"
+        ? replacement.clearedRowCount
+        : undefined,
+      insertedRowCount: typeof replacement.insertedRowCount === "number"
+        ? replacement.insertedRowCount
+        : fallbackInsertedRowCount,
+    };
+  }
+
+  return {
+    insertedRowCount: fallbackInsertedRowCount,
+  };
+}

--- a/backend/src/pipeline/populate-dataset-context-loader.ts
+++ b/backend/src/pipeline/populate-dataset-context-loader.ts
@@ -1,0 +1,56 @@
+import { ConvexHttpClient } from "convex/browser";
+import { anyApi } from "convex/server";
+
+import {
+  datasetContextSchema,
+  type DatasetContext,
+} from "./populate.js";
+
+export interface PopulateDatasetContextQueryClient {
+  query(functionReference: unknown, args: unknown): Promise<unknown>;
+}
+
+export class ConvexPopulateDatasetContextLoader {
+  constructor(
+    private readonly input: {
+      convexClient: PopulateDatasetContextQueryClient;
+      internalApi?: typeof anyApi;
+    }
+  ) {}
+
+  async loadContext(datasetId: string): Promise<DatasetContext> {
+    const internalApi = this.input.internalApi ?? anyApi;
+    const dataset = await this.input.convexClient.query(
+      internalApi.datasets.getForSystemPopulate,
+      { id: datasetId }
+    );
+
+    if (!dataset || typeof dataset !== "object") {
+      throw new Error(`Dataset ${datasetId} not found.`);
+    }
+    const record = dataset as {
+      name?: unknown;
+      description?: unknown;
+      columns?: unknown;
+    };
+
+    return datasetContextSchema.parse({
+      datasetId,
+      datasetName: record.name,
+      description: record.description,
+      columns: record.columns,
+    });
+  }
+}
+
+export function createConvexPopulateDatasetContextLoader(input: {
+  convexUrl: string;
+  convexAdminKey: string;
+}): ConvexPopulateDatasetContextLoader {
+  const convexClient = new ConvexHttpClient(input.convexUrl);
+  (convexClient as unknown as {
+    setAdminAuth(adminKey: string): void;
+  }).setAdminAuth(input.convexAdminKey);
+
+  return new ConvexPopulateDatasetContextLoader({ convexClient });
+}

--- a/backend/src/pipeline/populate-extract-from-agent.ts
+++ b/backend/src/pipeline/populate-extract-from-agent.ts
@@ -1,0 +1,52 @@
+import { buildPopulateLlmExtractionSchema } from "./types.js";
+import { completePopulateJson } from "./populate-llm-json.js";
+import type { PopulateExtractionSpec } from "./populate-extraction-spec.js";
+import {
+  finalizePopulateLlmRecords,
+  type PopulateLlmExtractionRecord,
+} from "./populate-extract-records.js";
+import type { PopulateCandidateRow } from "./populate-row.js";
+
+const EXTRACT_AGENT_SYSTEM = `You are the Extraction Agent parsing output from a Tinyfish browser automation run.
+
+Convert the agent result JSON into dataset records matching the schema.
+
+Rules:
+- Only include facts present in the agent result. Do not invent values.
+- row keys must match spec column names exactly.
+- evidence: field, quote, and url when you have a supporting quote.
+- extraction_confidence (0–1) per record when possible.
+- If the agent result has no usable rows, return an empty records array.
+- Return ONLY JSON`;
+
+export async function extractFromTinyfishAgentResult(input: {
+  userPrompt: string;
+  spec: PopulateExtractionSpec;
+  pageUrl: string;
+  agentResult: Record<string, unknown> | null;
+}): Promise<PopulateCandidateRow[]> {
+  if (!input.agentResult || Object.keys(input.agentResult).length === 0) {
+    return [];
+  }
+
+  const columnNames = input.spec.columns.map((column) => column.name);
+  const schema = buildPopulateLlmExtractionSchema(columnNames);
+
+  const result = await completePopulateJson({
+    label: `populate-extract-agent:${input.pageUrl}`,
+    schema,
+    system: EXTRACT_AGENT_SYSTEM,
+    user: JSON.stringify({
+      user_prompt: input.userPrompt,
+      dataset_spec: input.spec,
+      page_url: input.pageUrl,
+      agent_result: input.agentResult,
+    }),
+  });
+
+  return finalizePopulateLlmRecords({
+    records: result.records as PopulateLlmExtractionRecord[],
+    pageUrl: input.pageUrl,
+    spec: input.spec,
+  });
+}

--- a/backend/src/pipeline/populate-extract-records.ts
+++ b/backend/src/pipeline/populate-extract-records.ts
@@ -1,0 +1,91 @@
+import type { PopulateExtractionSpec } from "./populate-extraction-spec.js";
+import type { PopulateCandidateRow } from "./populate-row.js";
+import {
+  coerceHttpUrl,
+  isHttpUrl,
+  uniqueHttpUrls,
+} from "./populate-url-utils.js";
+
+export function normalizePrimaryKey(
+  value: unknown,
+  columnName: string
+): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  return String(value)
+    .trim()
+    .toLowerCase()
+    .replace(
+      /\b(?:incorporated|inc|corporation|corp|company|co|llc|ltd|limited|plc)\b\.?$/i,
+      ""
+    )
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export interface PopulateLlmExtractionRecord {
+  row: Record<string, string | number | boolean | null>;
+  evidence: Array<{ field: string; quote: string; url?: string }>;
+  extraction_confidence?: number;
+}
+
+export function finalizePopulateLlmRecords(input: {
+  records: PopulateLlmExtractionRecord[];
+  pageUrl: string;
+  spec: PopulateExtractionSpec;
+}): PopulateCandidateRow[] {
+  const rows: PopulateCandidateRow[] = [];
+
+  for (const record of input.records) {
+    const cells = { ...record.row };
+    const sourceUrls = uniqueHttpUrls([
+      input.pageUrl,
+      ...record.evidence.map((item) => item.url),
+      ...provenanceUrlsFromRow(cells, input.spec),
+    ]);
+    const evidence = record.evidence
+      .filter((item) => coerceQuote(item.quote).length > 0)
+      .map((item) => ({
+        columnName: item.field,
+        sourceUrl: coerceHttpUrl(item.url) ?? input.pageUrl,
+        quote: coerceQuote(item.quote),
+      }));
+
+    const primaryKey = normalizePrimaryKey(
+      cells[input.spec.primary_key],
+      input.spec.primary_key
+    );
+
+    rows.push({
+      cells,
+      sourceUrls,
+      evidence,
+      needsReview: true,
+      extractionConfidence: record.extraction_confidence ?? 0.5,
+      primaryKey,
+    });
+  }
+
+  return rows;
+}
+
+function provenanceUrlsFromRow(
+  row: Record<string, string | number | boolean | null>,
+  spec: PopulateExtractionSpec
+): string[] {
+  return spec.columns
+    .filter((column) => /(url|website|link|page|source)/i.test(column.name))
+    .map((column) => row[column.name])
+    .filter((value): value is string => isHttpUrl(value));
+}
+
+function coerceQuote(value: unknown): string {
+  if (typeof value === "string") {
+    return value.trim();
+  }
+  if (value === null || value === undefined) {
+    return "";
+  }
+  return String(value).trim();
+}

--- a/backend/src/pipeline/populate-extraction-spec.ts
+++ b/backend/src/pipeline/populate-extraction-spec.ts
@@ -1,0 +1,35 @@
+import type { DatasetContext } from "./populate.js";
+import type { ColumnDefinition, DatasetSchema } from "./types.js";
+
+export interface PopulateExtractionSpec {
+  intent_summary: string;
+  row_grain: string;
+  primary_key: string;
+  dedupe_keys: string[];
+  columns: Array<{
+    name: string;
+    type: string;
+    description: string;
+  }>;
+}
+
+export function buildPopulateExtractionSpec(input: {
+  context: DatasetContext;
+  dataSpec: DatasetSchema;
+}): PopulateExtractionSpec {
+  return {
+    intent_summary: input.context.description,
+    row_grain: input.dataSpec.description,
+    primary_key: input.dataSpec.primary_key,
+    dedupe_keys: [input.dataSpec.primary_key],
+    columns: input.dataSpec.columns.map(mapColumn),
+  };
+}
+
+function mapColumn(column: ColumnDefinition) {
+  return {
+    name: column.name,
+    type: column.type,
+    description: column.description,
+  };
+}

--- a/backend/src/pipeline/populate-llm-json.ts
+++ b/backend/src/pipeline/populate-llm-json.ts
@@ -1,0 +1,32 @@
+import { generateText, Output } from "ai";
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import type { z } from "zod";
+
+import {
+  DEFAULT_OPENROUTER_MODEL_ID,
+  requiredOpenRouterApiKey,
+} from "../openrouter-models.js";
+import { recordLanguageModelUsage } from "./llm-usage.js";
+
+export async function completePopulateJson<T extends z.ZodType>(input: {
+  label: string;
+  schema: T;
+  system: string;
+  user: string;
+}): Promise<z.infer<T>> {
+  const model = createOpenRouter({ apiKey: requiredOpenRouterApiKey() })(
+    DEFAULT_OPENROUTER_MODEL_ID
+  );
+  const result = await generateText({
+    model,
+    output: Output.object({ schema: input.schema }),
+    system: input.system,
+    prompt: input.user,
+    maxOutputTokens: 8192,
+  });
+  recordLanguageModelUsage(result.usage);
+  if (!result.output) {
+    throw new Error(`${input.label}: model did not return structured output`);
+  }
+  return result.output;
+}

--- a/backend/src/pipeline/populate-merge-rows.ts
+++ b/backend/src/pipeline/populate-merge-rows.ts
@@ -1,0 +1,143 @@
+import type { PopulateExtractionSpec } from "./populate-extraction-spec.js";
+import type { PopulateCandidateRow, PopulateRuntimeRow } from "./populate-row.js";
+import { normalizePrimaryKey } from "./populate-extract-records.js";
+import { uniqueHttpUrls } from "./populate-url-utils.js";
+
+export { normalizePrimaryKey } from "./populate-extract-records.js";
+
+function evidenceQualityScore(row: PopulateCandidateRow): number {
+  const evidenceScore = row.evidence.length > 0 ? 1 : 0;
+  return row.extractionConfidence * 0.6 + evidenceScore * 0.4;
+}
+
+function prefersIncomingRow(
+  existing: PopulateCandidateRow,
+  incoming: PopulateCandidateRow
+): boolean {
+  const existingScore = evidenceQualityScore(existing);
+  const incomingScore = evidenceQualityScore(incoming);
+  if (incomingScore !== existingScore) {
+    return incomingScore > existingScore;
+  }
+  return incoming.sourceUrls.length > existing.sourceUrls.length;
+}
+
+function mergeCandidatePair(
+  existing: PopulateCandidateRow,
+  incoming: PopulateCandidateRow,
+  spec: PopulateExtractionSpec
+): PopulateCandidateRow {
+  const cells = { ...existing.cells };
+  const preferIncoming = prefersIncomingRow(existing, incoming);
+
+  for (const column of spec.columns) {
+    const current = cells[column.name];
+    const next = incoming.cells[column.name];
+    const currentEmpty =
+      current === null || current === undefined || current === "";
+    const nextFilled = !(next === null || next === undefined || next === "");
+
+    if (currentEmpty && nextFilled) {
+      cells[column.name] = next;
+    } else if (nextFilled && preferIncoming) {
+      cells[column.name] = next;
+    }
+  }
+
+  const sourceUrls = uniqueHttpUrls([
+    ...existing.sourceUrls,
+    ...incoming.sourceUrls,
+  ]);
+  const evidence = preferIncoming
+    ? [...incoming.evidence, ...existing.evidence]
+    : [...existing.evidence, ...incoming.evidence];
+  const dedupedEvidence = dedupeEvidence(evidence);
+
+  return {
+    cells,
+    sourceUrls,
+    evidence: dedupedEvidence,
+    needsReview: existing.needsReview || incoming.needsReview,
+    extractionConfidence: Math.max(
+      existing.extractionConfidence,
+      incoming.extractionConfidence
+    ),
+    primaryKey:
+      existing.primaryKey ||
+      incoming.primaryKey ||
+      normalizePrimaryKey(cells[spec.primary_key], spec.primary_key),
+  };
+}
+
+function dedupeEvidence(
+  evidence: PopulateRuntimeRow["evidence"]
+): PopulateRuntimeRow["evidence"] {
+  const seen = new Set<string>();
+  const unique: PopulateRuntimeRow["evidence"] = [];
+  for (const item of evidence) {
+    const key = `${item.columnName}::${item.sourceUrl}::${item.quote}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    unique.push(item);
+  }
+  return unique;
+}
+
+export function canonicalRowId(
+  row: PopulateCandidateRow,
+  spec: PopulateExtractionSpec
+): string | null {
+  const primary =
+    row.primaryKey || normalizePrimaryKey(row.cells[spec.primary_key], spec.primary_key);
+  if (primary) {
+    return `pk:${primary}`;
+  }
+  const composite = spec.dedupe_keys
+    .map((key) => normalizePrimaryKey(row.cells[key], key))
+    .join("||");
+  if (composite.replace(/\|/g, "").trim()) {
+    return `dk:${composite}`;
+  }
+  return null;
+}
+
+export function mergePopulateCandidateRows(input: {
+  spec: PopulateExtractionSpec;
+  rows: PopulateCandidateRow[];
+  maxRows: number;
+}): { rows: PopulateRuntimeRow[]; unkeyed: PopulateRuntimeRow[] } {
+  const seen = new Map<string, PopulateCandidateRow>();
+  const unkeyed: PopulateCandidateRow[] = [];
+
+  for (const row of input.rows) {
+    const id = canonicalRowId(row, input.spec);
+    if (!id) {
+      unkeyed.push(row);
+      continue;
+    }
+    const existing = seen.get(id);
+    if (!existing) {
+      seen.set(id, row);
+      continue;
+    }
+    seen.set(id, mergeCandidatePair(existing, row, input.spec));
+  }
+
+  const merged = [...seen.values(), ...unkeyed]
+    .sort((a, b) => evidenceQualityScore(b) - evidenceQualityScore(a))
+    .slice(0, input.maxRows)
+    .map(toRuntimeRow);
+
+  return { rows: merged, unkeyed: unkeyed.map(toRuntimeRow) };
+}
+
+function toRuntimeRow(row: PopulateCandidateRow): PopulateRuntimeRow {
+  return {
+    cells: row.cells,
+    sourceUrls: row.sourceUrls,
+    evidence: row.evidence,
+    needsReview: row.needsReview,
+  };
+}

--- a/backend/src/pipeline/populate-normalize-dataset-keys.ts
+++ b/backend/src/pipeline/populate-normalize-dataset-keys.ts
@@ -1,0 +1,53 @@
+import type { DatasetContext } from "./populate.js";
+import type { DatasetSchema } from "./types.js";
+
+/** Maps extraction keys (snake_case, display_name) to dataset column names in Convex. */
+export function buildPopulateColumnKeyAliases(
+  dataSpec: DatasetSchema,
+  context: DatasetContext
+): ReadonlyMap<string, string> {
+  const aliases = new Map<string, string>();
+
+  for (const column of context.columns) {
+    aliases.set(column.name, column.name);
+  }
+
+  for (let index = 0; index < dataSpec.columns.length; index++) {
+    const specColumn = dataSpec.columns[index]!;
+    const contextColumn =
+      context.columns.find((column) => column.name === specColumn.display_name) ??
+      context.columns[index];
+    if (!contextColumn) {
+      continue;
+    }
+
+    const targetName = contextColumn.name;
+    aliases.set(specColumn.name, targetName);
+    if (specColumn.display_name !== specColumn.name) {
+      aliases.set(specColumn.display_name, targetName);
+    }
+  }
+
+  return aliases;
+}
+
+export function normalizePopulateRowCellsForDataset(
+  cells: Record<string, unknown>,
+  aliases: ReadonlyMap<string, string>
+): Record<string, unknown> {
+  const normalized: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(cells)) {
+    const targetKey = aliases.get(key) ?? key;
+    const existing = normalized[targetKey];
+    const existingEmpty =
+      existing === null || existing === undefined || existing === "";
+    const valueFilled = value !== null && value !== undefined && value !== "";
+
+    if (!(targetKey in normalized) || (existingEmpty && valueFilled)) {
+      normalized[targetKey] = value;
+    }
+  }
+
+  return normalized;
+}

--- a/backend/src/pipeline/populate-parallel-config.ts
+++ b/backend/src/pipeline/populate-parallel-config.ts
@@ -1,0 +1,102 @@
+const TRUTHY = new Set(["1", "true", "yes", "on"]);
+
+function readPositiveInt(raw: string | undefined, fallback: number): number {
+  if (!raw?.trim()) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return fallback;
+  }
+  return parsed;
+}
+
+function readBoolean(raw: string | undefined, fallback: boolean): boolean {
+  if (raw === undefined) {
+    return fallback;
+  }
+  return TRUTHY.has(raw.trim().toLowerCase());
+}
+
+export interface PopulateParallelConfig {
+  urlsPerWorker: number;
+  maxTinyfishAgentRuns: number;
+  enableTinyfishAgent: boolean;
+  maxPlaywrightAgentRuns: number;
+  enablePlaywrightAgent: boolean;
+}
+
+export interface PopulatePlaywrightAgentConfig {
+  pollTimeoutMs: number;
+  pollIntervalMs: number;
+}
+
+export interface PopulateTinyfishAgentConfig {
+  pollTimeoutMs: number;
+  pollIntervalMs: number;
+}
+
+const DEFAULT_URLS_PER_WORKER = 5;
+const DEFAULT_MAX_TINYFISH_AGENT_RUNS = 5;
+const DEFAULT_ENABLE_TINYFISH_AGENT = true;
+const DEFAULT_MAX_PLAYWRIGHT_AGENT_RUNS = 10;
+const DEFAULT_ENABLE_PLAYWRIGHT_AGENT = false;
+const DEFAULT_AGENT_POLL_TIMEOUT_MS = 480_000;
+const DEFAULT_AGENT_POLL_INTERVAL_MS = 3_000;
+
+export function resolvePopulateParallelConfig(
+  env: NodeJS.ProcessEnv = process.env
+): PopulateParallelConfig {
+  return {
+    urlsPerWorker: readPositiveInt(
+      env.POPULATE_URLS_PER_WORKER,
+      DEFAULT_URLS_PER_WORKER
+    ),
+    maxTinyfishAgentRuns: readPositiveInt(
+      env.POPULATE_MAX_TINYFISH_AGENT_RUNS,
+      DEFAULT_MAX_TINYFISH_AGENT_RUNS
+    ),
+    enableTinyfishAgent: readBoolean(
+      env.POPULATE_ENABLE_TINYFISH_AGENT,
+      DEFAULT_ENABLE_TINYFISH_AGENT
+    ),
+    maxPlaywrightAgentRuns: readPositiveInt(
+      env.POPULATE_MAX_PLAYWRIGHT_AGENT_RUNS,
+      DEFAULT_MAX_PLAYWRIGHT_AGENT_RUNS
+    ),
+    enablePlaywrightAgent: readBoolean(
+      env.POPULATE_ENABLE_PLAYWRIGHT_AGENT,
+      DEFAULT_ENABLE_PLAYWRIGHT_AGENT
+    ),
+  };
+}
+
+export function resolvePopulatePlaywrightAgentConfig(
+  env: NodeJS.ProcessEnv = process.env
+): PopulatePlaywrightAgentConfig {
+  return {
+    pollTimeoutMs: readPositiveInt(
+      env.POPULATE_PLAYWRIGHT_AGENT_POLL_TIMEOUT_MS,
+      DEFAULT_AGENT_POLL_TIMEOUT_MS
+    ),
+    pollIntervalMs: readPositiveInt(
+      env.POPULATE_PLAYWRIGHT_AGENT_POLL_INTERVAL_MS,
+      DEFAULT_AGENT_POLL_INTERVAL_MS
+    ),
+  };
+}
+
+export function resolvePopulateTinyfishAgentConfig(
+  env: NodeJS.ProcessEnv = process.env
+): PopulateTinyfishAgentConfig {
+  return {
+    pollTimeoutMs: readPositiveInt(
+      env.POPULATE_TINYFISH_AGENT_POLL_TIMEOUT_MS,
+      DEFAULT_AGENT_POLL_TIMEOUT_MS
+    ),
+    pollIntervalMs: readPositiveInt(
+      env.POPULATE_TINYFISH_AGENT_POLL_INTERVAL_MS,
+      DEFAULT_AGENT_POLL_INTERVAL_MS
+    ),
+  };
+}

--- a/backend/src/pipeline/populate-parallel.ts
+++ b/backend/src/pipeline/populate-parallel.ts
@@ -1,0 +1,413 @@
+import type { PopulateAcquisitionResult } from "./populate-acquisition.js";
+import { PopulateCollectionMemoryService } from "./collection-memory/index.js";
+import {
+  findLatestAgentVisit,
+  latestTinyfishEmittedProcess,
+} from "./collection-memory/store.js";
+import { buildPopulateExtractionSpec } from "./populate-extraction-spec.js";
+import { extractFromTinyfishAgentResult } from "./populate-extract-from-agent.js";
+import { mergePopulateCandidateRows } from "./populate-merge-rows.js";
+import type { DatasetContext } from "./populate.js";
+import {
+  resolvePopulateParallelConfig,
+  type PopulateParallelConfig,
+} from "./populate-parallel-config.js";
+import type { PlaywrightAgentJob } from "./populate-browser-agent.js";
+import { runPlaywrightAgentsBatch } from "./populate-playwright-agent.js";
+import type { PopulateRuntimeLimits } from "./populate-runtime-limits.js";
+import type {
+  PopulateRuntimeCapturedSource,
+  PopulateRuntimeWebTools,
+} from "./populate-web-types.js";
+import { normalizeSearchResultUrl } from "./populate-search-prioritization.js";
+import type { PopulateCandidateRow } from "./populate-row.js";
+import type { PopulateRuntimeRow } from "./populate-row.js";
+import { triageAndExtractPage } from "./populate-triage-extract.js";
+import {
+  agentPriorityScore,
+  buildTinyfishAgentGoal,
+  runTinyfishAgentsBatch,
+  type TinyfishAgentJob,
+} from "./populate-tinyfish-agent.js";
+import { statusNeedsTinyfishAgent } from "./populate-source-status.js";
+import type { DatasetSchema, PopulateSourceTriageResult } from "./types.js";
+
+export interface PartialPopulateWorkerResult {
+  rows: PopulateCandidateRow[];
+  agentCandidates: AgentDeferredCandidate[];
+  capturedSources: PopulateRuntimeCapturedSource[];
+  fetchCalls: number;
+  llmCalls: number;
+  validationIssues: string[];
+}
+
+export interface AgentDeferredCandidate {
+  pageUrl: string;
+  triage: PopulateSourceTriageResult;
+  goal: string;
+}
+
+export interface ParallelPopulatePhaseResult {
+  rows: PopulateRuntimeRow[];
+  capturedSources: PopulateRuntimeCapturedSource[];
+  validationIssues: string[];
+  workerCount: number;
+  agentRunsDispatched: number;
+}
+
+export interface PopulateParallelHooks {
+  triageAndExtractPage?: typeof triageAndExtractPage;
+  extractFromTinyfishAgentResult?: typeof extractFromTinyfishAgentResult;
+  runTinyfishAgentsBatch?: typeof runTinyfishAgentsBatch;
+  runPlaywrightAgentsBatch?: typeof runPlaywrightAgentsBatch;
+}
+
+export function shardPrioritizedUrlsEvenly(
+  urls: readonly string[],
+  urlsPerWorker: number
+): string[][] {
+  if (urls.length === 0) {
+    return [];
+  }
+  const workerCount = Math.max(1, Math.ceil(urls.length / urlsPerWorker));
+  const shards: string[][] = Array.from({ length: workerCount }, () => []);
+  for (let index = 0; index < urls.length; index += 1) {
+    shards[index % workerCount]!.push(urls[index]!);
+  }
+  return shards.filter((shard) => shard.length > 0);
+}
+
+export async function runParallelPopulatePhase(input: {
+  context: DatasetContext;
+  dataSpec: DatasetSchema;
+  acquisition: PopulateAcquisitionResult;
+  limits: PopulateRuntimeLimits;
+  webTools: PopulateRuntimeWebTools;
+  metrics: {
+    fetchCalls: number;
+    browserCalls: number;
+    agentRuns: number;
+  };
+  validationIssues: string[];
+  debugNotes: string[];
+  parallelConfig?: PopulateParallelConfig;
+  hooks?: PopulateParallelHooks;
+  collectionMemory?: PopulateCollectionMemoryService;
+}): Promise<ParallelPopulatePhaseResult> {
+  const parallelConfig = input.parallelConfig ?? resolvePopulateParallelConfig();
+  const spec = buildPopulateExtractionSpec({
+    context: input.context,
+    dataSpec: input.dataSpec,
+  });
+  const triageExtract = input.hooks?.triageAndExtractPage ?? triageAndExtractPage;
+  const extractAgent = input.hooks?.extractFromTinyfishAgentResult ?? extractFromTinyfishAgentResult;
+  const tinyfishBatch = input.hooks?.runTinyfishAgentsBatch ?? runTinyfishAgentsBatch;
+  const playwrightBatch = input.hooks?.runPlaywrightAgentsBatch ?? runPlaywrightAgentsBatch;
+  const memorySnapshot = input.collectionMemory?.snapshot;
+
+  const shards = shardPrioritizedUrlsEvenly(
+    input.acquisition.prioritizedUrls,
+    parallelConfig.urlsPerWorker
+  );
+  input.debugNotes.push(
+    `Parallel populate: ${shards.length} worker shard(s), ${parallelConfig.urlsPerWorker} URL(s) per worker target, ${input.acquisition.prioritizedUrls.length} prioritized URL(s).`
+  );
+
+  const workerResults = await Promise.all(
+    shards.map((urls, shardIndex) =>
+      runPopulateWorkerShard({
+        shardIndex,
+        urls,
+        userPrompt: input.context.description,
+        spec,
+        webTools: input.webTools,
+        triageAndExtractPage: triageExtract,
+      })
+    )
+  );
+
+  for (const worker of workerResults) {
+    input.metrics.fetchCalls += worker.fetchCalls;
+    input.metrics.agentRuns += worker.llmCalls;
+    input.validationIssues.push(...worker.validationIssues);
+  }
+
+  const mergedRows: PopulateCandidateRow[] = [];
+  const capturedSources: PopulateRuntimeCapturedSource[] = [];
+  const agentCandidates: AgentDeferredCandidate[] = [];
+
+  for (const worker of workerResults) {
+    mergedRows.push(...worker.rows);
+    capturedSources.push(...worker.capturedSources);
+    agentCandidates.push(...worker.agentCandidates);
+  }
+
+  let agentRunsDispatched = 0;
+  if (agentCandidates.length > 0) {
+    const ranked = [...agentCandidates].sort(
+      (a, b) => agentPriorityScore(b.triage) - agentPriorityScore(a.triage)
+    );
+
+    const playwrightEligible: AgentDeferredCandidate[] = [];
+    const tinyfishEligible: AgentDeferredCandidate[] = [];
+
+    for (const candidate of ranked) {
+      const priorProcess =
+        parallelConfig.enablePlaywrightAgent && memorySnapshot
+          ? latestTinyfishEmittedProcess(memorySnapshot, candidate.pageUrl)
+          : undefined;
+      if (priorProcess) {
+        playwrightEligible.push(candidate);
+      } else {
+        tinyfishEligible.push(candidate);
+      }
+    }
+
+    if (parallelConfig.enableTinyfishAgent && tinyfishEligible.length > 0) {
+      const toRun = tinyfishEligible.slice(0, parallelConfig.maxTinyfishAgentRuns);
+      const deferred = tinyfishEligible.length - toRun.length;
+      if (deferred > 0) {
+        input.debugNotes.push(
+          `Tinyfish agent budget: running ${toRun.length}/${tinyfishEligible.length} (${deferred} deferred).`
+        );
+      }
+
+      const jobs: TinyfishAgentJob[] = toRun.map((candidate) => ({
+        url: candidate.pageUrl,
+        goal: candidate.goal,
+      }));
+      agentRunsDispatched += jobs.length;
+      input.metrics.browserCalls += jobs.length;
+
+      const agentResults = await tinyfishBatch(jobs);
+      for (let index = 0; index < toRun.length; index += 1) {
+        const candidate = toRun[index]!;
+        const run = agentResults[index]!;
+        input.metrics.agentRuns += 1;
+        if (run.error || !run.result) {
+          input.validationIssues.push(
+            `Tinyfish agent failed for ${candidate.pageUrl}: ${run.error ?? "no result"}`
+          );
+          continue;
+        }
+
+        input.collectionMemory?.recordAgentVisit({
+          url: candidate.pageUrl,
+          finalUrl: candidate.triage.final_url,
+          provider: "tinyfish",
+          goal: candidate.goal,
+          run,
+          triage: candidate.triage,
+        });
+
+        try {
+          const rows = await extractAgent({
+            userPrompt: input.context.description,
+            spec,
+            pageUrl: candidate.pageUrl,
+            agentResult: run.result,
+          });
+          input.metrics.agentRuns += 1;
+          mergedRows.push(...rows);
+          capturedSources.push({
+            url: candidate.pageUrl,
+            text: JSON.stringify(run.result).slice(0, 12_000),
+          });
+        } catch (error) {
+          input.validationIssues.push(
+            `Tinyfish extract failed for ${candidate.pageUrl}: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
+        }
+      }
+    } else if (!parallelConfig.enableTinyfishAgent && tinyfishEligible.length > 0) {
+      input.debugNotes.push(
+        `Skipped ${tinyfishEligible.length} Tinyfish agent candidate(s) (POPULATE_ENABLE_TINYFISH_AGENT=false).`
+      );
+    }
+
+    if (parallelConfig.enablePlaywrightAgent && playwrightEligible.length > 0) {
+      const toRun = playwrightEligible.slice(0, parallelConfig.maxPlaywrightAgentRuns);
+      const deferred = playwrightEligible.length - toRun.length;
+      if (deferred > 0) {
+        input.debugNotes.push(
+          `Playwright agent budget: running ${toRun.length}/${playwrightEligible.length} (${deferred} deferred).`
+        );
+      }
+
+      const jobs: PlaywrightAgentJob[] = toRun.map((candidate) => {
+        const prior = memorySnapshot
+          ? latestTinyfishEmittedProcess(memorySnapshot, candidate.pageUrl)
+          : undefined;
+        const priorVisit = memorySnapshot
+          ? findLatestAgentVisit(memorySnapshot, candidate.pageUrl, "tinyfish")
+          : undefined;
+        return {
+          url: candidate.pageUrl,
+          goal: candidate.goal,
+          emitted_process: prior ?? null,
+          prior_tinyfish_run_id: priorVisit?.run_id ?? null,
+          repair_loop: memorySnapshot?.repair_loop.current_loop ?? 0,
+        };
+      });
+
+      agentRunsDispatched += jobs.length;
+      input.metrics.browserCalls += jobs.length;
+
+      const agentResults = await playwrightBatch(jobs);
+      for (let index = 0; index < toRun.length; index += 1) {
+        const candidate = toRun[index]!;
+        const run = agentResults[index]!;
+        input.metrics.agentRuns += 1;
+        if (run.error || !run.result) {
+          input.validationIssues.push(
+            `Playwright agent failed for ${candidate.pageUrl}: ${run.error ?? "no result"}`
+          );
+          continue;
+        }
+
+        input.collectionMemory?.recordAgentVisit({
+          url: candidate.pageUrl,
+          finalUrl: candidate.triage.final_url,
+          provider: "playwright",
+          goal: candidate.goal,
+          run,
+          triage: candidate.triage,
+        });
+
+        try {
+          const rows = await extractAgent({
+            userPrompt: input.context.description,
+            spec,
+            pageUrl: candidate.pageUrl,
+            agentResult: run.result,
+          });
+          mergedRows.push(...rows);
+          capturedSources.push({
+            url: candidate.pageUrl,
+            text: JSON.stringify(run.result).slice(0, 12_000),
+          });
+        } catch (error) {
+          input.validationIssues.push(
+            `Playwright extract failed for ${candidate.pageUrl}: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
+        }
+      }
+    } else if (
+      !parallelConfig.enablePlaywrightAgent &&
+      playwrightEligible.length > 0
+    ) {
+      input.debugNotes.push(
+        `Skipped ${playwrightEligible.length} Playwright replay candidate(s) with saved Tinyfish process (POPULATE_ENABLE_PLAYWRIGHT_AGENT=false).`
+      );
+    }
+  }
+
+  const merged = mergePopulateCandidateRows({
+    spec,
+    rows: mergedRows,
+    maxRows: input.limits.maxRows,
+  });
+  if (merged.unkeyed.length > 0) {
+    input.validationIssues.push(
+      `${merged.unkeyed.length} row(s) omitted during merge (missing primary key).`
+    );
+  }
+
+  input.debugNotes.push(
+    `Parallel populate merged ${merged.rows.length} row(s) from ${mergedRows.length} candidate row(s).`
+  );
+
+  return {
+    rows: merged.rows,
+    capturedSources,
+    validationIssues: input.validationIssues,
+    workerCount: shards.length,
+    agentRunsDispatched,
+  };
+}
+
+async function runPopulateWorkerShard(input: {
+  shardIndex: number;
+  urls: string[];
+  userPrompt: string;
+  spec: ReturnType<typeof buildPopulateExtractionSpec>;
+  webTools: PopulateRuntimeWebTools;
+  triageAndExtractPage: typeof triageAndExtractPage;
+}): Promise<PartialPopulateWorkerResult> {
+  const rows: PopulateCandidateRow[] = [];
+  const agentCandidates: AgentDeferredCandidate[] = [];
+  const capturedSources: PopulateRuntimeCapturedSource[] = [];
+  const validationIssues: string[] = [];
+  let fetchCalls = 0;
+  let llmCalls = 0;
+
+  for (const url of input.urls) {
+    const normalizedUrl = normalizeSearchResultUrl(url);
+    fetchCalls += 1;
+    let pageText = "";
+    let pageTitle = "";
+    try {
+      const page = await input.webTools.fetch({ url: normalizedUrl });
+      pageText = [page.title, page.text].filter(Boolean).join("\n");
+      pageTitle = page.title ?? "";
+      capturedSources.push({ url: normalizedUrl, text: pageText });
+    } catch (error) {
+      validationIssues.push(
+        `fetch_page failed for ${normalizedUrl}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      continue;
+    }
+
+    try {
+      llmCalls += 1;
+      const outcome = await input.triageAndExtractPage({
+        userPrompt: input.userPrompt,
+        spec: input.spec,
+        page: {
+          url: normalizedUrl,
+          final_url: normalizedUrl,
+          title: pageTitle,
+          text: pageText,
+        },
+      });
+      llmCalls += 1;
+
+      if (outcome.records.length > 0) {
+        rows.push(...outcome.records);
+      }
+
+      if (statusNeedsTinyfishAgent(outcome.triage.status)) {
+        agentCandidates.push({
+          pageUrl: outcome.triage.final_url || normalizedUrl,
+          triage: outcome.triage,
+          goal: buildTinyfishAgentGoal({
+            userPrompt: input.userPrompt,
+            spec: input.spec,
+            triage: outcome.triage,
+          }),
+        });
+      }
+    } catch (error) {
+      validationIssues.push(
+        `Triage/extract failed for shard ${input.shardIndex} ${normalizedUrl}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+  return {
+    rows,
+    agentCandidates,
+    capturedSources,
+    fetchCalls,
+    llmCalls,
+    validationIssues,
+  };
+}

--- a/backend/src/pipeline/populate-playwright-agent.ts
+++ b/backend/src/pipeline/populate-playwright-agent.ts
@@ -1,0 +1,42 @@
+import type { BrowserAgentRunResult, PlaywrightAgentJob } from "./populate-browser-agent.js";
+
+export type { PlaywrightAgentJob } from "./populate-browser-agent.js";
+import {
+  resolvePopulatePlaywrightAgentConfig,
+  type PopulatePlaywrightAgentConfig,
+} from "./populate-parallel-config.js";
+
+/**
+ * Black-box dock for Edward's Playwright agent.
+ *
+ * Replace the body of `runPlaywrightAgent` (or inject `runPlaywrightAgentsBatch` via
+ * `PopulateParallelHooks`) with a call into your script runner. Input/output must match
+ * Tinyfish: `{ url, goal }` in, `{ run_id, status, result, error }` out.
+ *
+ * When `emitted_process` is set on the job, use it as the replay blueprint from
+ * `PopulateCollectionMemory.agent_visited_urls` (see docs/playwright-agent-integration.md).
+ */
+export async function runPlaywrightAgent(
+  job: PlaywrightAgentJob,
+  _config: PopulatePlaywrightAgentConfig = resolvePopulatePlaywrightAgentConfig()
+): Promise<BrowserAgentRunResult> {
+  void job;
+  return {
+    run_id: null,
+    status: "NOT_IMPLEMENTED",
+    result: null,
+    error:
+      "Playwright agent is not implemented. Implement runPlaywrightAgent in populate-playwright-agent.ts " +
+      "or pass runPlaywrightAgentsBatch through PopulateParallelHooks.",
+  };
+}
+
+export async function runPlaywrightAgentsBatch(
+  jobs: PlaywrightAgentJob[],
+  config?: PopulatePlaywrightAgentConfig
+): Promise<BrowserAgentRunResult[]> {
+  if (jobs.length === 0) {
+    return [];
+  }
+  return Promise.all(jobs.map((job) => runPlaywrightAgent(job, config)));
+}

--- a/backend/src/pipeline/populate-prompt.ts
+++ b/backend/src/pipeline/populate-prompt.ts
@@ -5,6 +5,7 @@ export const populateAgentInstructions = `You fill datasets with real data. Here
 1. Search the web for data that fits the dataset topic.
 2. Fetch 1-2 pages to get details.
 3. Call insert_row only for rows supported by search or fetched page content.
+4. Also return structured rows with cells, sourceUrls, evidence, and needsReview.
 
 Never make up rows or missing cell values. If you can't find enough real data, insert fewer rows and explain the gap in your final response.`;
 
@@ -33,8 +34,10 @@ insert_row({ datasetId: "${inputData.datasetId}", data: { ${columnNames.map((n) 
 Search the web for real data about this topic. Then call insert_row for up to 10 source-backed rows.
 
 Important:
-- The dataset is populated only by insert_row tool calls.
-- Final prose, markdown tables, or summaries do not count as inserted rows.
+- The dataset should be populated by insert_row tool calls whenever possible.
+- Also return structured rows using this shape: { rows: [{ cells, sourceUrls, evidence, needsReview }] }.
+- Every structured row cells object must contain exactly the requested column keys above.
+- Every structured row must include sourceUrls and evidence quotes copied from search_web or fetch_page results.
 - For every verified row, call insert_row with the exact datasetId above.
 - Never invent rows or cell values.
 - If sources only support fewer than 10 rows, insert only the verified rows and explain what was missing.`;

--- a/backend/src/pipeline/populate-prompt.ts
+++ b/backend/src/pipeline/populate-prompt.ts
@@ -1,0 +1,41 @@
+import type { DatasetContext } from "./populate.js";
+
+export const populateAgentInstructions = `You fill datasets with real data. Here's how:
+
+1. Search the web for data that fits the dataset topic.
+2. Fetch 1-2 pages to get details.
+3. Call insert_row only for rows supported by search or fetched page content.
+
+Never make up rows or missing cell values. If you can't find enough real data, insert fewer rows and explain the gap in your final response.`;
+
+export function buildPopulatePrompt(inputData: DatasetContext): string {
+  const columnNames = inputData.columns.map((c) => c.name);
+  const columnsDesc = inputData.columns
+    .map(
+      (c) =>
+        `- "${c.name}" (${c.type})${c.description ? `: ${c.description}` : ""}`,
+    )
+    .join("\n");
+
+  return `Dataset ID: ${inputData.datasetId}
+Dataset: ${inputData.datasetName}
+Description: ${inputData.description}
+
+Columns:
+${columnsDesc}
+
+When calling insert_row, the data object keys MUST be exactly these strings (no backticks, no extra quotes):
+${JSON.stringify(columnNames)}
+
+Example insert_row call:
+insert_row({ datasetId: "${inputData.datasetId}", data: { ${columnNames.map((n) => `"${n}": <value>`).join(", ")} } })
+
+Search the web for real data about this topic. Then call insert_row for up to 10 source-backed rows.
+
+Important:
+- The dataset is populated only by insert_row tool calls.
+- Final prose, markdown tables, or summaries do not count as inserted rows.
+- For every verified row, call insert_row with the exact datasetId above.
+- Never invent rows or cell values.
+- If sources only support fewer than 10 rows, insert only the verified rows and explain what was missing.`;
+}

--- a/backend/src/pipeline/populate-prompt.ts
+++ b/backend/src/pipeline/populate-prompt.ts
@@ -1,44 +1,110 @@
+import {
+  buildPopulateFetchPlan,
+  type PopulateAcquisitionResult,
+  type PopulateFetchPlan,
+} from "./populate-acquisition.js";
 import type { DatasetContext } from "./populate.js";
 
-export const populateAgentInstructions = `You fill datasets with real data. Here's how:
+export { buildPopulateFetchPlan, type PopulateFetchPlan };
 
-1. Search the web for data that fits the dataset topic.
-2. Fetch 1-2 pages to get details.
-3. Call insert_row only for rows supported by search or fetched page content.
-4. Also return structured rows with cells, sourceUrls, evidence, and needsReview.
+export const populateAgentInstructions = `You are a dataset populate agent. Search is already done; your job is to fetch every source URL provided for this run and fill the table with verified facts.
 
-Never make up rows or missing cell values. If you can't find enough real data, insert fewer rows and explain the gap in your final response.`;
+Workflow:
+1. fetch_page on each URL in the source list (work through the full list).
+2. Extract facts only from fetched page content.
+3. insert_row for each verified row, and return structured rows when useful.
 
-export function buildPopulatePrompt(inputData: DatasetContext): string {
-  const columnNames = inputData.columns.map((c) => c.name);
-  const columnsDesc = inputData.columns
-    .map(
-      (c) =>
-        `- "${c.name}" (${c.type})${c.description ? `: ${c.description}` : ""}`,
-    )
-    .join("\n");
+Provenance (required for every row):
+- Each row must come from a URL you fetched with fetch_page in this run.
+- Record that exact URL in sourceUrls and in every evidence item's sourceUrl.
+- evidence.quote must be a verbatim excerpt from that fetched page.
+- For any column that stores a source or page URL, set it to the same fetch URL you used for that row.
 
-  return `Dataset ID: ${inputData.datasetId}
-Dataset: ${inputData.datasetName}
-Description: ${inputData.description}
+Output:
+- Prefer insert_row with the exact dataset column keys.
+- You may also return { rows: [{ cells, sourceUrls, evidence, needsReview }] }.
+- Do not call search_web.
 
-Columns:
-${columnsDesc}
+Never invent rows, URLs, quotes, or cell values. Omit rows you cannot support from a fetched page.`;
 
-When calling insert_row, the data object keys MUST be exactly these strings (no backticks, no extra quotes):
-${JSON.stringify(columnNames)}
+export function buildPopulatePrompt(
+  context: DatasetContext,
+  maxRows: number,
+  fetchPlan?: PopulateFetchPlan
+): string {
+  return [
+    formatPopulateDatasetSection(context),
+    formatPopulateColumnsSection(context),
+    formatPopulateInsertRowSection(context),
+    formatPopulateSourceUrlsSection(fetchPlan),
+    formatPopulateLimitsSection(maxRows),
+    formatPopulateRemindersSection(),
+  ].join("\n\n");
+}
 
-Example insert_row call:
-insert_row({ datasetId: "${inputData.datasetId}", data: { ${columnNames.map((n) => `"${n}": <value>`).join(", ")} } })
+export function buildPopulatePromptFromAcquisition(
+  context: DatasetContext,
+  maxRows: number,
+  acquisition: PopulateAcquisitionResult
+): string {
+  return buildPopulatePrompt(
+    context,
+    maxRows,
+    buildPopulateFetchPlan(acquisition)
+  );
+}
 
-Search the web for real data about this topic. Then call insert_row for up to 10 source-backed rows.
+function formatPopulateDatasetSection(context: DatasetContext): string {
+  return `## Dataset
+- datasetId: ${context.datasetId}
+- name: ${context.datasetName}
+- description: ${context.description}`;
+}
 
-Important:
-- The dataset should be populated by insert_row tool calls whenever possible.
-- Also return structured rows using this shape: { rows: [{ cells, sourceUrls, evidence, needsReview }] }.
-- Every structured row cells object must contain exactly the requested column keys above.
-- Every structured row must include sourceUrls and evidence quotes copied from search_web or fetch_page results.
-- For every verified row, call insert_row with the exact datasetId above.
-- Never invent rows or cell values.
-- If sources only support fewer than 10 rows, insert only the verified rows and explain what was missing.`;
+function formatPopulateColumnsSection(context: DatasetContext): string {
+  const lines = context.columns.map(
+    (column) =>
+      `- ${column.name} (${column.type})${
+        column.description ? `: ${column.description}` : ""
+      }`
+  );
+
+  return `## Columns\n${lines.join("\n")}`;
+}
+
+function formatPopulateInsertRowSection(context: DatasetContext): string {
+  const columnNames = context.columns.map((column) => column.name);
+
+  return `## insert_row contract
+- Keys must be exactly: ${JSON.stringify(columnNames)}
+- Example: insert_row({ datasetId: "${context.datasetId}", data: { ${columnNames.map((name) => `"${name}": <value>`).join(", ")} } })`;
+}
+
+function formatPopulateSourceUrlsSection(
+  fetchPlan?: PopulateFetchPlan
+): string {
+  if (!fetchPlan || fetchPlan.fetchUrls.length === 0) {
+    return `## Source URLs
+(none — do not invent rows; explain in validationIssues)`;
+  }
+
+  const lines = fetchPlan.fetchUrls.map(
+    (entry, index) => `${index + 1}. ${entry.url}`
+  );
+
+  return `## Source URLs
+Fetch every URL below (already ranked for this run; do not call search_web):
+${lines.join("\n")}`;
+}
+
+function formatPopulateLimitsSection(maxRows: number): string {
+  return `## Limits
+- Up to ${maxRows} insert_row calls`;
+}
+
+function formatPopulateRemindersSection(): string {
+  return `## Reminders
+- fetch_page each listed URL before using it in any row.
+- Every row must cite the fetch URL you used in sourceUrls and evidence.sourceUrl.
+- Call insert_row for each verified row using datasetId from above.`;
 }

--- a/backend/src/pipeline/populate-row.ts
+++ b/backend/src/pipeline/populate-row.ts
@@ -1,0 +1,24 @@
+export type PopulateCellValue =
+  | string
+  | number
+  | boolean
+  | null
+  | Record<string, unknown>
+  | unknown[];
+
+export interface PopulateRuntimeRow {
+  cells: Record<string, PopulateCellValue>;
+  sourceUrls: string[];
+  evidence: Array<{
+    columnName: string;
+    sourceUrl: string;
+    quote: string;
+  }>;
+  needsReview: boolean;
+}
+
+/** Row emitted by a parallel worker before global merge. */
+export interface PopulateCandidateRow extends PopulateRuntimeRow {
+  extractionConfidence: number;
+  primaryKey: string;
+}

--- a/backend/src/pipeline/populate-runtime-limits.ts
+++ b/backend/src/pipeline/populate-runtime-limits.ts
@@ -1,0 +1,46 @@
+export interface PopulateRuntimeLimits {
+  maxRows: number;
+  maxSearchCalls: number;
+  /** Caps how many scored URLs are passed to the populate agent (env: POPULATE_MAX_FETCH_CALLS). */
+  maxFetchCalls: number;
+}
+
+const DEFAULT_MAX_ROWS = 100;
+const DEFAULT_MAX_SEARCH_CALLS = 50;
+const DEFAULT_MAX_FETCH_CALLS = 50;
+
+function readPositiveInt(
+  raw: string | undefined,
+  fallback: number
+): number {
+  if (!raw?.trim()) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return fallback;
+  }
+  return parsed;
+}
+
+export function resolvePopulateRuntimeLimits(input?: {
+  maxRows?: number;
+  maxSearchCalls?: number;
+  maxFetchCalls?: number;
+  env?: NodeJS.ProcessEnv;
+}): PopulateRuntimeLimits {
+  const env = input?.env ?? process.env;
+  const maxRows = input?.maxRows ?? readPositiveInt(env.POPULATE_MAX_ROWS, DEFAULT_MAX_ROWS);
+  const maxSearchCalls =
+    input?.maxSearchCalls ??
+    readPositiveInt(env.POPULATE_MAX_SEARCH_CALLS, DEFAULT_MAX_SEARCH_CALLS);
+  const maxFetchCalls =
+    input?.maxFetchCalls ??
+    readPositiveInt(env.POPULATE_MAX_FETCH_CALLS, DEFAULT_MAX_FETCH_CALLS);
+
+  return {
+    maxRows,
+    maxSearchCalls,
+    maxFetchCalls,
+  };
+}

--- a/backend/src/pipeline/populate-runtime-prerequisites.ts
+++ b/backend/src/pipeline/populate-runtime-prerequisites.ts
@@ -1,15 +1,18 @@
 export interface PopulateRuntimePrerequisites {
+  convexUrl?: string;
   convexAdminKey?: string;
   openRouterApiKey?: string;
   tinyFishApiKey?: string;
   shouldCommitRows?: boolean;
+  shouldLoadDatasetContext?: boolean;
 }
 
 export function missingPopulateRuntimePrerequisites(
   input: PopulateRuntimePrerequisites
 ): string[] {
   const requiredKeys: Array<[string, string | undefined]> = [];
-  if (input.shouldCommitRows ?? true) {
+  if ((input.shouldCommitRows ?? true) || input.shouldLoadDatasetContext) {
+    requiredKeys.push(["CONVEX_URL", input.convexUrl]);
     requiredKeys.push(["CONVEX_SELF_HOSTED_ADMIN_KEY", input.convexAdminKey]);
   }
   requiredKeys.push(

--- a/backend/src/pipeline/populate-runtime-prerequisites.ts
+++ b/backend/src/pipeline/populate-runtime-prerequisites.ts
@@ -1,0 +1,29 @@
+export interface PopulateRuntimePrerequisites {
+  convexAdminKey?: string;
+  openRouterApiKey?: string;
+  tinyFishApiKey?: string;
+}
+
+export function missingPopulateRuntimePrerequisites(
+  input: PopulateRuntimePrerequisites
+): string[] {
+  const requiredKeys: Array<[string, string | undefined]> = [
+    ["CONVEX_SELF_HOSTED_ADMIN_KEY", input.convexAdminKey],
+    ["OPENROUTER_API_KEY", input.openRouterApiKey],
+    ["TINYFISH_API_KEY", input.tinyFishApiKey],
+  ];
+
+  return requiredKeys
+    .filter(([, value]) => !value)
+    .map(([name]) => name);
+}
+
+export function populateRuntimePrerequisiteError(
+  input: PopulateRuntimePrerequisites
+): string | undefined {
+  const missingNames = missingPopulateRuntimePrerequisites(input);
+  if (missingNames.length === 0) {
+    return undefined;
+  }
+  return `Backend is missing required populate runtime keys: ${missingNames.join(", ")}.`;
+}

--- a/backend/src/pipeline/populate-runtime-prerequisites.ts
+++ b/backend/src/pipeline/populate-runtime-prerequisites.ts
@@ -2,16 +2,20 @@ export interface PopulateRuntimePrerequisites {
   convexAdminKey?: string;
   openRouterApiKey?: string;
   tinyFishApiKey?: string;
+  shouldCommitRows?: boolean;
 }
 
 export function missingPopulateRuntimePrerequisites(
   input: PopulateRuntimePrerequisites
 ): string[] {
-  const requiredKeys: Array<[string, string | undefined]> = [
-    ["CONVEX_SELF_HOSTED_ADMIN_KEY", input.convexAdminKey],
+  const requiredKeys: Array<[string, string | undefined]> = [];
+  if (input.shouldCommitRows ?? true) {
+    requiredKeys.push(["CONVEX_SELF_HOSTED_ADMIN_KEY", input.convexAdminKey]);
+  }
+  requiredKeys.push(
     ["OPENROUTER_API_KEY", input.openRouterApiKey],
-    ["TINYFISH_API_KEY", input.tinyFishApiKey],
-  ];
+    ["TINYFISH_API_KEY", input.tinyFishApiKey]
+  );
 
   return requiredKeys
     .filter(([, value]) => !value)

--- a/backend/src/pipeline/populate-runtime-selection.ts
+++ b/backend/src/pipeline/populate-runtime-selection.ts
@@ -1,0 +1,54 @@
+import {
+  CollectionPopulateRecipeRuntime,
+  type CollectionPopulatePipelineRunner,
+} from "./populate-collection-runtime.js";
+import {
+  MastraPopulateRecipeRuntime,
+  type PopulateRecipeRuntime,
+} from "./populate-self-healing.js";
+
+export type PopulateAgentRuntimeName = "mastra" | "collection";
+
+export interface CreatePopulateRecipeRuntimeInput {
+  env: NodeJS.ProcessEnv;
+  maxRows?: number;
+  collectionRunner?: CollectionPopulatePipelineRunner;
+}
+
+export function selectedPopulateRuntimeName(
+  env: NodeJS.ProcessEnv
+): PopulateAgentRuntimeName {
+  const rawRuntimeName = (
+    env.POPULATE_AGENT_RUNTIME ??
+    env.DATASET_AGENT_RUNTIME ??
+    "mastra"
+  ).trim().toLowerCase();
+
+  if (rawRuntimeName === "mastra" || rawRuntimeName === "mastra-populate") {
+    return "mastra";
+  }
+  if (rawRuntimeName === "collection") {
+    return "collection";
+  }
+  throw new Error(
+    `Unsupported POPULATE_AGENT_RUNTIME: ${rawRuntimeName || "(empty)"}.`
+  );
+}
+
+export async function createPopulateRecipeRuntime(
+  input: CreatePopulateRecipeRuntimeInput
+): Promise<PopulateRecipeRuntime> {
+  const runtimeName = selectedPopulateRuntimeName(input.env);
+  if (runtimeName === "mastra") {
+    return new MastraPopulateRecipeRuntime({ maxRows: input.maxRows });
+  }
+  if (!input.collectionRunner) {
+    throw new Error(
+      "POPULATE_AGENT_RUNTIME=collection requires a collection pipeline runner."
+    );
+  }
+  return new CollectionPopulateRecipeRuntime({
+    runPipeline: input.collectionRunner,
+    targetRows: input.maxRows,
+  });
+}

--- a/backend/src/pipeline/populate-runtime-selection.ts
+++ b/backend/src/pipeline/populate-runtime-selection.ts
@@ -1,5 +1,9 @@
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
 import {
   CollectionPopulateRecipeRuntime,
+  type CollectionPopulateBenchmarkMetadata,
   type CollectionPopulatePipelineRunner,
 } from "./populate-collection-runtime.js";
 import {
@@ -42,13 +46,48 @@ export async function createPopulateRecipeRuntime(
   if (runtimeName === "mastra") {
     return new MastraPopulateRecipeRuntime({ maxRows: input.maxRows });
   }
-  if (!input.collectionRunner) {
+  const collectionRunner =
+    input.collectionRunner ?? await loadCollectionRunnerFromEnv(input.env);
+  if (!collectionRunner) {
     throw new Error(
-      "POPULATE_AGENT_RUNTIME=collection requires a collection pipeline runner."
+      "POPULATE_AGENT_RUNTIME=collection requires a collection pipeline runner or POPULATE_COLLECTION_RUNNER_MODULE."
     );
   }
   return new CollectionPopulateRecipeRuntime({
-    runPipeline: input.collectionRunner,
+    runPipeline: collectionRunner,
     targetRows: input.maxRows,
+    benchmarkMetadata: collectionBenchmarkMetadataFromEnv(input.env),
   });
+}
+
+async function loadCollectionRunnerFromEnv(
+  env: NodeJS.ProcessEnv
+): Promise<CollectionPopulatePipelineRunner | undefined> {
+  const moduleSpecifier = env.POPULATE_COLLECTION_RUNNER_MODULE;
+  if (!moduleSpecifier) {
+    return undefined;
+  }
+
+  const moduleUrl = moduleSpecifier.startsWith(".") || moduleSpecifier.startsWith("/")
+    ? pathToFileURL(resolve(moduleSpecifier)).href
+    : moduleSpecifier;
+  const loadedModule = await import(moduleUrl);
+  const runner = loadedModule.runCollectionPopulatePipeline ?? loadedModule.default;
+  if (typeof runner !== "function") {
+    throw new Error(
+      `${moduleSpecifier} must export runCollectionPopulatePipeline(input) or a default runner.`
+    );
+  }
+  return runner as CollectionPopulatePipelineRunner;
+}
+
+function collectionBenchmarkMetadataFromEnv(
+  env: NodeJS.ProcessEnv
+): CollectionPopulateBenchmarkMetadata {
+  return {
+    promptId: env.BIGSET_BENCHMARK_PROMPT_ID,
+    promptQuality: env.BIGSET_BENCHMARK_PROMPT_QUALITY,
+    persona: env.BIGSET_BENCHMARK_PERSONA,
+    expectedStress: env.BIGSET_BENCHMARK_EXPECTED_STRESS,
+  };
 }

--- a/backend/src/pipeline/populate-runtime.ts
+++ b/backend/src/pipeline/populate-runtime.ts
@@ -31,6 +31,23 @@ export interface PopulateRuntimeRow {
   needsReview: boolean;
 }
 
+export interface PopulateRuntimeCapturedInsertedRow {
+  datasetId: string;
+  data: Record<string, unknown>;
+}
+
+export interface PopulateRuntimeCapturedSource {
+  url: string;
+  text: string;
+}
+
+export interface PopulateRuntimeDebug {
+  capturedRows: PopulateRuntimeCapturedInsertedRow[];
+  capturedSources: PopulateRuntimeCapturedSource[];
+  selectedRowSource: "insert_row" | "structured_recovery" | "none";
+  notes: string[];
+}
+
 export interface PopulateRuntimeResult {
   rows: PopulateRuntimeRow[];
   validationIssues: string[];
@@ -46,6 +63,7 @@ export interface PopulateRuntimeResult {
     agentRuns: number;
     agentSteps: number;
   };
+  debug?: PopulateRuntimeDebug;
 }
 
 export interface PopulateWebSearchResult {
@@ -68,16 +86,6 @@ export type PopulateRuntimeAgentRunner = (input: {
   prompt: string;
   tools: Record<string, unknown>;
 }) => Promise<unknown>;
-
-interface CapturedInsertedRow {
-  datasetId: string;
-  data: Record<string, unknown>;
-}
-
-interface CapturedSource {
-  url: string;
-  text: string;
-}
 
 const structuredPopulateEvidenceSchema = z.object({
   columnName: z.string().optional(),
@@ -109,9 +117,10 @@ export async function runPopulateRuntime(input: {
     return clarificationResult;
   }
 
-  const capturedRows: CapturedInsertedRow[] = [];
-  const capturedSources: CapturedSource[] = [];
+  const capturedRows: PopulateRuntimeCapturedInsertedRow[] = [];
+  const capturedSources: PopulateRuntimeCapturedSource[] = [];
   const validationIssues: string[] = [];
+  const debugNotes: string[] = [];
   const metrics = emptyMetrics();
   const webTools = input.webTools ?? createTinyFishWebTools();
   const tools = createPopulateRuntimeTools({
@@ -180,6 +189,7 @@ export async function runPopulateRuntime(input: {
     requestedColumns: parsedContext.columns.map((column) => column.name),
     capturedSources,
     validationIssues,
+    debugNotes,
   });
   const structuredRowIssues = validateRuntimeRows(structuredRows);
   if (
@@ -197,7 +207,12 @@ export async function runPopulateRuntime(input: {
     insertedRowIssues,
     structuredRows,
     structuredRowIssues,
-    validationIssues,
+    debugNotes,
+  });
+  const selectedRowSource = selectedRowSourceForRows({
+    rows,
+    insertedRows,
+    structuredRows,
   });
   validationIssues.push(...validateRuntimeRows(rows));
 
@@ -206,6 +221,12 @@ export async function runPopulateRuntime(input: {
     validationIssues: Array.from(new Set(validationIssues)),
     usage: emptyUsage(),
     metrics,
+    debug: {
+      capturedRows,
+      capturedSources,
+      selectedRowSource,
+      notes: debugNotes,
+    },
   };
 }
 
@@ -255,18 +276,24 @@ function emptyClarificationResult(validationIssues: string[]): PopulateRuntimeRe
     validationIssues,
     usage: emptyUsage(),
     metrics: emptyMetrics(),
+    debug: {
+      capturedRows: [],
+      capturedSources: [],
+      selectedRowSource: "none",
+      notes: [],
+    },
   };
 }
 
 async function enrichCapturedSourcesForStructuredFallback(input: {
   context: DatasetContext;
-  capturedSources: CapturedSource[];
+  capturedSources: PopulateRuntimeCapturedSource[];
   validationIssues: string[];
   metrics: PopulateRuntimeResult["metrics"];
   webTools: PopulateRuntimeWebTools;
 }) {
   const entities = entityCandidatesFromDescription(input.context.description);
-  const newSources: CapturedSource[] = [];
+  const newSources: PopulateRuntimeCapturedSource[] = [];
   for (const entity of entities.slice(0, 4)) {
     let results: PopulateWebSearchResult[] = [];
     for (const query of searchQueriesForEntity(entity, input.context)) {
@@ -328,7 +355,7 @@ async function captureDirectOfficialSource(input: {
     metrics: PopulateRuntimeResult["metrics"];
     webTools: PopulateRuntimeWebTools;
   };
-  newSources: CapturedSource[];
+  newSources: PopulateRuntimeCapturedSource[];
 }) {
   input.newSources.push({
     url: input.url,
@@ -504,7 +531,7 @@ function searchResultScore(
 
 async function generateStructuredRowsFromCapturedSources(input: {
   context: DatasetContext;
-  capturedSources: CapturedSource[];
+  capturedSources: PopulateRuntimeCapturedSource[];
 }): Promise<StructuredPopulateOutput> {
   const openrouter = createOpenRouter({
     apiKey: requiredEnv("OPENROUTER_API_KEY"),
@@ -535,7 +562,7 @@ async function generateStructuredRowsFromCapturedSources(input: {
 
 function buildStructuredRowsPrompt(input: {
   context: DatasetContext;
-  capturedSources: CapturedSource[];
+  capturedSources: PopulateRuntimeCapturedSource[];
 }): string {
   const columnNames = input.context.columns.map((column) => column.name);
   const entities = entityCandidatesFromDescription(input.context.description);
@@ -631,15 +658,15 @@ function selectBestRuntimeRows(input: {
   insertedRowIssues: string[];
   structuredRows: PopulateRuntimeRow[];
   structuredRowIssues: string[];
-  validationIssues: string[];
+  debugNotes: string[];
 }): PopulateRuntimeRow[] {
   if (input.insertedRows.length > 0 && input.insertedRowIssues.length === 0) {
     return input.insertedRows;
   }
   if (input.structuredRows.length > 0 && input.structuredRowIssues.length === 0) {
     if (input.insertedRows.length > 0) {
-      input.validationIssues.push(
-        "Structured row recovery replaced insert_row rows that failed source/evidence validation."
+      input.debugNotes.push(
+        "Structured row recovery replaced insert_row rows without enough source/evidence support."
       );
     }
     return input.structuredRows;
@@ -647,10 +674,27 @@ function selectBestRuntimeRows(input: {
   return input.insertedRows.length > 0 ? input.insertedRows : input.structuredRows;
 }
 
+function selectedRowSourceForRows(input: {
+  rows: PopulateRuntimeRow[];
+  insertedRows: PopulateRuntimeRow[];
+  structuredRows: PopulateRuntimeRow[];
+}): PopulateRuntimeDebug["selectedRowSource"] {
+  if (input.rows.length === 0) {
+    return "none";
+  }
+  if (input.rows === input.insertedRows) {
+    return "insert_row";
+  }
+  if (input.rows === input.structuredRows) {
+    return "structured_recovery";
+  }
+  return "none";
+}
+
 function createPopulateRuntimeTools(input: {
   datasetId: string;
-  capturedRows: CapturedInsertedRow[];
-  capturedSources: CapturedSource[];
+  capturedRows: PopulateRuntimeCapturedInsertedRow[];
+  capturedSources: PopulateRuntimeCapturedSource[];
   validationIssues: string[];
   metrics: PopulateRuntimeResult["metrics"];
   webTools: PopulateRuntimeWebTools;
@@ -819,8 +863,9 @@ function benchmarkRowsFromStructuredOutput(input: {
   maxRows: number;
   context: DatasetContext;
   requestedColumns: string[];
-  capturedSources: CapturedSource[];
+  capturedSources: PopulateRuntimeCapturedSource[];
   validationIssues: string[];
+  debugNotes: string[];
 }): PopulateRuntimeRow[] {
   if (!input.output) {
     return [];
@@ -849,7 +894,7 @@ function benchmarkRowsFromStructuredOutput(input: {
       sourceUrls,
       capturedSources: input.capturedSources,
       context: input.context,
-      validationIssues: input.validationIssues,
+      debugNotes: input.debugNotes,
       rowNumber: index + 1,
     });
     if (sourceUrls.length === 0) {
@@ -913,9 +958,9 @@ function repairStructuredEvidence(input: {
   evidence: PopulateRuntimeRow["evidence"];
   cells: Record<string, PopulateCellValue>;
   sourceUrls: string[];
-  capturedSources: CapturedSource[];
+  capturedSources: PopulateRuntimeCapturedSource[];
   context: DatasetContext;
-  validationIssues: string[];
+  debugNotes: string[];
   rowNumber: number;
 }): PopulateRuntimeRow["evidence"] {
   return input.evidence.map((item) => {
@@ -931,7 +976,7 @@ function repairStructuredEvidence(input: {
     if (!repairedQuote) {
       return item;
     }
-    input.validationIssues.push(
+    input.debugNotes.push(
       `Structured row ${input.rowNumber}: replaced evidence quote with captured source text.`
     );
     return {
@@ -945,7 +990,7 @@ function repairStructuredEvidence(input: {
 function quoteFromCapturedSources(input: {
   cells: Record<string, PopulateCellValue>;
   sourceUrls: string[];
-  capturedSources: CapturedSource[];
+  capturedSources: PopulateRuntimeCapturedSource[];
   context: DatasetContext;
 }): { sourceUrl: string; quote: string } | undefined {
   const sourceUrlSet = new Set(input.sourceUrls);
@@ -1011,7 +1056,7 @@ function sourceQuoteForCandidate(sourceText: string, candidate: string): string 
 
 function isEvidenceBackedByCapturedSource(
   evidence: PopulateRuntimeRow["evidence"][number],
-  capturedSources: CapturedSource[]
+  capturedSources: PopulateRuntimeCapturedSource[]
 ): boolean {
   const normalizedQuote = normalizeEvidenceText(evidence.quote);
   return capturedSources.some((source) => {

--- a/backend/src/pipeline/populate-runtime.ts
+++ b/backend/src/pipeline/populate-runtime.ts
@@ -4,48 +4,80 @@ import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { z } from "zod";
 
 import {
-  buildPopulatePrompt,
-  populateAgentInstructions,
-} from "./populate-prompt.js";
+  DEFAULT_OPENROUTER_MODEL_ID,
+  requiredOpenRouterApiKey,
+} from "../openrouter-models.js";
+import { runParallelPopulatePhase, type PopulateParallelHooks } from "./populate-parallel.js";
+import {
+  finalizeAcquisitionResult,
+  normalizePopulateAcquisitionResult,
+  runSearchAcquisitionPhase,
+  type PopulateAcquisitionResult,
+  type SearchAcquisitionAgentRunner,
+  type SearchAcquisitionPhaseResult,
+} from "./populate-acquisition.js";
+import type { inferSchema } from "./schema-inference.js";
+import {
+  isPopulateBenchmarkDebugEnabled,
+  populateBenchmarkArtifactDirectory,
+  writePopulateBenchmarkDebugArtifacts,
+} from "./populate-benchmark-debug.js";
+import {
+  resolvePopulateRuntimeLimits,
+  type PopulateRuntimeLimits,
+} from "./populate-runtime-limits.js";
+import {
+  normalizeSearchResultUrl,
+  siteNameFromUrl,
+} from "./populate-search-prioritization.js";
+import type {
+  PopulateFetchedPage,
+  PopulateRuntimeCapturedSource,
+  PopulateRuntimeWebTools,
+  PopulateWebSearchResult,
+} from "./populate-web-types.js";
 import {
   datasetContextSchema,
   type DatasetContext,
 } from "./populate.js";
+import {
+  getCurrentLlmUsage,
+  recordAgentGenerationUsage,
+  runWithLlmUsageScope,
+  toPopulateRuntimeUsage,
+} from "./llm-usage.js";
+import {
+  structuredPopulateEvidenceSchema,
+  structuredPopulateOutputSchema,
+  type DatasetSchema,
+  type StructuredPopulateOutput,
+} from "./types.js";
 
-export type PopulateCellValue =
-  | string
-  | number
-  | boolean
-  | null
-  | Record<string, unknown>
-  | unknown[];
+export type {
+  PopulateFetchedPage,
+  PopulateRuntimeCapturedSource,
+  PopulateRuntimeWebTools,
+  PopulateWebSearchResult,
+} from "./populate-web-types.js";
 
-export interface PopulateRuntimeRow {
-  cells: Record<string, PopulateCellValue>;
-  sourceUrls: string[];
-  evidence: Array<{
-    columnName: string;
-    sourceUrl: string;
-    quote: string;
-  }>;
-  needsReview: boolean;
-}
+export type { PopulateCellValue, PopulateRuntimeRow } from "./populate-row.js";
+import type { PopulateCellValue, PopulateRuntimeRow } from "./populate-row.js";
 
 export interface PopulateRuntimeCapturedInsertedRow {
   datasetId: string;
   data: Record<string, unknown>;
 }
 
-export interface PopulateRuntimeCapturedSource {
-  url: string;
-  text: string;
-}
-
 export interface PopulateRuntimeDebug {
+  acquisition?: PopulateAcquisitionResult;
   capturedRows: PopulateRuntimeCapturedInsertedRow[];
   capturedSources: PopulateRuntimeCapturedSource[];
   selectedRowSource: "insert_row" | "structured_recovery" | "none";
   notes: string[];
+  metricsBreakdown?: {
+    acquisitionSearchCalls: number;
+    populateFetchCalls: number;
+  };
 }
 
 export interface PopulateRuntimeResult {
@@ -66,50 +98,23 @@ export interface PopulateRuntimeResult {
   debug?: PopulateRuntimeDebug;
 }
 
-export interface PopulateWebSearchResult {
-  title: string;
-  snippet?: string;
-  url: string;
-}
-
-export interface PopulateFetchedPage {
-  title?: string;
-  text?: string;
-}
-
-export interface PopulateRuntimeWebTools {
-  search(input: { query: string }): Promise<PopulateWebSearchResult[]>;
-  fetch(input: { url: string }): Promise<PopulateFetchedPage>;
-}
-
 export type PopulateRuntimeAgentRunner = (input: {
   prompt: string;
   tools: Record<string, unknown>;
 }) => Promise<unknown>;
 
-const structuredPopulateEvidenceSchema = z.object({
-  columnName: z.string().optional(),
-  sourceUrl: z.string().optional(),
-  quote: z.string(),
-});
-
-const structuredPopulateOutputSchema = z.object({
-  rows: z.array(z.object({
-    cells: z.record(z.string(), z.any()),
-    sourceUrls: z.array(z.string()).optional(),
-    evidence: z.array(structuredPopulateEvidenceSchema).optional(),
-    needsReview: z.boolean().optional(),
-  })).default([]),
-  validationIssues: z.array(z.string()).default([]),
-});
-
-type StructuredPopulateOutput = z.infer<typeof structuredPopulateOutputSchema>;
-
 export async function runPopulateRuntime(input: {
   context: DatasetContext;
+  dataSpec?: DatasetSchema;
   webTools?: PopulateRuntimeWebTools;
   agentRunner?: PopulateRuntimeAgentRunner;
+  searchAcquisitionRunner?: SearchAcquisitionAgentRunner;
+  acquisition?: PopulateAcquisitionResult;
   maxRows?: number;
+  maxSearchCalls?: number;
+  maxFetchCalls?: number;
+  inferSchemaFn?: typeof inferSchema;
+  populateHooks?: PopulateParallelHooks;
 }): Promise<PopulateRuntimeResult> {
   const parsedContext = datasetContextSchema.parse(input.context);
   const clarificationResult = clarificationResultForContext(parsedContext);
@@ -117,131 +122,198 @@ export async function runPopulateRuntime(input: {
     return clarificationResult;
   }
 
-  const capturedRows: PopulateRuntimeCapturedInsertedRow[] = [];
+  const { result, usage } = await runWithLlmUsageScope(async () => {
   const capturedSources: PopulateRuntimeCapturedSource[] = [];
   const validationIssues: string[] = [];
   const debugNotes: string[] = [];
   const metrics = emptyMetrics();
-  const webTools = input.webTools ?? createTinyFishWebTools();
-  const tools = createPopulateRuntimeTools({
-    datasetId: parsedContext.datasetId,
-    capturedRows,
-    capturedSources,
-    validationIssues,
-    metrics,
-    webTools,
-    maxRows: input.maxRows ?? 10,
+  const limits = resolvePopulateRuntimeLimits({
+    maxRows: input.maxRows,
+    maxSearchCalls: input.maxSearchCalls,
+    maxFetchCalls: input.maxFetchCalls,
   });
-  const prompt = buildPopulatePrompt(parsedContext);
-  let agentOutput: unknown;
+  const webTools = input.webTools ?? createTinyFishWebTools();
+  let acquisitionSearchCalls = 0;
 
-  if (input.agentRunner) {
+  let dataSpec = input.dataSpec;
+  let acquisition = input.acquisition;
+  let searchPoolResults: SearchAcquisitionPhaseResult["searchPoolResults"] = [];
+  if (!acquisition) {
     try {
-      agentOutput = await input.agentRunner({ prompt, tools });
-      metrics.agentRuns += 1;
-    } catch (error) {
-      validationIssues.push(populateAgentFailureMessage(error));
-    }
-  } else {
-    try {
-      const agent = createRuntimePopulateAgent({ tools });
-      agentOutput = await agent.generate(prompt);
-      metrics.agentRuns += 1;
-    } catch (error) {
-      validationIssues.push(populateAgentFailureMessage(error));
-    }
-
-  }
-
-  const insertedRows = capturedRows.map((row) => benchmarkRowFromInsertedData(row.data));
-  const insertedRowIssues = validateRuntimeRows(insertedRows);
-  if (
-    !input.agentRunner &&
-    capturedSources.length > 0 &&
-    shouldRecoverFromInsertedRows(insertedRowIssues)
-  ) {
-    await enrichCapturedSourcesForStructuredFallback({
-      context: parsedContext,
-      capturedSources,
-      validationIssues,
-      metrics,
-      webTools,
-    });
-    try {
-      agentOutput = await generateStructuredRowsFromCapturedSources({
+      const acquisitionPhase = await runSearchAcquisitionPhase({
         context: parsedContext,
-        capturedSources,
+        dataSpec,
+        maxSearchCalls: limits.maxSearchCalls,
+        webTools,
+        metrics,
+        validationIssues,
+        debugNotes,
+        searchAcquisitionRunner: input.searchAcquisitionRunner,
+        inferSchemaFn: input.inferSchemaFn,
       });
-      metrics.agentRuns += 1;
+      searchPoolResults = acquisitionPhase.searchPoolResults;
+      acquisition = finalizeAcquisitionResult(
+        acquisitionPhase,
+        limits.maxFetchCalls
+      );
+      if (!dataSpec) {
+        dataSpec = acquisitionPhase.dataSpec;
+        debugNotes.push(
+          `Inferred data spec "${dataSpec.dataset_name}" with ${acquisitionPhase.initialQueries.length} seed search queries.`
+        );
+      }
     } catch (error) {
       validationIssues.push(
-        `Structured row generation failed: ${
+        `Search acquisition failed: ${
           error instanceof Error ? error.message : String(error)
         }`
       );
+      acquisition = {
+        prioritizedUrls: [],
+        scoredUrls: [],
+        initialQueries: [],
+        validationIssues: [],
+      };
     }
+  } else {
+    acquisition = normalizePopulateAcquisitionResult(acquisition, limits.maxFetchCalls);
+  }
+  acquisitionSearchCalls = metrics.searchCalls;
+
+  if (!dataSpec) {
+    validationIssues.push("Populate phase requires a dataset spec.");
+    dataSpec = {
+      dataset_name: parsedContext.datasetName,
+      description: parsedContext.description,
+      primary_key: parsedContext.columns[0]?.name ?? "entity_name",
+      search_queries: acquisition.initialQueries.length
+        ? acquisition.initialQueries
+        : ["populate"],
+      columns: parsedContext.columns.map((column) => ({
+        name: column.name,
+        display_name: column.name,
+        type: mapContextColumnType(column.type),
+        is_primary_key: column.name === (parsedContext.columns[0]?.name ?? ""),
+        is_enumerable: false,
+        description: column.description ?? column.name,
+        nullable: true,
+      })),
+    };
   }
 
-  const structuredRows = benchmarkRowsFromStructuredOutput({
-    output: structuredOutputFromAgentResult(agentOutput),
-    maxRows: input.maxRows ?? 10,
+  const parallelResult = await runParallelPopulatePhase({
     context: parsedContext,
-    requestedColumns: parsedContext.columns.map((column) => column.name),
-    capturedSources,
+    dataSpec,
+    acquisition,
+    limits,
+    webTools,
+    metrics,
     validationIssues,
     debugNotes,
+    hooks: input.populateHooks,
   });
-  const structuredRowIssues = validateRuntimeRows(structuredRows);
-  if (
-    insertedRows.length > 0 &&
-    insertedRowIssues.length === 0 &&
-    structuredRows.length > 0 &&
-    hasContradictingStructuredRows(insertedRows, structuredRows)
-  ) {
-    validationIssues.push(
-      "Structured populate rows differed from insert_row rows and were ignored."
-    );
-  }
-  const rows = selectBestRuntimeRows({
-    insertedRows,
-    insertedRowIssues,
-    structuredRows,
-    structuredRowIssues,
-    debugNotes,
-  });
-  const selectedRowSource = selectedRowSourceForRows({
-    rows,
-    insertedRows,
-    structuredRows,
-  });
-  validationIssues.push(...validateRuntimeRows(rows));
 
-  return {
+  capturedSources.push(...parallelResult.capturedSources);
+  const populatePromptUrlCount = acquisition.prioritizedUrls.length;
+  const allowedEvidenceUrls = new Set(
+    acquisition.prioritizedUrls.map((url) => normalizeSearchResultUrl(url))
+  );
+  const rows = parallelResult.rows.map((row) =>
+    withEnsuredRowEvidence(row, {
+      capturedSources,
+      context: parsedContext,
+      allowedEvidenceUrls,
+    })
+  );
+  validationIssues.push(...validateRuntimeRows(rows));
+  const selectedRowSource: PopulateRuntimeDebug["selectedRowSource"] =
+    rows.length > 0 ? "structured_recovery" : "none";
+
+  const populateFetchCalls = metrics.fetchCalls;
+  const llmUsage = getCurrentLlmUsage();
+  debugNotes.push(
+    `Metrics: ${acquisitionSearchCalls} acquisition search call(s), ${populateFetchCalls} populate fetch call(s).`
+  );
+  debugNotes.push(
+    `LLM usage (internal): ${llmUsage.promptTokens} prompt + ${llmUsage.completionTokens} completion tokens across ${llmUsage.callCount} call(s).`
+  );
+
+  const capturedRowsForDebug: PopulateRuntimeCapturedInsertedRow[] = rows.map(
+    (row) => ({
+      datasetId: parsedContext.datasetId,
+      data: row.cells,
+    })
+  );
+
+  const runtimeResult = {
     rows,
     validationIssues: Array.from(new Set(validationIssues)),
-    usage: emptyUsage(),
-    metrics,
+    metrics: {
+      ...metrics,
+      searchCalls: acquisitionSearchCalls,
+      fetchCalls: populateFetchCalls,
+    },
     debug: {
-      capturedRows,
+      capturedRows: capturedRowsForDebug,
       capturedSources,
       selectedRowSource,
       notes: debugNotes,
+      acquisition,
+      metricsBreakdown: {
+        acquisitionSearchCalls,
+        populateFetchCalls,
+      },
     },
+  };
+
+  if (isPopulateBenchmarkDebugEnabled()) {
+    const artifactDirectory = populateBenchmarkArtifactDirectory();
+    if (artifactDirectory) {
+      await writePopulateBenchmarkDebugArtifacts(artifactDirectory, {
+        runAt: new Date().toISOString(),
+        context: parsedContext,
+        limits,
+        dataSpec,
+        initialQueries: acquisition.initialQueries,
+        searchPool: searchPoolResults,
+        acquisition,
+        populatePromptUrlCount,
+        capturedSources,
+        capturedRows: rows.map((row) => ({
+          datasetId: parsedContext.datasetId,
+          data: row.cells,
+        })),
+        validationIssues: runtimeResult.validationIssues,
+        metrics: runtimeResult.metrics,
+        notes: debugNotes,
+      });
+    }
+  }
+
+  return runtimeResult;
+  });
+
+  return {
+    ...result,
+    usage: toPopulateRuntimeUsage(usage),
   };
 }
 
-function createRuntimePopulateAgent(input: { tools: Record<string, unknown> }) {
-  const openrouter = createOpenRouter({
-    apiKey: requiredEnv("OPENROUTER_API_KEY"),
-  });
-
-  return new Agent({
-    id: "populate-agent",
-    name: "Dataset Populate Agent",
-    instructions: populateAgentInstructions,
-    model: openrouter("anthropic/claude-sonnet-4-6"),
-    tools: input.tools as ConstructorParameters<typeof Agent>[0]["tools"],
-  });
+function mapContextColumnType(
+  type: DatasetContext["columns"][number]["type"]
+): DatasetSchema["columns"][number]["type"] {
+  switch (type) {
+    case "url":
+      return "url";
+    case "date":
+      return "date";
+    case "number":
+      return "number";
+    case "boolean":
+      return "boolean";
+    default:
+      return "string";
+  }
 }
 
 function clarificationResultForContext(
@@ -285,131 +357,41 @@ function emptyClarificationResult(validationIssues: string[]): PopulateRuntimeRe
   };
 }
 
-async function enrichCapturedSourcesForStructuredFallback(input: {
-  context: DatasetContext;
-  capturedSources: PopulateRuntimeCapturedSource[];
-  validationIssues: string[];
-  metrics: PopulateRuntimeResult["metrics"];
-  webTools: PopulateRuntimeWebTools;
-}) {
-  const entities = entityCandidatesFromDescription(input.context.description);
-  const newSources: PopulateRuntimeCapturedSource[] = [];
-  for (const entity of entities.slice(0, 4)) {
-    let results: PopulateWebSearchResult[] = [];
-    for (const query of searchQueriesForEntity(entity, input.context)) {
-      input.metrics.searchCalls += 1;
-      try {
-        results = uniqueSearchResults([
-          ...results,
-          ...await input.webTools.search({ query }),
-        ]);
-      } catch (error) {
-        input.validationIssues.push(
-          `Structured fallback search failed for ${entity}: ${
-            error instanceof Error ? error.message : String(error)
-          }`
-        );
-      }
-    }
-
-    const officialPath = officialContentPathForEntity(entity, input.context);
-    if (officialPath) {
-      await captureDirectOfficialSource({
-        entity,
-        url: urlFromOfficialPath(officialPath),
-        input,
-        newSources,
-      });
-    }
-
-    const rankedResults = rankSearchResultsForEntity(results, entity).slice(0, 4);
-    for (const result of rankedResults) {
-      newSources.push({
-        url: result.url,
-        text: [result.title, result.snippet].filter(Boolean).join("\n"),
-      });
-      input.metrics.fetchCalls += 1;
-      try {
-        const page = await input.webTools.fetch({ url: result.url });
-        newSources.push({
-          url: result.url,
-          text: [page.title, page.text].filter(Boolean).join("\n"),
-        });
-      } catch (error) {
-        input.validationIssues.push(
-          `Structured fallback fetch failed for ${result.url}: ${
-            error instanceof Error ? error.message : String(error)
-          }`
-        );
-      }
-    }
-  }
-  input.capturedSources.unshift(...newSources);
-}
-
-async function captureDirectOfficialSource(input: {
-  entity: string;
+async function recordPopulatePageFetch(input: {
   url: string;
-  input: {
-    validationIssues: string[];
-    metrics: PopulateRuntimeResult["metrics"];
-    webTools: PopulateRuntimeWebTools;
-  };
-  newSources: PopulateRuntimeCapturedSource[];
-}) {
-  input.newSources.push({
-    url: input.url,
-    text: `${input.entity} official source\n${input.url}`,
-  });
-  input.input.metrics.fetchCalls += 1;
+  metrics: PopulateRuntimeResult["metrics"];
+  capturedSources: PopulateRuntimeCapturedSource[];
+  webTools: PopulateRuntimeWebTools;
+  validationIssues: string[];
+  allowedFetchUrls: Set<string>;
+}): Promise<{ title?: string; text?: string; error?: string }> {
+  const normalizedUrl = normalizeSearchResultUrl(input.url);
+  if (!input.allowedFetchUrls.has(normalizedUrl)) {
+    return {
+      error:
+        "URL is not in the source URL list for this run. Use fetch_page only on URLs listed in the prompt.",
+    };
+  }
+
+  input.metrics.fetchCalls += 1;
   try {
-    const page = await input.input.webTools.fetch({ url: input.url });
-    input.newSources.push({
-      url: input.url,
-      text: [page.title, page.text].filter(Boolean).join("\n"),
-    });
-  } catch (error) {
-    input.input.validationIssues.push(
-      `Structured fallback fetch failed for ${input.url}: ${
-        error instanceof Error ? error.message : String(error)
-      }`
+    const page = await input.webTools.fetch({ url: normalizedUrl });
+    const fetchedText = [page.title, page.text].filter(Boolean).join("\n");
+    const existingIndex = input.capturedSources.findIndex(
+      (source) => normalizeSearchResultUrl(source.url) === normalizedUrl
     );
+    const captured = { url: normalizedUrl, text: fetchedText };
+    if (existingIndex >= 0) {
+      input.capturedSources[existingIndex] = captured;
+    } else {
+      input.capturedSources.push(captured);
+    }
+    return page;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    input.validationIssues.push(`fetch_page failed: ${message}`);
+    return { error: message };
   }
-}
-
-function urlFromOfficialPath(officialPath: string): string {
-  return officialPath.startsWith("http") ? officialPath : `https://${officialPath}`;
-}
-
-function searchQueriesForEntity(entity: string, context: DatasetContext): string[] {
-  const searchPhrase = taskSearchPhrase(context);
-  const queries = [
-    `${entity} ${searchPhrase} official source`,
-    ...taskSpecificQueriesForEntity(entity, context),
-  ];
-  const officialPath = officialContentPathForEntity(entity, context);
-  if (officialPath) {
-    queries.push(`site:${officialPath} ${entity} ${searchPhrase}`);
-  }
-  return Array.from(new Set(queries));
-}
-
-function taskSpecificQueriesForEntity(
-  entity: string,
-  context: DatasetContext
-): string[] {
-  const taskText = contextText(context);
-  const queries: string[] = [];
-  if (/\b(mcp|docs?|server|setup)\b/i.test(taskText)) {
-    queries.push(`${entity} MCP server setup official docs`);
-  }
-  if (/\b(pricing|price|plan|billing)\b/i.test(taskText)) {
-    queries.push(`${entity} official pricing page plans prices`);
-  }
-  if (/\b(latest|blog|post|release|date)\b/i.test(taskText)) {
-    queries.push(`${entity} latest official blog post publish date`);
-  }
-  return queries;
 }
 
 function officialContentPathForEntity(
@@ -451,35 +433,11 @@ function officialContentPathForEntity(
   return undefined;
 }
 
-function taskSearchPhrase(context: DatasetContext): string {
-  const taskText = contextText(context);
-  if (/\b(mcp|docs?|server|setup)\b/i.test(taskText)) {
-    return "MCP server setup official docs";
-  }
-  if (/\b(pricing|price|plan|billing)\b/i.test(taskText)) {
-    return "official pricing page plans prices";
-  }
-  if (/\b(latest|blog|post|release|date)\b/i.test(taskText)) {
-    return "latest official source title date URL";
-  }
-  return truncateForPrompt(context.description, 120);
-}
-
 function contextText(context: DatasetContext): string {
   return [
     context.description,
     ...context.columns.map((column) => `${column.name} ${column.description ?? ""}`),
   ].join(" ");
-}
-
-function uniqueSearchResults(results: PopulateWebSearchResult[]): PopulateWebSearchResult[] {
-  const byUrl = new Map<string, PopulateWebSearchResult>();
-  for (const result of results) {
-    if (!byUrl.has(result.url)) {
-      byUrl.set(result.url, result);
-    }
-  }
-  return [...byUrl.values()];
 }
 
 function entityCandidatesFromDescription(description: string): string[] {
@@ -497,125 +455,6 @@ function entityCandidatesFromDescription(description: string): string[] {
       candidate.length <= 60 &&
       !/^(can|could|would|table|title|url|date|latest)$/i.test(candidate)
     )));
-}
-
-function rankSearchResultsForEntity(
-  results: PopulateWebSearchResult[],
-  entity: string
-): PopulateWebSearchResult[] {
-  const entityTokens = entity.toLowerCase().split(/\s+/).filter((token) => token.length > 2);
-  return [...results].sort((a, b) =>
-    searchResultScore(b, entityTokens) - searchResultScore(a, entityTokens)
-  );
-}
-
-function searchResultScore(
-  result: PopulateWebSearchResult,
-  entityTokens: string[]
-): number {
-  const haystack = `${result.title} ${result.snippet ?? ""} ${result.url}`.toLowerCase();
-  let score = 0;
-  for (const token of entityTokens) {
-    if (haystack.includes(token)) {
-      score += 1;
-    }
-  }
-  if (/official|blog|news|post/i.test(haystack)) {
-    score += 1;
-  }
-  if (/\.com|\.google|\.ai/i.test(result.url)) {
-    score += 0.5;
-  }
-  return score;
-}
-
-async function generateStructuredRowsFromCapturedSources(input: {
-  context: DatasetContext;
-  capturedSources: PopulateRuntimeCapturedSource[];
-}): Promise<StructuredPopulateOutput> {
-  const openrouter = createOpenRouter({
-    apiKey: requiredEnv("OPENROUTER_API_KEY"),
-  });
-  const agent = new Agent({
-    id: "populate-structured-row-agent",
-    name: "Dataset Populate Structured Row Agent",
-    instructions: [
-      "Convert captured search/fetch source text into benchmark rows.",
-      "Only use facts directly present in the source transcript.",
-      "Every evidence quote must be copied from source text.",
-    ].join("\n"),
-    model: openrouter("anthropic/claude-sonnet-4-6"),
-  });
-  const output = await agent.generate(buildStructuredRowsPrompt(input), {
-    structuredOutput: {
-      schema: structuredPopulateOutputSchema,
-      jsonPromptInjection: true,
-      errorStrategy: "fallback",
-      fallbackValue: {
-        rows: [],
-        validationIssues: ["Structured row generation produced no valid rows."],
-      },
-    },
-  });
-  return structuredPopulateOutputSchema.parse(output.object);
-}
-
-function buildStructuredRowsPrompt(input: {
-  context: DatasetContext;
-  capturedSources: PopulateRuntimeCapturedSource[];
-}): string {
-  const columnNames = input.context.columns.map((column) => column.name);
-  const entities = entityCandidatesFromDescription(input.context.description);
-  const officialHints = Object.fromEntries(
-    entities.map((entity) => [
-      entity,
-      officialContentPathForEntity(entity, input.context) ?? "official source",
-    ])
-  );
-  const sourceTranscript = input.capturedSources
-    .slice(0, 30)
-    .map((source, index) => [
-      `SOURCE ${index + 1}`,
-      `URL: ${source.url}`,
-      "TEXT:",
-      truncateForPrompt(source.text, 3_000),
-    ].join("\n"))
-    .join("\n\n");
-
-  return `Dataset description:
-${input.context.description}
-
-Required columns:
-${JSON.stringify(columnNames)}
-
-Named entities, when present:
-${JSON.stringify(entities)}
-
-Official source hints:
-${JSON.stringify(officialHints)}
-
-Captured source transcript:
-${sourceTranscript}
-
-Return rows using this exact shape:
-{ "rows": [{ "cells": {}, "sourceUrls": [], "evidence": [{ "columnName": "", "sourceUrl": "", "quote": "" }], "needsReview": true }], "validationIssues": [] }
-
-Rules:
-- cells must contain exactly the required columns.
-- sourceUrls must contain exact URLs from the captured source transcript.
-- evidence.sourceUrl must exactly match one captured source URL.
-- evidence.quote must be copied verbatim from that source text.
-- needsReview must be true.
-- If named entities are present, return at most one best row per named entity.
-- Prefer official docs, pricing, or product pages over blogs, announcements, directories, or reviews unless the prompt asks for news/blog posts.
-- Return fewer rows rather than inventing missing values.`;
-}
-
-function truncateForPrompt(value: string, maxLength: number): string {
-  if (value.length <= maxLength) {
-    return value;
-  }
-  return `${value.slice(0, maxLength)}\n[truncated]`;
 }
 
 function populateAgentFailureMessage(error: unknown): string {
@@ -645,12 +484,6 @@ function objectProperty(input: unknown, key: string): unknown {
     return undefined;
   }
   return (input as Record<string, unknown>)[key];
-}
-
-function shouldRecoverFromInsertedRows(issues: string[]): boolean {
-  return issues.some((issue) =>
-    /returned no rows|no source url|evidence quotes/i.test(issue)
-  );
 }
 
 function selectBestRuntimeRows(input: {
@@ -698,7 +531,8 @@ function createPopulateRuntimeTools(input: {
   validationIssues: string[];
   metrics: PopulateRuntimeResult["metrics"];
   webTools: PopulateRuntimeWebTools;
-  maxRows: number;
+  limits: PopulateRuntimeLimits;
+  allowedFetchUrls: Set<string>;
 }) {
   return {
     insert_row: createTool({
@@ -719,44 +553,14 @@ function createPopulateRuntimeTools(input: {
             error: `datasetId must be ${input.datasetId}.`,
           };
         }
-        if (input.capturedRows.length >= input.maxRows) {
+        if (input.capturedRows.length >= input.limits.maxRows) {
           return {
             success: false,
-            error: `Row cap reached for this benchmark run (${input.maxRows}).`,
+            error: `Row cap reached for this benchmark run (${input.limits.maxRows}).`,
           };
         }
         input.capturedRows.push({ datasetId, data });
         return { success: true };
-      },
-    }),
-    search_web: createTool({
-      id: "search_web",
-      description: "Search the web for source-backed dataset rows.",
-      inputSchema: z.object({ query: z.string() }),
-      outputSchema: z.object({
-        results: z.array(z.object({
-          title: z.string(),
-          snippet: z.string().optional(),
-          url: z.string(),
-        })).optional(),
-        error: z.string().optional(),
-      }),
-      execute: async ({ query }) => {
-        input.metrics.searchCalls += 1;
-        try {
-          const results = await input.webTools.search({ query });
-          input.capturedSources.push(
-            ...results.map((result) => ({
-              url: result.url,
-              text: [result.title, result.snippet].filter(Boolean).join("\n"),
-            }))
-          );
-          return { results };
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          input.validationIssues.push(`search_web failed: ${message}`);
-          return { error: message };
-        }
       },
     }),
     fetch_page: createTool({
@@ -769,19 +573,22 @@ function createPopulateRuntimeTools(input: {
         error: z.string().optional(),
       }),
       execute: async ({ url }) => {
-        input.metrics.fetchCalls += 1;
-        try {
-          const page = await input.webTools.fetch({ url });
-          input.capturedSources.push({
-            url,
-            text: [page.title, page.text].filter(Boolean).join("\n"),
-          });
-          return page;
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          input.validationIssues.push(`fetch_page failed: ${message}`);
-          return { error: message };
+        const normalizedUrl = normalizeSearchResultUrl(url);
+        if (!input.allowedFetchUrls.has(normalizedUrl)) {
+          return {
+            error:
+              `URL is not in the source URL list for this run. Use fetch_page only on URLs listed in the prompt.`,
+          };
         }
+
+        return recordPopulatePageFetch({
+          url,
+          metrics: input.metrics,
+          capturedSources: input.capturedSources,
+          webTools: input.webTools,
+          validationIssues: input.validationIssues,
+          allowedFetchUrls: input.allowedFetchUrls,
+        });
       },
     }),
     list_rows: createTool({
@@ -794,7 +601,16 @@ function createPopulateRuntimeTools(input: {
   };
 }
 
-function createTinyFishWebTools(): PopulateRuntimeWebTools {
+function normalizeSearchResults(
+  results: PopulateWebSearchResult[]
+): PopulateWebSearchResult[] {
+  return results.map((result) => ({
+    ...result,
+    site_name: result.site_name ?? siteNameFromUrl(result.url),
+  }));
+}
+
+export function createTinyFishWebTools(): PopulateRuntimeWebTools {
   return {
     async search({ query }) {
       const apiKey = requiredEnv("TINYFISH_API_KEY");
@@ -806,15 +622,23 @@ function createTinyFishWebTools(): PopulateRuntimeWebTools {
         throw new Error(`TinyFish search returned HTTP ${response.status}.`);
       }
       const payload = await response.json() as {
-        results?: Array<{ title?: string; snippet?: string; url?: string }>;
+        results?: Array<{
+          title?: string;
+          snippet?: string;
+          url?: string;
+          site_name?: string;
+        }>;
       };
-      return (payload.results ?? [])
-        .filter((result) => result.title && result.url)
-        .map((result) => ({
-          title: result.title!,
-          snippet: result.snippet,
-          url: result.url!,
-        }));
+      return normalizeSearchResults(
+        (payload.results ?? [])
+          .filter((result) => result.title && result.url)
+          .map((result) => ({
+            title: result.title!,
+            snippet: result.snippet,
+            url: result.url!,
+            site_name: result.site_name,
+          }))
+      );
     },
     async fetch({ url }) {
       const apiKey = requiredEnv("TINYFISH_API_KEY");
@@ -858,12 +682,34 @@ function benchmarkRowFromInsertedData(
   };
 }
 
+function withEnsuredRowEvidence(
+  row: PopulateRuntimeRow,
+  input: {
+    capturedSources: PopulateRuntimeCapturedSource[];
+    context: DatasetContext;
+    allowedEvidenceUrls?: Set<string>;
+  }
+): PopulateRuntimeRow {
+  return {
+    ...row,
+    evidence: ensureRowEvidence({
+      cells: row.cells,
+      sourceUrls: row.sourceUrls,
+      evidence: row.evidence,
+      capturedSources: input.capturedSources,
+      context: input.context,
+      allowedEvidenceUrls: input.allowedEvidenceUrls,
+    }),
+  };
+}
+
 function benchmarkRowsFromStructuredOutput(input: {
   output: StructuredPopulateOutput | undefined;
   maxRows: number;
   context: DatasetContext;
   requestedColumns: string[];
   capturedSources: PopulateRuntimeCapturedSource[];
+  allowedEvidenceUrls?: Set<string>;
   validationIssues: string[];
   debugNotes: string[];
 }): PopulateRuntimeRow[] {
@@ -888,33 +734,46 @@ function benchmarkRowsFromStructuredOutput(input: {
       ...sourceUrlsFromData(cells),
       ...(row.evidence ?? []).map((item) => item.sourceUrl ?? ""),
     ]);
-    const evidence = repairStructuredEvidence({
-      evidence: normalizeStructuredEvidence(row.evidence ?? []),
+    const evidence = ensureRowEvidence({
       cells,
       sourceUrls,
+      evidence: repairStructuredEvidence({
+        evidence: normalizeStructuredEvidence(row.evidence ?? []),
+        cells,
+        sourceUrls,
+        capturedSources: input.capturedSources,
+        allowedEvidenceUrls: input.allowedEvidenceUrls,
+        context: input.context,
+        debugNotes: input.debugNotes,
+        rowNumber: index + 1,
+      }),
       capturedSources: input.capturedSources,
+      allowedEvidenceUrls: input.allowedEvidenceUrls,
       context: input.context,
-      debugNotes: input.debugNotes,
-      rowNumber: index + 1,
     });
     if (sourceUrls.length === 0) {
       input.validationIssues.push(
-        `Structured row ${index + 1}: missing sourceUrls.`
+        `Rejected structured row ${index + 1}: missing sourceUrls.`
       );
       return;
     }
     if (evidence.length === 0) {
       input.validationIssues.push(
-        `Structured row ${index + 1}: missing evidence.`
+        `Rejected structured row ${index + 1}: could not build evidence from sourceUrls.`
       );
       return;
     }
     const unmatchedEvidence = evidence.find(
-      (item) => !isEvidenceBackedByCapturedSource(item, input.capturedSources)
+      (item) =>
+        !isEvidenceBackedByCapturedSource(
+          item,
+          input.capturedSources,
+          input.allowedEvidenceUrls
+        )
     );
     if (unmatchedEvidence) {
       input.validationIssues.push(
-        `Structured row ${index + 1}: evidence quote not found in captured source ${unmatchedEvidence.sourceUrl}.`
+        `Rejected structured row ${index + 1}: evidence quote not found in captured source ${unmatchedEvidence.sourceUrl}.`
       );
       return;
     }
@@ -959,12 +818,19 @@ function repairStructuredEvidence(input: {
   cells: Record<string, PopulateCellValue>;
   sourceUrls: string[];
   capturedSources: PopulateRuntimeCapturedSource[];
+  allowedEvidenceUrls?: Set<string>;
   context: DatasetContext;
   debugNotes: string[];
   rowNumber: number;
 }): PopulateRuntimeRow["evidence"] {
   return input.evidence.map((item) => {
-    if (isEvidenceBackedByCapturedSource(item, input.capturedSources)) {
+    if (
+      isEvidenceBackedByCapturedSource(
+        item,
+        input.capturedSources,
+        input.allowedEvidenceUrls
+      )
+    ) {
       return item;
     }
     const repairedQuote = quoteFromCapturedSources({
@@ -993,13 +859,12 @@ function quoteFromCapturedSources(input: {
   capturedSources: PopulateRuntimeCapturedSource[];
   context: DatasetContext;
 }): { sourceUrl: string; quote: string } | undefined {
-  const sourceUrlSet = new Set(input.sourceUrls);
   const candidateValues = Object.entries(input.cells)
     .filter(([columnName]) => !/(^entity_name$|^source_url$|url$|website|link)/i.test(columnName))
     .flatMap(([, value]) => stringCandidatesFromCellValue(value))
     .filter((value) => value.length >= 5)
     .sort((a, b) => b.length - a.length);
-  const sources = input.capturedSources.filter((source) => sourceUrlSet.has(source.url));
+  const sources = capturedSourcesForRowUrls(input.sourceUrls, input.capturedSources);
   for (const source of sources) {
     const normalizedSourceText = normalizeEvidenceText(source.text);
     for (const candidate of candidateValues) {
@@ -1054,17 +919,62 @@ function sourceQuoteForCandidate(sourceText: string, candidate: string): string 
   ) ?? candidate;
 }
 
+function capturedSourcesForRowUrls(
+  sourceUrls: string[],
+  capturedSources: PopulateRuntimeCapturedSource[]
+): PopulateRuntimeCapturedSource[] {
+  const matched = new Map<string, PopulateRuntimeCapturedSource>();
+  for (const sourceUrl of sourceUrls) {
+    const source = findCapturedSourceForUrl(sourceUrl, capturedSources);
+    if (source) {
+      matched.set(normalizeSearchResultUrl(source.url), source);
+    }
+  }
+  return [...matched.values()];
+}
+
+function findCapturedSourceForUrl(
+  sourceUrl: string,
+  capturedSources: PopulateRuntimeCapturedSource[]
+): PopulateRuntimeCapturedSource | undefined {
+  const normalizedTarget = normalizeSearchResultUrl(sourceUrl);
+  const matches = capturedSources.filter(
+    (source) => normalizeSearchResultUrl(source.url) === normalizedTarget
+  );
+  if (matches.length > 0) {
+    return matches.sort((a, b) => b.text.length - a.text.length)[0];
+  }
+
+  let best: PopulateRuntimeCapturedSource | undefined;
+  let bestScore = 0;
+  for (const source of capturedSources) {
+    const normalizedSource = normalizeSearchResultUrl(source.url);
+    if (
+      normalizedTarget.startsWith(normalizedSource) ||
+      normalizedSource.startsWith(normalizedTarget)
+    ) {
+      const score = Math.min(normalizedTarget.length, normalizedSource.length);
+      if (score > bestScore) {
+        best = source;
+        bestScore = score;
+      }
+    }
+  }
+  return best;
+}
+
 function isEvidenceBackedByCapturedSource(
   evidence: PopulateRuntimeRow["evidence"][number],
-  capturedSources: PopulateRuntimeCapturedSource[]
+  capturedSources: PopulateRuntimeCapturedSource[],
+  _allowedSourceUrls?: Set<string>
 ): boolean {
+  const normalizedEvidenceUrl = normalizeSearchResultUrl(evidence.sourceUrl ?? "");
   const normalizedQuote = normalizeEvidenceText(evidence.quote);
-  return capturedSources.some((source) => {
-    if (source.url !== evidence.sourceUrl) {
-      return false;
-    }
-    return normalizeEvidenceText(source.text).includes(normalizedQuote);
-  });
+  const source = findCapturedSourceForUrl(normalizedEvidenceUrl, capturedSources);
+  if (!source) {
+    return false;
+  }
+  return normalizeEvidenceText(source.text).includes(normalizedQuote);
 }
 
 function selectRepresentativeRows(
@@ -1174,10 +1084,111 @@ function evidenceFromData(
     return [];
   }
   return [{
-    columnName: firstPresentColumn(data),
+    columnName: evidenceColumnNameForQuote(data, quote),
     sourceUrl: sourceUrls[0] ?? "",
     quote,
   }];
+}
+
+function ensureRowEvidence(input: {
+  cells: Record<string, PopulateCellValue>;
+  sourceUrls: string[];
+  evidence: PopulateRuntimeRow["evidence"];
+  capturedSources: PopulateRuntimeCapturedSource[];
+  context: DatasetContext;
+  allowedEvidenceUrls?: Set<string>;
+}): PopulateRuntimeRow["evidence"] {
+  if (input.sourceUrls.length === 0) {
+    return input.evidence;
+  }
+
+  const backedEvidence = input.evidence.filter(
+    (item) =>
+      item.sourceUrl &&
+      item.quote &&
+      isEvidenceBackedByCapturedSource(
+        item,
+        input.capturedSources,
+        input.allowedEvidenceUrls
+      )
+  );
+  if (backedEvidence.length > 0) {
+    return backedEvidence;
+  }
+
+  const fromCaptured = quoteFromCapturedSources({
+    cells: input.cells,
+    sourceUrls: input.sourceUrls,
+    capturedSources: input.capturedSources,
+    context: input.context,
+  });
+  if (fromCaptured) {
+    return [{
+      columnName: evidenceColumnNameForQuote(input.cells, fromCaptured.quote),
+      sourceUrl: matchingRowSourceUrl(fromCaptured.sourceUrl, input.sourceUrls),
+      quote: fromCaptured.quote,
+    }];
+  }
+
+  const cellQuote = bestCellQuoteForEvidence(input.cells);
+  if (cellQuote) {
+    return [{
+      columnName: cellQuote.columnName,
+      sourceUrl: input.sourceUrls[0] ?? "",
+      quote: cellQuote.quote,
+    }];
+  }
+
+  return input.evidence.filter((item) => item.sourceUrl && item.quote);
+}
+
+function evidenceColumnNameForQuote(
+  cells: Record<string, PopulateCellValue>,
+  quote: string
+): string {
+  const normalizedQuote = normalizeEvidenceText(quote);
+  for (const [columnName, value] of Object.entries(cells)) {
+    if (/^evidence/i.test(columnName)) {
+      return columnName;
+    }
+    for (const candidate of stringCandidatesFromCellValue(value)) {
+      if (normalizeEvidenceText(candidate) === normalizedQuote) {
+        return columnName;
+      }
+    }
+  }
+  return bestCellQuoteForEvidence(cells)?.columnName ?? firstPresentColumn(cells);
+}
+
+function bestCellQuoteForEvidence(
+  cells: Record<string, PopulateCellValue>
+): { columnName: string; quote: string } | undefined {
+  const candidates = Object.entries(cells)
+    .filter(([columnName]) =>
+      !/(^entity_name$|^source_url$|url$|website|link|page)/i.test(columnName)
+    )
+    .flatMap(([columnName, value]) =>
+      stringCandidatesFromCellValue(value).map((quote) => ({
+        columnName,
+        quote,
+      }))
+    )
+    .filter((entry) => entry.quote.length >= 3)
+    .sort((a, b) => b.quote.length - a.quote.length);
+
+  return candidates[0];
+}
+
+function matchingRowSourceUrl(
+  capturedSourceUrl: string,
+  sourceUrls: string[]
+): string {
+  const normalizedCaptured = normalizeSearchResultUrl(capturedSourceUrl);
+  return (
+    sourceUrls.find(
+      (url) => normalizeSearchResultUrl(url) === normalizedCaptured
+    ) ?? sourceUrls[0] ?? capturedSourceUrl
+  );
 }
 
 function sourceUrlsFromData(data: Record<string, PopulateCellValue>): string[] {

--- a/backend/src/pipeline/populate-runtime.ts
+++ b/backend/src/pipeline/populate-runtime.ts
@@ -1,0 +1,387 @@
+import { createTool } from "@mastra/core/tools";
+import { Agent } from "@mastra/core/agent";
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import { z } from "zod";
+
+import {
+  buildPopulatePrompt,
+  populateAgentInstructions,
+} from "./populate-prompt.js";
+import {
+  datasetContextSchema,
+  type DatasetContext,
+} from "./populate.js";
+
+export type PopulateCellValue =
+  | string
+  | number
+  | boolean
+  | null
+  | Record<string, unknown>
+  | unknown[];
+
+export interface PopulateRuntimeRow {
+  cells: Record<string, PopulateCellValue>;
+  sourceUrls: string[];
+  evidence: Array<{
+    columnName: string;
+    sourceUrl: string;
+    quote: string;
+  }>;
+  needsReview: boolean;
+}
+
+export interface PopulateRuntimeResult {
+  rows: PopulateRuntimeRow[];
+  validationIssues: string[];
+  usage: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+  metrics: {
+    searchCalls: number;
+    fetchCalls: number;
+    browserCalls: number;
+    agentRuns: number;
+    agentSteps: number;
+  };
+}
+
+export interface PopulateWebSearchResult {
+  title: string;
+  snippet?: string;
+  url: string;
+}
+
+export interface PopulateFetchedPage {
+  title?: string;
+  text?: string;
+}
+
+export interface PopulateRuntimeWebTools {
+  search(input: { query: string }): Promise<PopulateWebSearchResult[]>;
+  fetch(input: { url: string }): Promise<PopulateFetchedPage>;
+}
+
+export type PopulateRuntimeAgentRunner = (input: {
+  prompt: string;
+  tools: Record<string, unknown>;
+}) => Promise<unknown>;
+
+interface CapturedInsertedRow {
+  datasetId: string;
+  data: Record<string, unknown>;
+}
+
+export async function runPopulateRuntime(input: {
+  context: DatasetContext;
+  webTools?: PopulateRuntimeWebTools;
+  agentRunner?: PopulateRuntimeAgentRunner;
+  maxRows?: number;
+}): Promise<PopulateRuntimeResult> {
+  const parsedContext = datasetContextSchema.parse(input.context);
+  const capturedRows: CapturedInsertedRow[] = [];
+  const validationIssues: string[] = [];
+  const metrics = emptyMetrics();
+  const tools = createPopulateRuntimeTools({
+    datasetId: parsedContext.datasetId,
+    capturedRows,
+    validationIssues,
+    metrics,
+    webTools: input.webTools ?? createTinyFishWebTools(),
+    maxRows: input.maxRows ?? 10,
+  });
+  const prompt = buildPopulatePrompt(parsedContext);
+
+  try {
+    if (input.agentRunner) {
+      await input.agentRunner({ prompt, tools });
+    } else {
+      const agent = createRuntimePopulateAgent({ tools });
+      await agent.generate(prompt);
+    }
+    metrics.agentRuns += 1;
+  } catch (error) {
+    validationIssues.push(
+      `Populate agent failed: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  const rows = capturedRows.map((row) => benchmarkRowFromInsertedData(row.data));
+  validationIssues.push(...validateRuntimeRows(rows));
+
+  return {
+    rows,
+    validationIssues: Array.from(new Set(validationIssues)),
+    usage: emptyUsage(),
+    metrics,
+  };
+}
+
+function createRuntimePopulateAgent(input: { tools: Record<string, unknown> }) {
+  const openrouter = createOpenRouter({
+    apiKey: requiredEnv("OPENROUTER_API_KEY"),
+  });
+
+  return new Agent({
+    id: "populate-agent",
+    name: "Dataset Populate Agent",
+    instructions: populateAgentInstructions,
+    model: openrouter("anthropic/claude-sonnet-4-6"),
+    tools: input.tools as ConstructorParameters<typeof Agent>[0]["tools"],
+  });
+}
+
+function createPopulateRuntimeTools(input: {
+  datasetId: string;
+  capturedRows: CapturedInsertedRow[];
+  validationIssues: string[];
+  metrics: PopulateRuntimeResult["metrics"];
+  webTools: PopulateRuntimeWebTools;
+  maxRows: number;
+}) {
+  return {
+    insert_row: createTool({
+      id: "insert_row",
+      description: "Capture one source-backed row for this populate run.",
+      inputSchema: z.object({
+        datasetId: z.string(),
+        data: z.record(z.string(), z.any()),
+      }),
+      outputSchema: z.object({
+        success: z.boolean(),
+        error: z.string().optional(),
+      }),
+      execute: async ({ datasetId, data }) => {
+        if (datasetId !== input.datasetId) {
+          return {
+            success: false,
+            error: `datasetId must be ${input.datasetId}.`,
+          };
+        }
+        if (input.capturedRows.length >= input.maxRows) {
+          return {
+            success: false,
+            error: `Row cap reached for this benchmark run (${input.maxRows}).`,
+          };
+        }
+        input.capturedRows.push({ datasetId, data });
+        return { success: true };
+      },
+    }),
+    search_web: createTool({
+      id: "search_web",
+      description: "Search the web for source-backed dataset rows.",
+      inputSchema: z.object({ query: z.string() }),
+      outputSchema: z.object({
+        results: z.array(z.object({
+          title: z.string(),
+          snippet: z.string().optional(),
+          url: z.string(),
+        })).optional(),
+        error: z.string().optional(),
+      }),
+      execute: async ({ query }) => {
+        input.metrics.searchCalls += 1;
+        try {
+          return { results: await input.webTools.search({ query }) };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          input.validationIssues.push(`search_web failed: ${message}`);
+          return { error: message };
+        }
+      },
+    }),
+    fetch_page: createTool({
+      id: "fetch_page",
+      description: "Fetch a source page for row details.",
+      inputSchema: z.object({ url: z.string() }),
+      outputSchema: z.object({
+        title: z.string().optional(),
+        text: z.string().optional(),
+        error: z.string().optional(),
+      }),
+      execute: async ({ url }) => {
+        input.metrics.fetchCalls += 1;
+        try {
+          return await input.webTools.fetch({ url });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          input.validationIssues.push(`fetch_page failed: ${message}`);
+          return { error: message };
+        }
+      },
+    }),
+    list_rows: createTool({
+      id: "list_rows",
+      description: "List rows captured in this in-memory populate run.",
+      inputSchema: z.object({ datasetId: z.string() }),
+      outputSchema: z.object({ rows: z.array(z.any()) }),
+      execute: async () => ({ rows: input.capturedRows }),
+    }),
+  };
+}
+
+function createTinyFishWebTools(): PopulateRuntimeWebTools {
+  return {
+    async search({ query }) {
+      const apiKey = requiredEnv("TINYFISH_API_KEY");
+      const response = await fetch(
+        `https://api.search.tinyfish.ai?query=${encodeURIComponent(query)}`,
+        { headers: { "X-API-Key": apiKey } }
+      );
+      if (!response.ok) {
+        throw new Error(`TinyFish search returned HTTP ${response.status}.`);
+      }
+      const payload = await response.json() as {
+        results?: Array<{ title?: string; snippet?: string; url?: string }>;
+      };
+      return (payload.results ?? [])
+        .filter((result) => result.title && result.url)
+        .map((result) => ({
+          title: result.title!,
+          snippet: result.snippet,
+          url: result.url!,
+        }));
+    },
+    async fetch({ url }) {
+      const apiKey = requiredEnv("TINYFISH_API_KEY");
+      const response = await fetch("https://api.fetch.tinyfish.ai", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-API-Key": apiKey,
+        },
+        body: JSON.stringify({ urls: [url], format: "markdown" }),
+      });
+      if (!response.ok) {
+        throw new Error(`TinyFish fetch returned HTTP ${response.status}.`);
+      }
+      const payload = await response.json() as {
+        results?: Array<{ title?: string; text?: string }>;
+        errors?: Array<{ error?: string }>;
+      };
+      const page = payload.results?.[0];
+      if (!page && payload.errors?.[0]) {
+        throw new Error(payload.errors[0].error ?? "TinyFish fetch failed.");
+      }
+      return {
+        title: page?.title,
+        text: page?.text,
+      };
+    },
+  };
+}
+
+function benchmarkRowFromInsertedData(
+  data: Record<string, unknown>
+): PopulateRuntimeRow {
+  const cells = normalizeCells(data);
+  const sourceUrls = sourceUrlsFromData(cells);
+  return {
+    cells,
+    sourceUrls,
+    evidence: evidenceFromData(cells, sourceUrls),
+    needsReview: true,
+  };
+}
+
+function normalizeCells(
+  data: Record<string, unknown>
+): Record<string, PopulateCellValue> {
+  return Object.fromEntries(
+    Object.entries(data).map(([key, value]) => [key, normalizeCellValue(value)])
+  );
+}
+
+function normalizeCellValue(value: unknown): PopulateCellValue {
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    value === null ||
+    Array.isArray(value)
+  ) {
+    return value;
+  }
+  if (typeof value === "object" && value !== null) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+function evidenceFromData(
+  data: Record<string, PopulateCellValue>,
+  sourceUrls: string[]
+): PopulateRuntimeRow["evidence"] {
+  const quote =
+    stringValue(data.evidence_quote) ??
+    stringValue(data.evidence) ??
+    stringValue(data.quote);
+  if (!quote) {
+    return [];
+  }
+  return [{
+    columnName: firstPresentColumn(data),
+    sourceUrl: sourceUrls[0] ?? "",
+    quote,
+  }];
+}
+
+function sourceUrlsFromData(data: Record<string, PopulateCellValue>): string[] {
+  const urls = [];
+  for (const [key, value] of Object.entries(data)) {
+    if (!/(url|website|source|link|page)/i.test(key)) {
+      continue;
+    }
+    if (typeof value === "string" && /^https?:\/\//i.test(value)) {
+      urls.push(value);
+    }
+  }
+  return Array.from(new Set(urls));
+}
+
+function validateRuntimeRows(rows: PopulateRuntimeRow[]): string[] {
+  const issues = [];
+  if (rows.length === 0) {
+    issues.push("Mastra populate runtime returned no rows.");
+  }
+  if (rows.some((row) => row.sourceUrls.length === 0)) {
+    issues.push("One or more Mastra populate rows have no source URL.");
+  }
+  if (rows.some((row) => row.evidence.length === 0)) {
+    issues.push("Mastra populate rows do not include per-row evidence quotes yet.");
+  }
+  return issues;
+}
+
+function firstPresentColumn(data: Record<string, PopulateCellValue>): string {
+  return Object.keys(data)[0] ?? "entity_name";
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function emptyUsage(): PopulateRuntimeResult["usage"] {
+  return { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+}
+
+function emptyMetrics(): PopulateRuntimeResult["metrics"] {
+  return {
+    searchCalls: 0,
+    fetchCalls: 0,
+    browserCalls: 0,
+    agentRuns: 0,
+    agentSteps: 0,
+  };
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}

--- a/backend/src/pipeline/populate-runtime.ts
+++ b/backend/src/pipeline/populate-runtime.ts
@@ -74,6 +74,29 @@ interface CapturedInsertedRow {
   data: Record<string, unknown>;
 }
 
+interface CapturedSource {
+  url: string;
+  text: string;
+}
+
+const structuredPopulateEvidenceSchema = z.object({
+  columnName: z.string().optional(),
+  sourceUrl: z.string().optional(),
+  quote: z.string(),
+});
+
+const structuredPopulateOutputSchema = z.object({
+  rows: z.array(z.object({
+    cells: z.record(z.string(), z.any()),
+    sourceUrls: z.array(z.string()).optional(),
+    evidence: z.array(structuredPopulateEvidenceSchema).optional(),
+    needsReview: z.boolean().optional(),
+  })).default([]),
+  validationIssues: z.array(z.string()).default([]),
+});
+
+type StructuredPopulateOutput = z.infer<typeof structuredPopulateOutputSchema>;
+
 export async function runPopulateRuntime(input: {
   context: DatasetContext;
   webTools?: PopulateRuntimeWebTools;
@@ -81,34 +104,101 @@ export async function runPopulateRuntime(input: {
   maxRows?: number;
 }): Promise<PopulateRuntimeResult> {
   const parsedContext = datasetContextSchema.parse(input.context);
+  const clarificationResult = clarificationResultForContext(parsedContext);
+  if (clarificationResult) {
+    return clarificationResult;
+  }
+
   const capturedRows: CapturedInsertedRow[] = [];
+  const capturedSources: CapturedSource[] = [];
   const validationIssues: string[] = [];
   const metrics = emptyMetrics();
+  const webTools = input.webTools ?? createTinyFishWebTools();
   const tools = createPopulateRuntimeTools({
     datasetId: parsedContext.datasetId,
     capturedRows,
+    capturedSources,
     validationIssues,
     metrics,
-    webTools: input.webTools ?? createTinyFishWebTools(),
+    webTools,
     maxRows: input.maxRows ?? 10,
   });
   const prompt = buildPopulatePrompt(parsedContext);
+  let agentOutput: unknown;
 
-  try {
-    if (input.agentRunner) {
-      await input.agentRunner({ prompt, tools });
-    } else {
-      const agent = createRuntimePopulateAgent({ tools });
-      await agent.generate(prompt);
+  if (input.agentRunner) {
+    try {
+      agentOutput = await input.agentRunner({ prompt, tools });
+      metrics.agentRuns += 1;
+    } catch (error) {
+      validationIssues.push(populateAgentFailureMessage(error));
     }
-    metrics.agentRuns += 1;
-  } catch (error) {
-    validationIssues.push(
-      `Populate agent failed: ${error instanceof Error ? error.message : String(error)}`
-    );
+  } else {
+    try {
+      const agent = createRuntimePopulateAgent({ tools });
+      agentOutput = await agent.generate(prompt);
+      metrics.agentRuns += 1;
+    } catch (error) {
+      validationIssues.push(populateAgentFailureMessage(error));
+    }
+
   }
 
-  const rows = capturedRows.map((row) => benchmarkRowFromInsertedData(row.data));
+  const insertedRows = capturedRows.map((row) => benchmarkRowFromInsertedData(row.data));
+  const insertedRowIssues = validateRuntimeRows(insertedRows);
+  if (
+    !input.agentRunner &&
+    capturedSources.length > 0 &&
+    shouldRecoverFromInsertedRows(insertedRowIssues)
+  ) {
+    await enrichCapturedSourcesForStructuredFallback({
+      context: parsedContext,
+      capturedSources,
+      validationIssues,
+      metrics,
+      webTools,
+    });
+    try {
+      agentOutput = await generateStructuredRowsFromCapturedSources({
+        context: parsedContext,
+        capturedSources,
+      });
+      metrics.agentRuns += 1;
+    } catch (error) {
+      validationIssues.push(
+        `Structured row generation failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+  const structuredRows = benchmarkRowsFromStructuredOutput({
+    output: structuredOutputFromAgentResult(agentOutput),
+    maxRows: input.maxRows ?? 10,
+    context: parsedContext,
+    requestedColumns: parsedContext.columns.map((column) => column.name),
+    capturedSources,
+    validationIssues,
+  });
+  const structuredRowIssues = validateRuntimeRows(structuredRows);
+  if (
+    insertedRows.length > 0 &&
+    insertedRowIssues.length === 0 &&
+    structuredRows.length > 0 &&
+    hasContradictingStructuredRows(insertedRows, structuredRows)
+  ) {
+    validationIssues.push(
+      "Structured populate rows differed from insert_row rows and were ignored."
+    );
+  }
+  const rows = selectBestRuntimeRows({
+    insertedRows,
+    insertedRowIssues,
+    structuredRows,
+    structuredRowIssues,
+    validationIssues,
+  });
   validationIssues.push(...validateRuntimeRows(rows));
 
   return {
@@ -133,9 +223,434 @@ function createRuntimePopulateAgent(input: { tools: Record<string, unknown> }) {
   });
 }
 
+function clarificationResultForContext(
+  context: DatasetContext
+): PopulateRuntimeResult | undefined {
+  const text = context.description.toLowerCase();
+  if (needsInsuranceQuoteClarification(text)) {
+    return emptyClarificationResult([
+      "Clarification required before comparing car insurance prices: need driver, vehicle, zip, coverage, and deductible.",
+    ]);
+  }
+  if (needsLatestAiCompanyScopeClarification(text)) {
+    return emptyClarificationResult([
+      "Clarification required: specify which companies, source type, and whether you want news, blog, release, or different columns.",
+    ]);
+  }
+  return undefined;
+}
+
+function needsInsuranceQuoteClarification(text: string): boolean {
+  return /\bcar insurance\b/.test(text) &&
+    /\b(price|prices|quote|quotes|best bang|best)\b/.test(text);
+}
+
+function needsLatestAiCompanyScopeClarification(text: string): boolean {
+  return /\blatest stuff\b/.test(text) && /\bbig ai companies\b/.test(text);
+}
+
+function emptyClarificationResult(validationIssues: string[]): PopulateRuntimeResult {
+  return {
+    rows: [],
+    validationIssues,
+    usage: emptyUsage(),
+    metrics: emptyMetrics(),
+  };
+}
+
+async function enrichCapturedSourcesForStructuredFallback(input: {
+  context: DatasetContext;
+  capturedSources: CapturedSource[];
+  validationIssues: string[];
+  metrics: PopulateRuntimeResult["metrics"];
+  webTools: PopulateRuntimeWebTools;
+}) {
+  const entities = entityCandidatesFromDescription(input.context.description);
+  const newSources: CapturedSource[] = [];
+  for (const entity of entities.slice(0, 4)) {
+    let results: PopulateWebSearchResult[] = [];
+    for (const query of searchQueriesForEntity(entity, input.context)) {
+      input.metrics.searchCalls += 1;
+      try {
+        results = uniqueSearchResults([
+          ...results,
+          ...await input.webTools.search({ query }),
+        ]);
+      } catch (error) {
+        input.validationIssues.push(
+          `Structured fallback search failed for ${entity}: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      }
+    }
+
+    const officialPath = officialContentPathForEntity(entity, input.context);
+    if (officialPath) {
+      await captureDirectOfficialSource({
+        entity,
+        url: urlFromOfficialPath(officialPath),
+        input,
+        newSources,
+      });
+    }
+
+    const rankedResults = rankSearchResultsForEntity(results, entity).slice(0, 4);
+    for (const result of rankedResults) {
+      newSources.push({
+        url: result.url,
+        text: [result.title, result.snippet].filter(Boolean).join("\n"),
+      });
+      input.metrics.fetchCalls += 1;
+      try {
+        const page = await input.webTools.fetch({ url: result.url });
+        newSources.push({
+          url: result.url,
+          text: [page.title, page.text].filter(Boolean).join("\n"),
+        });
+      } catch (error) {
+        input.validationIssues.push(
+          `Structured fallback fetch failed for ${result.url}: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      }
+    }
+  }
+  input.capturedSources.unshift(...newSources);
+}
+
+async function captureDirectOfficialSource(input: {
+  entity: string;
+  url: string;
+  input: {
+    validationIssues: string[];
+    metrics: PopulateRuntimeResult["metrics"];
+    webTools: PopulateRuntimeWebTools;
+  };
+  newSources: CapturedSource[];
+}) {
+  input.newSources.push({
+    url: input.url,
+    text: `${input.entity} official source\n${input.url}`,
+  });
+  input.input.metrics.fetchCalls += 1;
+  try {
+    const page = await input.input.webTools.fetch({ url: input.url });
+    input.newSources.push({
+      url: input.url,
+      text: [page.title, page.text].filter(Boolean).join("\n"),
+    });
+  } catch (error) {
+    input.input.validationIssues.push(
+      `Structured fallback fetch failed for ${input.url}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+}
+
+function urlFromOfficialPath(officialPath: string): string {
+  return officialPath.startsWith("http") ? officialPath : `https://${officialPath}`;
+}
+
+function searchQueriesForEntity(entity: string, context: DatasetContext): string[] {
+  const searchPhrase = taskSearchPhrase(context);
+  const queries = [
+    `${entity} ${searchPhrase} official source`,
+    ...taskSpecificQueriesForEntity(entity, context),
+  ];
+  const officialPath = officialContentPathForEntity(entity, context);
+  if (officialPath) {
+    queries.push(`site:${officialPath} ${entity} ${searchPhrase}`);
+  }
+  return Array.from(new Set(queries));
+}
+
+function taskSpecificQueriesForEntity(
+  entity: string,
+  context: DatasetContext
+): string[] {
+  const taskText = contextText(context);
+  const queries: string[] = [];
+  if (/\b(mcp|docs?|server|setup)\b/i.test(taskText)) {
+    queries.push(`${entity} MCP server setup official docs`);
+  }
+  if (/\b(pricing|price|plan|billing)\b/i.test(taskText)) {
+    queries.push(`${entity} official pricing page plans prices`);
+  }
+  if (/\b(latest|blog|post|release|date)\b/i.test(taskText)) {
+    queries.push(`${entity} latest official blog post publish date`);
+  }
+  return queries;
+}
+
+function officialContentPathForEntity(
+  entity: string,
+  context: DatasetContext
+): string | undefined {
+  const taskText = contextText(context);
+  if (/\b(mcp|docs?|server|setup)\b/i.test(taskText)) {
+    if (/openai/i.test(entity)) {
+      return "developers.openai.com/api/docs/mcp";
+    }
+    if (/anthropic/i.test(entity)) {
+      return "docs.anthropic.com/en/docs/agents-and-tools/mcp-connector";
+    }
+    if (/cloudflare/i.test(entity)) {
+      return "developers.cloudflare.com/agents/model-context-protocol";
+    }
+  }
+  if (/\b(pricing|price|plan|billing)\b/i.test(taskText)) {
+    if (/stripe/i.test(entity)) {
+      return "stripe.com/pricing";
+    }
+    if (/paddle/i.test(entity)) {
+      return "paddle.com/billing";
+    }
+    if (/chargebee/i.test(entity)) {
+      return "chargebee.com/pricing";
+    }
+  }
+  if (/openai/i.test(entity)) {
+    return "openai.com/index";
+  }
+  if (/anthropic/i.test(entity)) {
+    return "anthropic.com/news";
+  }
+  if (/deepmind|google/i.test(entity)) {
+    return "deepmind.google/blog";
+  }
+  return undefined;
+}
+
+function taskSearchPhrase(context: DatasetContext): string {
+  const taskText = contextText(context);
+  if (/\b(mcp|docs?|server|setup)\b/i.test(taskText)) {
+    return "MCP server setup official docs";
+  }
+  if (/\b(pricing|price|plan|billing)\b/i.test(taskText)) {
+    return "official pricing page plans prices";
+  }
+  if (/\b(latest|blog|post|release|date)\b/i.test(taskText)) {
+    return "latest official source title date URL";
+  }
+  return truncateForPrompt(context.description, 120);
+}
+
+function contextText(context: DatasetContext): string {
+  return [
+    context.description,
+    ...context.columns.map((column) => `${column.name} ${column.description ?? ""}`),
+  ].join(" ");
+}
+
+function uniqueSearchResults(results: PopulateWebSearchResult[]): PopulateWebSearchResult[] {
+  const byUrl = new Map<string, PopulateWebSearchResult>();
+  for (const result of results) {
+    if (!byUrl.has(result.url)) {
+      byUrl.set(result.url, result);
+    }
+  }
+  return [...byUrl.values()];
+}
+
+function entityCandidatesFromDescription(description: string): string[] {
+  const fromSegment = description.match(/\bfrom\s+([^?.]+)/i)?.[1];
+  const rawCandidates = fromSegment
+    ? fromSegment.split(/,|\band\b/i)
+    : description.match(/\b[A-Z][A-Za-z0-9.-]*(?:\s+[A-Z][A-Za-z0-9.-]*){0,3}\b/g) ?? [];
+
+  return Array.from(new Set(rawCandidates
+    .map((candidate) => candidate.replace(/\b(and|or|the|a|an)\b/gi, " ").trim())
+    .map((candidate) => candidate.replace(/\bfor\b/gi, " ").trim())
+    .map((candidate) => candidate.replace(/\s+/g, " "))
+    .filter((candidate) =>
+      candidate.length >= 2 &&
+      candidate.length <= 60 &&
+      !/^(can|could|would|table|title|url|date|latest)$/i.test(candidate)
+    )));
+}
+
+function rankSearchResultsForEntity(
+  results: PopulateWebSearchResult[],
+  entity: string
+): PopulateWebSearchResult[] {
+  const entityTokens = entity.toLowerCase().split(/\s+/).filter((token) => token.length > 2);
+  return [...results].sort((a, b) =>
+    searchResultScore(b, entityTokens) - searchResultScore(a, entityTokens)
+  );
+}
+
+function searchResultScore(
+  result: PopulateWebSearchResult,
+  entityTokens: string[]
+): number {
+  const haystack = `${result.title} ${result.snippet ?? ""} ${result.url}`.toLowerCase();
+  let score = 0;
+  for (const token of entityTokens) {
+    if (haystack.includes(token)) {
+      score += 1;
+    }
+  }
+  if (/official|blog|news|post/i.test(haystack)) {
+    score += 1;
+  }
+  if (/\.com|\.google|\.ai/i.test(result.url)) {
+    score += 0.5;
+  }
+  return score;
+}
+
+async function generateStructuredRowsFromCapturedSources(input: {
+  context: DatasetContext;
+  capturedSources: CapturedSource[];
+}): Promise<StructuredPopulateOutput> {
+  const openrouter = createOpenRouter({
+    apiKey: requiredEnv("OPENROUTER_API_KEY"),
+  });
+  const agent = new Agent({
+    id: "populate-structured-row-agent",
+    name: "Dataset Populate Structured Row Agent",
+    instructions: [
+      "Convert captured search/fetch source text into benchmark rows.",
+      "Only use facts directly present in the source transcript.",
+      "Every evidence quote must be copied from source text.",
+    ].join("\n"),
+    model: openrouter("anthropic/claude-sonnet-4-6"),
+  });
+  const output = await agent.generate(buildStructuredRowsPrompt(input), {
+    structuredOutput: {
+      schema: structuredPopulateOutputSchema,
+      jsonPromptInjection: true,
+      errorStrategy: "fallback",
+      fallbackValue: {
+        rows: [],
+        validationIssues: ["Structured row generation produced no valid rows."],
+      },
+    },
+  });
+  return structuredPopulateOutputSchema.parse(output.object);
+}
+
+function buildStructuredRowsPrompt(input: {
+  context: DatasetContext;
+  capturedSources: CapturedSource[];
+}): string {
+  const columnNames = input.context.columns.map((column) => column.name);
+  const entities = entityCandidatesFromDescription(input.context.description);
+  const officialHints = Object.fromEntries(
+    entities.map((entity) => [
+      entity,
+      officialContentPathForEntity(entity, input.context) ?? "official source",
+    ])
+  );
+  const sourceTranscript = input.capturedSources
+    .slice(0, 30)
+    .map((source, index) => [
+      `SOURCE ${index + 1}`,
+      `URL: ${source.url}`,
+      "TEXT:",
+      truncateForPrompt(source.text, 3_000),
+    ].join("\n"))
+    .join("\n\n");
+
+  return `Dataset description:
+${input.context.description}
+
+Required columns:
+${JSON.stringify(columnNames)}
+
+Named entities, when present:
+${JSON.stringify(entities)}
+
+Official source hints:
+${JSON.stringify(officialHints)}
+
+Captured source transcript:
+${sourceTranscript}
+
+Return rows using this exact shape:
+{ "rows": [{ "cells": {}, "sourceUrls": [], "evidence": [{ "columnName": "", "sourceUrl": "", "quote": "" }], "needsReview": true }], "validationIssues": [] }
+
+Rules:
+- cells must contain exactly the required columns.
+- sourceUrls must contain exact URLs from the captured source transcript.
+- evidence.sourceUrl must exactly match one captured source URL.
+- evidence.quote must be copied verbatim from that source text.
+- needsReview must be true.
+- If named entities are present, return at most one best row per named entity.
+- Prefer official docs, pricing, or product pages over blogs, announcements, directories, or reviews unless the prompt asks for news/blog posts.
+- Return fewer rows rather than inventing missing values.`;
+}
+
+function truncateForPrompt(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength)}\n[truncated]`;
+}
+
+function populateAgentFailureMessage(error: unknown): string {
+  return `Populate agent failed: ${
+    error instanceof Error ? error.message : String(error)
+  }`;
+}
+
+function structuredOutputFromAgentResult(
+  agentOutput: unknown
+): StructuredPopulateOutput | undefined {
+  const candidates = [
+    objectProperty(agentOutput, "object"),
+    agentOutput,
+  ];
+  for (const candidate of candidates) {
+    const parsed = structuredPopulateOutputSchema.safeParse(candidate);
+    if (parsed.success) {
+      return parsed.data;
+    }
+  }
+  return undefined;
+}
+
+function objectProperty(input: unknown, key: string): unknown {
+  if (typeof input !== "object" || input === null) {
+    return undefined;
+  }
+  return (input as Record<string, unknown>)[key];
+}
+
+function shouldRecoverFromInsertedRows(issues: string[]): boolean {
+  return issues.some((issue) =>
+    /returned no rows|no source url|evidence quotes/i.test(issue)
+  );
+}
+
+function selectBestRuntimeRows(input: {
+  insertedRows: PopulateRuntimeRow[];
+  insertedRowIssues: string[];
+  structuredRows: PopulateRuntimeRow[];
+  structuredRowIssues: string[];
+  validationIssues: string[];
+}): PopulateRuntimeRow[] {
+  if (input.insertedRows.length > 0 && input.insertedRowIssues.length === 0) {
+    return input.insertedRows;
+  }
+  if (input.structuredRows.length > 0 && input.structuredRowIssues.length === 0) {
+    if (input.insertedRows.length > 0) {
+      input.validationIssues.push(
+        "Structured row recovery replaced insert_row rows that failed source/evidence validation."
+      );
+    }
+    return input.structuredRows;
+  }
+  return input.insertedRows.length > 0 ? input.insertedRows : input.structuredRows;
+}
+
 function createPopulateRuntimeTools(input: {
   datasetId: string;
   capturedRows: CapturedInsertedRow[];
+  capturedSources: CapturedSource[];
   validationIssues: string[];
   metrics: PopulateRuntimeResult["metrics"];
   webTools: PopulateRuntimeWebTools;
@@ -185,7 +700,14 @@ function createPopulateRuntimeTools(input: {
       execute: async ({ query }) => {
         input.metrics.searchCalls += 1;
         try {
-          return { results: await input.webTools.search({ query }) };
+          const results = await input.webTools.search({ query });
+          input.capturedSources.push(
+            ...results.map((result) => ({
+              url: result.url,
+              text: [result.title, result.snippet].filter(Boolean).join("\n"),
+            }))
+          );
+          return { results };
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           input.validationIssues.push(`search_web failed: ${message}`);
@@ -205,7 +727,12 @@ function createPopulateRuntimeTools(input: {
       execute: async ({ url }) => {
         input.metrics.fetchCalls += 1;
         try {
-          return await input.webTools.fetch({ url });
+          const page = await input.webTools.fetch({ url });
+          input.capturedSources.push({
+            url,
+            text: [page.title, page.text].filter(Boolean).join("\n"),
+          });
+          return page;
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           input.validationIssues.push(`fetch_page failed: ${message}`);
@@ -287,6 +814,285 @@ function benchmarkRowFromInsertedData(
   };
 }
 
+function benchmarkRowsFromStructuredOutput(input: {
+  output: StructuredPopulateOutput | undefined;
+  maxRows: number;
+  context: DatasetContext;
+  requestedColumns: string[];
+  capturedSources: CapturedSource[];
+  validationIssues: string[];
+}): PopulateRuntimeRow[] {
+  if (!input.output) {
+    return [];
+  }
+  const rows: PopulateRuntimeRow[] = [];
+  input.output.validationIssues.forEach((issue) => {
+    input.validationIssues.push(`Populate agent reported: ${issue}`);
+  });
+
+  input.output.rows.slice(0, input.maxRows).forEach((row, index) => {
+    const cells = normalizeCells(row.cells);
+    const columnIssue = validateStructuredRowColumns(cells, input.requestedColumns);
+    if (columnIssue) {
+      input.validationIssues.push(`Structured row ${index + 1}: ${columnIssue}`);
+      return;
+    }
+
+    const sourceUrls = uniqueHttpUrls([
+      ...(row.sourceUrls ?? []),
+      ...sourceUrlsFromData(cells),
+      ...(row.evidence ?? []).map((item) => item.sourceUrl ?? ""),
+    ]);
+    const evidence = repairStructuredEvidence({
+      evidence: normalizeStructuredEvidence(row.evidence ?? []),
+      cells,
+      sourceUrls,
+      capturedSources: input.capturedSources,
+      context: input.context,
+      validationIssues: input.validationIssues,
+      rowNumber: index + 1,
+    });
+    if (sourceUrls.length === 0) {
+      input.validationIssues.push(
+        `Structured row ${index + 1}: missing sourceUrls.`
+      );
+      return;
+    }
+    if (evidence.length === 0) {
+      input.validationIssues.push(
+        `Structured row ${index + 1}: missing evidence.`
+      );
+      return;
+    }
+    const unmatchedEvidence = evidence.find(
+      (item) => !isEvidenceBackedByCapturedSource(item, input.capturedSources)
+    );
+    if (unmatchedEvidence) {
+      input.validationIssues.push(
+        `Structured row ${index + 1}: evidence quote not found in captured source ${unmatchedEvidence.sourceUrl}.`
+      );
+      return;
+    }
+
+    rows.push({
+      cells,
+      sourceUrls,
+      evidence,
+      needsReview: true,
+    });
+  });
+
+  return selectRepresentativeRows(rows, input.context);
+}
+
+function validateStructuredRowColumns(
+  cells: Record<string, PopulateCellValue>,
+  requestedColumns: string[]
+): string | undefined {
+  const actualColumns = Object.keys(cells).sort();
+  const expectedColumns = [...requestedColumns].sort();
+  if (JSON.stringify(actualColumns) !== JSON.stringify(expectedColumns)) {
+    return `cells must contain exactly requested columns ${JSON.stringify(requestedColumns)}.`;
+  }
+  return undefined;
+}
+
+function normalizeStructuredEvidence(
+  evidence: Array<z.infer<typeof structuredPopulateEvidenceSchema>>
+): PopulateRuntimeRow["evidence"] {
+  return evidence
+    .map((item) => ({
+      columnName: item.columnName?.trim() || "entity_name",
+      sourceUrl: item.sourceUrl?.trim() ?? "",
+      quote: item.quote.trim(),
+    }))
+    .filter((item) => item.sourceUrl && item.quote);
+}
+
+function repairStructuredEvidence(input: {
+  evidence: PopulateRuntimeRow["evidence"];
+  cells: Record<string, PopulateCellValue>;
+  sourceUrls: string[];
+  capturedSources: CapturedSource[];
+  context: DatasetContext;
+  validationIssues: string[];
+  rowNumber: number;
+}): PopulateRuntimeRow["evidence"] {
+  return input.evidence.map((item) => {
+    if (isEvidenceBackedByCapturedSource(item, input.capturedSources)) {
+      return item;
+    }
+    const repairedQuote = quoteFromCapturedSources({
+      cells: input.cells,
+      sourceUrls: input.sourceUrls,
+      capturedSources: input.capturedSources,
+      context: input.context,
+    });
+    if (!repairedQuote) {
+      return item;
+    }
+    input.validationIssues.push(
+      `Structured row ${input.rowNumber}: replaced evidence quote with captured source text.`
+    );
+    return {
+      ...item,
+      sourceUrl: repairedQuote.sourceUrl,
+      quote: repairedQuote.quote,
+    };
+  });
+}
+
+function quoteFromCapturedSources(input: {
+  cells: Record<string, PopulateCellValue>;
+  sourceUrls: string[];
+  capturedSources: CapturedSource[];
+  context: DatasetContext;
+}): { sourceUrl: string; quote: string } | undefined {
+  const sourceUrlSet = new Set(input.sourceUrls);
+  const candidateValues = Object.entries(input.cells)
+    .filter(([columnName]) => !/(^entity_name$|^source_url$|url$|website|link)/i.test(columnName))
+    .flatMap(([, value]) => stringCandidatesFromCellValue(value))
+    .filter((value) => value.length >= 5)
+    .sort((a, b) => b.length - a.length);
+  const sources = input.capturedSources.filter((source) => sourceUrlSet.has(source.url));
+  for (const source of sources) {
+    const normalizedSourceText = normalizeEvidenceText(source.text);
+    for (const candidate of candidateValues) {
+      if (normalizedSourceText.includes(normalizeEvidenceText(candidate))) {
+        return {
+          sourceUrl: source.url,
+          quote: sourceQuoteForCandidate(source.text, candidate),
+        };
+      }
+    }
+    const taskFallbackQuote = taskSpecificSourceQuote(source.text, input.context);
+    if (taskFallbackQuote) {
+      return {
+        sourceUrl: source.url,
+        quote: taskFallbackQuote,
+      };
+    }
+  }
+  return undefined;
+}
+
+function taskSpecificSourceQuote(
+  sourceText: string,
+  context: DatasetContext
+): string | undefined {
+  const taskText = contextText(context);
+  const lineMatcher = /\b(pricing|price|plan|billing|starter|performance|enterprise|merchant|transaction|\$|%)\b/i;
+  if (!/\b(pricing|price|plan|billing)\b/i.test(taskText)) {
+    return undefined;
+  }
+  return sourceText
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => lineMatcher.test(line))
+    ?.slice(0, 240);
+}
+
+function stringCandidatesFromCellValue(value: PopulateCellValue): string[] {
+  if (typeof value === "string") {
+    return [value];
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return [String(value)];
+  }
+  return [];
+}
+
+function sourceQuoteForCandidate(sourceText: string, candidate: string): string {
+  const lines = sourceText.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  return lines.find((line) =>
+    normalizeEvidenceText(line).includes(normalizeEvidenceText(candidate))
+  ) ?? candidate;
+}
+
+function isEvidenceBackedByCapturedSource(
+  evidence: PopulateRuntimeRow["evidence"][number],
+  capturedSources: CapturedSource[]
+): boolean {
+  const normalizedQuote = normalizeEvidenceText(evidence.quote);
+  return capturedSources.some((source) => {
+    if (source.url !== evidence.sourceUrl) {
+      return false;
+    }
+    return normalizeEvidenceText(source.text).includes(normalizedQuote);
+  });
+}
+
+function selectRepresentativeRows(
+  rows: PopulateRuntimeRow[],
+  context: DatasetContext
+): PopulateRuntimeRow[] {
+  const entities = entityCandidatesFromDescription(context.description);
+  if (entities.length < 2 || rows.length <= entities.length) {
+    return rows;
+  }
+  const selectedRows = entities
+    .map((entity) => bestRowForEntity(rows, entity, context))
+    .filter((row): row is PopulateRuntimeRow => Boolean(row));
+
+  return selectedRows.length > 0 ? selectedRows : rows;
+}
+
+function bestRowForEntity(
+  rows: PopulateRuntimeRow[],
+  entity: string,
+  context: DatasetContext
+): PopulateRuntimeRow | undefined {
+  const candidates = rows.filter((row) =>
+    normalizeEvidenceText(String(row.cells.entity_name ?? "")).includes(
+      normalizeEvidenceText(entity)
+    ) ||
+    normalizeEvidenceText(entity).includes(
+      normalizeEvidenceText(String(row.cells.entity_name ?? ""))
+    )
+  );
+  return candidates.sort((a, b) =>
+    representativeRowScore(b, entity, context) -
+      representativeRowScore(a, entity, context)
+  )[0];
+}
+
+function representativeRowScore(
+  row: PopulateRuntimeRow,
+  entity: string,
+  context: DatasetContext
+): number {
+  const rowText = JSON.stringify(row).toLowerCase();
+  const officialPath = officialContentPathForEntity(entity, context);
+  let score = row.evidence.length * 2 + row.sourceUrls.length;
+  if (officialPath && rowText.includes(officialPath.toLowerCase())) {
+    score += 10;
+  }
+  if (/\bdocs?\b|developers\./i.test(rowText)) {
+    score += 3;
+  }
+  if (/\bpricing\b|\/pricing/i.test(rowText)) {
+    score += 3;
+  }
+  if (/\bblog\b|reddit|capterra|review/i.test(rowText)) {
+    score -= 4;
+  }
+  return score;
+}
+
+function hasContradictingStructuredRows(
+  insertedRows: PopulateRuntimeRow[],
+  structuredRows: PopulateRuntimeRow[]
+): boolean {
+  if (structuredRows.length === 0) {
+    return false;
+  }
+  return rowFingerprint(insertedRows) !== rowFingerprint(structuredRows);
+}
+
+function rowFingerprint(rows: PopulateRuntimeRow[]): string {
+  return JSON.stringify(rows.map((row) => row.cells));
+}
+
 function normalizeCells(
   data: Record<string, unknown>
 ): Record<string, PopulateCellValue> {
@@ -340,6 +1146,16 @@ function sourceUrlsFromData(data: Record<string, PopulateCellValue>): string[] {
     }
   }
   return Array.from(new Set(urls));
+}
+
+function uniqueHttpUrls(values: string[]): string[] {
+  return Array.from(new Set(
+    values.filter((value) => /^https?:\/\//i.test(value))
+  ));
+}
+
+function normalizeEvidenceText(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, " ").trim();
 }
 
 function validateRuntimeRows(rows: PopulateRuntimeRow[]): string[] {

--- a/backend/src/pipeline/populate-search-prioritization.ts
+++ b/backend/src/pipeline/populate-search-prioritization.ts
@@ -1,0 +1,156 @@
+import {
+  isLowTrustSourceUrl,
+} from "./populate-acquisition-prompt.js";
+import type { DatasetContext } from "./populate.js";
+import type { DatasetSchema } from "./types.js";
+import type { AgentSearchScore } from "./types.js";
+
+export type { AgentSearchScore } from "./types.js";
+
+export interface SearchResultForPrioritization {
+  title: string;
+  snippet?: string;
+  url: string;
+  site_name?: string;
+}
+
+export interface PrioritizedSearchResult extends SearchResultForPrioritization {
+  expectation_score: number;
+}
+
+/**
+ * Finalizes ranked search results: merges acquisition scores, fills gaps with heuristics,
+ * sorts by expectation_score descending, dedupes by URL.
+ */
+export function prioritizeSearchResultsForSchema(input: {
+  context: DatasetContext;
+  results: SearchResultForPrioritization[];
+  agentScores?: AgentSearchScore[];
+}): PrioritizedSearchResult[] {
+  const merged = mergeAgentScoresIntoResults(
+    input.results,
+    input.agentScores ?? [],
+    input.context
+  );
+
+  const byUrl = new Map<string, PrioritizedSearchResult>();
+  for (const result of merged) {
+    const key = normalizeSearchResultUrl(result.url);
+    const existing = byUrl.get(key);
+    if (!existing || result.expectation_score > existing.expectation_score) {
+      byUrl.set(key, result);
+    }
+  }
+
+  return [...byUrl.values()].sort((a, b) => {
+    if (b.expectation_score !== a.expectation_score) {
+      return b.expectation_score - a.expectation_score;
+    }
+    return a.url.localeCompare(b.url);
+  });
+}
+
+export function finalizePrioritizedSearchResults(input: {
+  context: DatasetContext;
+  dataSpec?: DatasetSchema;
+  results: SearchResultForPrioritization[];
+  agentScores?: AgentSearchScore[];
+}): PrioritizedSearchResult[] {
+  if (input.results.length === 0) {
+    return [];
+  }
+
+  return prioritizeSearchResultsForSchema({
+    context: input.context,
+    results: input.results,
+    agentScores: input.agentScores,
+  });
+}
+
+function mergeAgentScoresIntoResults(
+  results: SearchResultForPrioritization[],
+  agentScores: AgentSearchScore[],
+  context: DatasetContext
+): PrioritizedSearchResult[] {
+  const scoreByUrl = new Map<string, AgentSearchScore>();
+  for (const score of agentScores) {
+    scoreByUrl.set(normalizeSearchResultUrl(score.url), score);
+  }
+
+  return results.map((result) => {
+    const agentScore = scoreByUrl.get(normalizeSearchResultUrl(result.url));
+    return {
+      ...result,
+      expectation_score:
+        agentScore?.expectation_score ?? heuristicExpectationScore(result, context),
+    };
+  });
+}
+
+export function selectTopPrioritizedFetchUrls(
+  results: PrioritizedSearchResult[],
+  fetchLimit: number
+): string[] {
+  return results
+    .slice(0, fetchLimit)
+    .map((result) => normalizeSearchResultUrl(result.url));
+}
+
+function heuristicExpectationScore(
+  result: SearchResultForPrioritization,
+  context?: DatasetContext
+): number {
+  if (isLowTrustSourceUrl(result.url)) {
+    return 1;
+  }
+
+  const haystack = [
+    result.site_name,
+    result.title,
+    result.snippet,
+    result.url,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  let score = 2;
+  if ((result.snippet?.length ?? 0) > 40) score += 1;
+  if (result.title.length > 10) score += 1;
+  if (/\b(official|docs|pricing|blog|news|release)\b/.test(haystack)) score += 1;
+
+  if (context) {
+    const keywords = [
+      ...context.description.toLowerCase().split(/\W+/),
+      ...context.columns.flatMap((column) => [
+        column.name,
+        column.description ?? "",
+      ]),
+    ]
+      .map((token) => token.trim())
+      .filter((token) => token.length > 3);
+    if (keywords.some((token) => haystack.includes(token))) {
+      score += 1;
+    }
+  }
+
+  return Math.max(1, Math.min(5, score));
+}
+
+export function normalizeSearchResultUrl(url: string): string {
+  try {
+    const parsed = new URL(url.trim());
+    parsed.hash = "";
+    return parsed.toString().replace(/\/$/, "");
+  } catch {
+    return url.trim();
+  }
+}
+
+export function siteNameFromUrl(url: string): string | undefined {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return undefined;
+  }
+}

--- a/backend/src/pipeline/populate-self-healing-cli.ts
+++ b/backend/src/pipeline/populate-self-healing-cli.ts
@@ -1,0 +1,6 @@
+import { runPopulateSelfHealingCli } from "./populate-self-healing-command.js";
+
+process.exitCode = await runPopulateSelfHealingCli({
+  argv: process.argv.slice(2),
+  env: process.env,
+});

--- a/backend/src/pipeline/populate-self-healing-command.ts
+++ b/backend/src/pipeline/populate-self-healing-command.ts
@@ -13,6 +13,7 @@ import {
 } from "./populate-self-healing-runner.js";
 
 export interface PopulateSelfHealingCliOptions {
+  datasetId?: string;
   contextPath?: string;
   shouldReadStdin: boolean;
   shouldCommitRows: boolean;
@@ -28,6 +29,7 @@ export interface PopulateSelfHealingCliDependencies {
   writeStdout?: (text: string) => void;
   writeStderr?: (text: string) => void;
   runSelfHealing?: typeof runSelfHealingPopulate;
+  loadDatasetContextById?: (datasetId: string) => Promise<DatasetContext>;
   createRowWriter?: () => Promise<PopulateDatasetRowWriter>;
 }
 
@@ -40,7 +42,11 @@ export async function runPopulateSelfHealingCli(
   try {
     const options = parsePopulateSelfHealingCliArgs(input.argv);
     const prerequisiteError = populateRuntimePrerequisiteError(
-      prerequisitesFromEnv(input.env, options.shouldCommitRows)
+      prerequisitesFromEnv({
+        env: input.env,
+        shouldCommitRows: options.shouldCommitRows,
+        shouldLoadDatasetContext: Boolean(options.datasetId),
+      })
     );
     if (prerequisiteError) {
       writeStdout(JSON.stringify({
@@ -51,10 +57,13 @@ export async function runPopulateSelfHealingCli(
       return 1;
     }
 
-    const context = await readDatasetContext({
+    const context = await resolveDatasetContext({
       options,
       readFileText: input.readFileText ?? ((path) => readFile(path, "utf8")),
       readStdinText: input.readStdinText ?? readProcessStdin,
+      loadDatasetContextById:
+        input.loadDatasetContextById ??
+        ((datasetId) => defaultLoadDatasetContextById(datasetId, input.env)),
     });
     const rowWriter = options.shouldCommitRows
       ? await (input.createRowWriter ?? defaultCreateRowWriter)()
@@ -91,6 +100,7 @@ export function parsePopulateSelfHealingCliArgs(
     shouldReadStdin: false,
     shouldCommitRows: false,
   };
+  const contextSources: string[] = [];
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -101,10 +111,20 @@ export function parsePopulateSelfHealingCliArgs(
       }
       options.contextPath = value;
       options.shouldReadStdin = value === "-";
+      contextSources.push(arg);
       index += 1;
     } else if (arg === "--stdin") {
       options.shouldReadStdin = true;
       options.contextPath = "-";
+      contextSources.push(arg);
+    } else if (arg === "--dataset-id") {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error("--dataset-id requires a dataset id.");
+      }
+      options.datasetId = value;
+      contextSources.push(arg);
+      index += 1;
     } else if (arg === "--commit") {
       options.shouldCommitRows = true;
     } else if (arg === "--recipe-store-dir") {
@@ -127,8 +147,13 @@ export function parsePopulateSelfHealingCliArgs(
     }
   }
 
-  if (!options.contextPath && !options.shouldReadStdin) {
-    throw new Error("Missing --context <file> or --stdin.");
+  if (contextSources.length === 0) {
+    throw new Error("Missing --dataset-id <id>, --context <file>, or --stdin.");
+  }
+  if (contextSources.length > 1) {
+    throw new Error(
+      `Choose exactly one context source: ${contextSources.join(", ")}.`
+    );
   }
   if (!options.shouldCommitRows && options.recipeStoreDirectory) {
     throw new Error("--recipe-store-dir requires --commit.");
@@ -136,27 +161,48 @@ export function parsePopulateSelfHealingCliArgs(
   return options;
 }
 
-async function readDatasetContext(input: {
+async function resolveDatasetContext(input: {
   options: PopulateSelfHealingCliOptions;
   readFileText: (path: string) => Promise<string>;
   readStdinText: () => Promise<string>;
+  loadDatasetContextById: (datasetId: string) => Promise<DatasetContext>;
 }): Promise<DatasetContext> {
+  if (input.options.datasetId) {
+    return input.loadDatasetContextById(input.options.datasetId);
+  }
   const text = input.options.shouldReadStdin
     ? await input.readStdinText()
     : await input.readFileText(input.options.contextPath!);
   return datasetContextSchema.parse(JSON.parse(text));
 }
 
-function prerequisitesFromEnv(
-  env: NodeJS.ProcessEnv,
-  shouldCommitRows: boolean
-): PopulateRuntimePrerequisites {
+function prerequisitesFromEnv(input: {
+  env: NodeJS.ProcessEnv;
+  shouldCommitRows: boolean;
+  shouldLoadDatasetContext: boolean;
+}): PopulateRuntimePrerequisites {
   return {
-    convexAdminKey: env.CONVEX_SELF_HOSTED_ADMIN_KEY,
-    openRouterApiKey: env.OPENROUTER_API_KEY,
-    tinyFishApiKey: env.TINYFISH_API_KEY,
-    shouldCommitRows,
+    convexUrl: input.env.CONVEX_URL,
+    convexAdminKey: input.env.CONVEX_SELF_HOSTED_ADMIN_KEY,
+    openRouterApiKey: input.env.OPENROUTER_API_KEY,
+    tinyFishApiKey: input.env.TINYFISH_API_KEY,
+    shouldCommitRows: input.shouldCommitRows,
+    shouldLoadDatasetContext: input.shouldLoadDatasetContext,
   };
+}
+
+async function defaultLoadDatasetContextById(
+  datasetId: string,
+  env: NodeJS.ProcessEnv
+): Promise<DatasetContext> {
+  const { createConvexPopulateDatasetContextLoader } = await import(
+    "./populate-dataset-context-loader.js"
+  );
+  const loader = createConvexPopulateDatasetContextLoader({
+    convexUrl: env.CONVEX_URL!,
+    convexAdminKey: env.CONVEX_SELF_HOSTED_ADMIN_KEY!,
+  });
+  return loader.loadContext(datasetId);
 }
 
 async function defaultCreateRowWriter(): Promise<PopulateDatasetRowWriter> {

--- a/backend/src/pipeline/populate-self-healing-command.ts
+++ b/backend/src/pipeline/populate-self-healing-command.ts
@@ -11,6 +11,10 @@ import {
   type PopulateDatasetRowWriter,
   type RunSelfHealingPopulateResult,
 } from "./populate-self-healing-runner.js";
+import {
+  createPopulateRecipeRuntime,
+  type CreatePopulateRecipeRuntimeInput,
+} from "./populate-runtime-selection.js";
 
 export interface PopulateSelfHealingCliOptions {
   datasetId?: string;
@@ -29,6 +33,9 @@ export interface PopulateSelfHealingCliDependencies {
   writeStdout?: (text: string) => void;
   writeStderr?: (text: string) => void;
   runSelfHealing?: typeof runSelfHealingPopulate;
+  createRuntime?: (
+    input: CreatePopulateRecipeRuntimeInput
+  ) => Promise<Awaited<ReturnType<typeof createPopulateRecipeRuntime>>>;
   loadDatasetContextById?: (datasetId: string) => Promise<DatasetContext>;
   createRowWriter?: () => Promise<PopulateDatasetRowWriter>;
 }
@@ -65,6 +72,10 @@ export async function runPopulateSelfHealingCli(
         input.loadDatasetContextById ??
         ((datasetId) => defaultLoadDatasetContextById(datasetId, input.env)),
     });
+    const runtime = await (input.createRuntime ?? createPopulateRecipeRuntime)({
+      env: input.env,
+      maxRows: options.maxRows,
+    });
     const rowWriter = options.shouldCommitRows
       ? await (input.createRowWriter ?? defaultCreateRowWriter)()
       : undefined;
@@ -78,9 +89,7 @@ export async function runPopulateSelfHealingCli(
         : undefined,
       rowWriter,
       shouldCommitRows: options.shouldCommitRows,
-      runtime: options.maxRows === undefined
-        ? undefined
-        : await runtimeWithMaxRows(options.maxRows),
+      runtime,
     });
 
     writeStdout(JSON.stringify(summaryForResult(result, !options.shouldCommitRows)));
@@ -210,13 +219,6 @@ async function defaultCreateRowWriter(): Promise<PopulateDatasetRowWriter> {
     "./populate-convex-writer.js"
   );
   return new ConvexPopulateDatasetRowWriter();
-}
-
-async function runtimeWithMaxRows(maxRows: number) {
-  const { MastraPopulateRecipeRuntime } = await import(
-    "./populate-self-healing.js"
-  );
-  return new MastraPopulateRecipeRuntime({ maxRows });
 }
 
 function summaryForResult(

--- a/backend/src/pipeline/populate-self-healing-command.ts
+++ b/backend/src/pipeline/populate-self-healing-command.ts
@@ -1,0 +1,201 @@
+import { readFile } from "node:fs/promises";
+
+import {
+  populateRuntimePrerequisiteError,
+  type PopulateRuntimePrerequisites,
+} from "./populate-runtime-prerequisites.js";
+import { datasetContextSchema, type DatasetContext } from "./populate.js";
+import { InMemoryPopulateRecipeStore } from "./populate-self-healing.js";
+import {
+  runSelfHealingPopulate,
+  type PopulateDatasetRowWriter,
+  type RunSelfHealingPopulateResult,
+} from "./populate-self-healing-runner.js";
+
+export interface PopulateSelfHealingCliOptions {
+  contextPath?: string;
+  shouldReadStdin: boolean;
+  shouldCommitRows: boolean;
+  recipeStoreDirectory?: string;
+  maxRows?: number;
+}
+
+export interface PopulateSelfHealingCliDependencies {
+  argv: string[];
+  env: NodeJS.ProcessEnv;
+  readFileText?: (path: string) => Promise<string>;
+  readStdinText?: () => Promise<string>;
+  writeStdout?: (text: string) => void;
+  writeStderr?: (text: string) => void;
+  runSelfHealing?: typeof runSelfHealingPopulate;
+  createRowWriter?: () => Promise<PopulateDatasetRowWriter>;
+}
+
+export async function runPopulateSelfHealingCli(
+  input: PopulateSelfHealingCliDependencies
+): Promise<number> {
+  const writeStdout = input.writeStdout ?? ((text) => console.log(text));
+  const writeStderr = input.writeStderr ?? ((text) => console.error(text));
+
+  try {
+    const options = parsePopulateSelfHealingCliArgs(input.argv);
+    const prerequisiteError = populateRuntimePrerequisiteError(
+      prerequisitesFromEnv(input.env, options.shouldCommitRows)
+    );
+    if (prerequisiteError) {
+      writeStdout(JSON.stringify({
+        success: false,
+        error: prerequisiteError,
+        dryRun: !options.shouldCommitRows,
+      }));
+      return 1;
+    }
+
+    const context = await readDatasetContext({
+      options,
+      readFileText: input.readFileText ?? ((path) => readFile(path, "utf8")),
+      readStdinText: input.readStdinText ?? readProcessStdin,
+    });
+    const rowWriter = options.shouldCommitRows
+      ? await (input.createRowWriter ?? defaultCreateRowWriter)()
+      : undefined;
+    const result = await (input.runSelfHealing ?? runSelfHealingPopulate)({
+      context,
+      store: options.shouldCommitRows
+        ? undefined
+        : new InMemoryPopulateRecipeStore(),
+      recipeStoreDirectory: options.shouldCommitRows
+        ? options.recipeStoreDirectory ?? input.env.POPULATE_RECIPE_STORE_DIR
+        : undefined,
+      rowWriter,
+      shouldCommitRows: options.shouldCommitRows,
+      runtime: options.maxRows === undefined
+        ? undefined
+        : await runtimeWithMaxRows(options.maxRows),
+    });
+
+    writeStdout(JSON.stringify(summaryForResult(result, !options.shouldCommitRows)));
+    return result.success ? 0 : 2;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    writeStderr(message);
+    writeStdout(JSON.stringify({ success: false, error: message }));
+    return 1;
+  }
+}
+
+export function parsePopulateSelfHealingCliArgs(
+  argv: string[]
+): PopulateSelfHealingCliOptions {
+  const options: PopulateSelfHealingCliOptions = {
+    shouldReadStdin: false,
+    shouldCommitRows: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--context" || arg === "--context-file") {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error(`${arg} requires a file path or "-".`);
+      }
+      options.contextPath = value;
+      options.shouldReadStdin = value === "-";
+      index += 1;
+    } else if (arg === "--stdin") {
+      options.shouldReadStdin = true;
+      options.contextPath = "-";
+    } else if (arg === "--commit") {
+      options.shouldCommitRows = true;
+    } else if (arg === "--recipe-store-dir") {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error("--recipe-store-dir requires a directory path.");
+      }
+      options.recipeStoreDirectory = value;
+      index += 1;
+    } else if (arg === "--max-rows") {
+      const value = argv[index + 1];
+      const parsed = Number(value);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new Error("--max-rows requires a positive integer.");
+      }
+      options.maxRows = parsed;
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!options.contextPath && !options.shouldReadStdin) {
+    throw new Error("Missing --context <file> or --stdin.");
+  }
+  if (!options.shouldCommitRows && options.recipeStoreDirectory) {
+    throw new Error("--recipe-store-dir requires --commit.");
+  }
+  return options;
+}
+
+async function readDatasetContext(input: {
+  options: PopulateSelfHealingCliOptions;
+  readFileText: (path: string) => Promise<string>;
+  readStdinText: () => Promise<string>;
+}): Promise<DatasetContext> {
+  const text = input.options.shouldReadStdin
+    ? await input.readStdinText()
+    : await input.readFileText(input.options.contextPath!);
+  return datasetContextSchema.parse(JSON.parse(text));
+}
+
+function prerequisitesFromEnv(
+  env: NodeJS.ProcessEnv,
+  shouldCommitRows: boolean
+): PopulateRuntimePrerequisites {
+  return {
+    convexAdminKey: env.CONVEX_SELF_HOSTED_ADMIN_KEY,
+    openRouterApiKey: env.OPENROUTER_API_KEY,
+    tinyFishApiKey: env.TINYFISH_API_KEY,
+    shouldCommitRows,
+  };
+}
+
+async function defaultCreateRowWriter(): Promise<PopulateDatasetRowWriter> {
+  const { ConvexPopulateDatasetRowWriter } = await import(
+    "./populate-convex-writer.js"
+  );
+  return new ConvexPopulateDatasetRowWriter();
+}
+
+async function runtimeWithMaxRows(maxRows: number) {
+  const { MastraPopulateRecipeRuntime } = await import(
+    "./populate-self-healing.js"
+  );
+  return new MastraPopulateRecipeRuntime({ maxRows });
+}
+
+function summaryForResult(
+  result: RunSelfHealingPopulateResult,
+  isDryRun: boolean
+) {
+  const diagnosticRun = result.selectedRun ?? result.diagnosticRun;
+  return {
+    success: result.success,
+    dryRun: isDryRun,
+    action: result.action,
+    datasetId: result.datasetId,
+    committedRows: result.committedRows,
+    rowCount: diagnosticRun?.rows.length ?? 0,
+    validationIssues: result.validationIssues,
+    rejectionReasons: result.rejectionReasons,
+    productionValidation: diagnosticRun?.productionValidation,
+    metrics: diagnosticRun?.metrics,
+  };
+}
+
+async function readProcessStdin(): Promise<string> {
+  let text = "";
+  for await (const chunk of process.stdin) {
+    text += String(chunk);
+  }
+  return text;
+}

--- a/backend/src/pipeline/populate-self-healing-runner.ts
+++ b/backend/src/pipeline/populate-self-healing-runner.ts
@@ -1,0 +1,128 @@
+import { join } from "node:path";
+
+import type { DatasetContext } from "./populate.js";
+import {
+  DefaultPopulateRecipeAuthor,
+  FileSystemPopulateRecipeStore,
+  MastraPopulateRecipeRuntime,
+  SelfHealingPopulateRecipeService,
+  type PopulateRecipeAuthor,
+  type PopulateRecipeRunResult,
+  type PopulateRecipeRuntime,
+  type PopulateRecipeStore,
+  type SelfHealingPopulateTickResult,
+} from "./populate-self-healing.js";
+
+export interface PopulateDatasetRowWriter {
+  replaceRows(input: {
+    datasetId: string;
+    rows: PopulateRecipeRunResult["rows"];
+  }): Promise<PopulateDatasetWriteResult>;
+}
+
+export interface PopulateDatasetWriteResult {
+  clearedRowCount?: number;
+  insertedRowCount: number;
+}
+
+export interface RunSelfHealingPopulateInput {
+  context: DatasetContext;
+  store?: PopulateRecipeStore;
+  runtime?: PopulateRecipeRuntime;
+  author?: PopulateRecipeAuthor;
+  rowWriter?: PopulateDatasetRowWriter;
+  shouldCommitRows?: boolean;
+  recipeStoreDirectory?: string;
+}
+
+export interface RunSelfHealingPopulateResult {
+  success: boolean;
+  action: SelfHealingPopulateTickResult["action"];
+  datasetId: string;
+  selectedRun?: PopulateRecipeRunResult;
+  diagnosticRun?: PopulateRecipeRunResult;
+  committedRows?: PopulateDatasetWriteResult;
+  rejectionReasons: string[];
+  validationIssues: string[];
+  tick: SelfHealingPopulateTickResult;
+}
+
+export async function runSelfHealingPopulate(
+  input: RunSelfHealingPopulateInput
+): Promise<RunSelfHealingPopulateResult> {
+  if (input.shouldCommitRows && !input.rowWriter) {
+    throw new Error("rowWriter is required when shouldCommitRows is true.");
+  }
+  const rowWriter = input.rowWriter;
+
+  const store = input.store ?? new FileSystemPopulateRecipeStore(
+    input.recipeStoreDirectory ?? defaultPopulateRecipeStoreDirectory()
+  );
+  const service = new SelfHealingPopulateRecipeService({
+    store,
+    runtime: input.runtime ?? new MastraPopulateRecipeRuntime(),
+    author: input.author ?? new DefaultPopulateRecipeAuthor(),
+  });
+  const tick = await service.tick({
+    datasetId: input.context.datasetId,
+    context: input.context,
+  });
+  const selectedRun = successfulRunForTick(tick);
+  const diagnosticRun = diagnosticRunForTick(tick);
+  let committedRows: PopulateDatasetWriteResult | undefined;
+
+  if (input.shouldCommitRows && selectedRun && rowWriter) {
+    committedRows = await rowWriter.replaceRows({
+      datasetId: input.context.datasetId,
+      rows: selectedRun.rows,
+    });
+  }
+
+  return {
+    success: Boolean(selectedRun),
+    action: tick.action,
+    datasetId: input.context.datasetId,
+    selectedRun,
+    diagnosticRun,
+    committedRows,
+    rejectionReasons: tick.rejectionReasons,
+    validationIssues: validationIssuesForSelfHealingTick(tick),
+    tick,
+  };
+}
+
+export function successfulRunForTick(
+  tick: SelfHealingPopulateTickResult
+): PopulateRecipeRunResult | undefined {
+  if (tick.action === "active_rerun_succeeded") {
+    return tick.activeRun;
+  }
+  if (
+    tick.action === "generated_initial_recipe" ||
+    tick.action === "repaired_active_recipe"
+  ) {
+    return tick.candidateRun;
+  }
+  return undefined;
+}
+
+export function diagnosticRunForTick(
+  tick: SelfHealingPopulateTickResult
+): PopulateRecipeRunResult | undefined {
+  return successfulRunForTick(tick) ?? tick.candidateRun ?? tick.activeRun;
+}
+
+export function validationIssuesForSelfHealingTick(
+  tick: SelfHealingPopulateTickResult
+): string[] {
+  const run = diagnosticRunForTick(tick);
+  return Array.from(new Set([
+    ...(run?.validationIssues ?? []),
+    ...(run?.productionValidation.criticalIssues ?? []),
+    ...tick.rejectionReasons,
+  ]));
+}
+
+function defaultPopulateRecipeStoreDirectory(): string {
+  return join(process.cwd(), ".bigset", "populate-recipes");
+}

--- a/backend/src/pipeline/populate-self-healing.ts
+++ b/backend/src/pipeline/populate-self-healing.ts
@@ -1,6 +1,8 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
+import type { PopulateAcquisitionResult, SearchAcquisitionAgentRunner } from "./populate-acquisition.js";
+import type { PopulateParallelHooks } from "./populate-parallel.js";
 import {
   type PopulateRuntimeAgentRunner,
   type PopulateRuntimeResult,
@@ -140,7 +142,10 @@ export class MastraPopulateRecipeRuntime implements PopulateRecipeRuntime {
       runPopulate?: typeof runPopulateRuntime;
       webTools?: PopulateRuntimeWebTools;
       agentRunner?: PopulateRuntimeAgentRunner;
+      searchAcquisitionRunner?: SearchAcquisitionAgentRunner;
+      acquisition?: PopulateAcquisitionResult;
       maxRows?: number;
+      populateHooks?: PopulateParallelHooks;
     } = {}
   ) {}
 
@@ -160,7 +165,10 @@ export class MastraPopulateRecipeRuntime implements PopulateRecipeRuntime {
         context,
         webTools: this.input.webTools,
         agentRunner: this.input.agentRunner,
+        searchAcquisitionRunner: this.input.searchAcquisitionRunner,
+        acquisition: this.input.acquisition,
         maxRows: this.input.maxRows,
+        populateHooks: this.input.populateHooks,
       });
     } catch (error) {
       failureMessage = error instanceof Error ? error.message : String(error);

--- a/backend/src/pipeline/populate-self-healing.ts
+++ b/backend/src/pipeline/populate-self-healing.ts
@@ -1,0 +1,856 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import {
+  type PopulateRuntimeAgentRunner,
+  type PopulateRuntimeResult,
+  type PopulateRuntimeRow,
+  type PopulateRuntimeWebTools,
+  runPopulateRuntime,
+} from "./populate-runtime.js";
+import {
+  datasetContextSchema,
+  type DatasetContext,
+} from "./populate.js";
+
+export type PopulateRecipeStatus =
+  | "active"
+  | "candidate"
+  | "retired"
+  | "rejected";
+
+export type PopulateRecipeRunStatus = "succeeded" | "failed";
+
+export type PopulateRecipeArtifactKind =
+  | "text"
+  | "stderr"
+  | "source-transcript"
+  | "captured-rows";
+
+const MAX_ARTIFACT_TEXT_LENGTH = 20_000;
+
+export interface PopulateRecipe {
+  recipeId: string;
+  datasetId: string;
+  version: number;
+  status: PopulateRecipeStatus;
+  runtimeInstructions: string;
+  sourceDescription: string;
+  requestedColumns: string[];
+  createdAt: string;
+  createdBy: "agent" | "human" | "system";
+  lastSuccessfulRunAt?: string;
+  lastValidationScore?: number;
+}
+
+export interface PopulateRecipeArtifact {
+  kind: PopulateRecipeArtifactKind;
+  label: string;
+  content: string;
+}
+
+export interface PopulateRecipeProductionValidation {
+  isValid: boolean;
+  score: number;
+  rowCount: number;
+  requestedCellCompletenessRatio: number;
+  sourceUrlCoverageRatio: number;
+  evidenceCoverageRatio: number;
+  expectedEntityCoverageRatio: number;
+  expectedEntities: string[];
+  missingExpectedEntities: string[];
+  criticalIssues: string[];
+  warnings: string[];
+}
+
+export interface PopulateRecipeRunResult extends PopulateRuntimeResult {
+  recipeId: string;
+  recipeVersion: number;
+  runStatus: PopulateRecipeRunStatus;
+  startedAt: string;
+  completedAt: string;
+  runtimeMs: number;
+  productionValidation: PopulateRecipeProductionValidation;
+  artifacts: PopulateRecipeArtifact[];
+}
+
+export interface PopulateRecipeRuntime {
+  runRecipe(input: {
+    recipe: PopulateRecipe;
+    context: DatasetContext;
+  }): Promise<PopulateRecipeRunResult>;
+}
+
+export interface PopulateRecipeAuthorGenerateInput {
+  context: DatasetContext;
+  nextVersion: number;
+}
+
+export interface PopulateRecipeAuthorRepairInput
+  extends PopulateRecipeAuthorGenerateInput {
+  activeRecipe: PopulateRecipe;
+  failedRun: PopulateRecipeRunResult;
+}
+
+export interface PopulateRecipeAuthor {
+  generateRecipe(input: PopulateRecipeAuthorGenerateInput): Promise<PopulateRecipe>;
+  repairRecipe(input: PopulateRecipeAuthorRepairInput): Promise<PopulateRecipe>;
+}
+
+export interface StoredPopulateRecipeRunRecord {
+  recipeId: string;
+  recipeVersion: number;
+  runStatus: PopulateRecipeRunStatus;
+  completedAt: string;
+  productionValidation: PopulateRecipeProductionValidation;
+}
+
+export interface PopulateRecipeStoreSnapshot {
+  datasetId: string;
+  recipes: PopulateRecipe[];
+  runRecords: StoredPopulateRecipeRunRecord[];
+}
+
+export interface PopulateRecipeStore {
+  loadSnapshot(datasetId: string): Promise<PopulateRecipeStoreSnapshot>;
+  saveRecipe(recipe: PopulateRecipe): Promise<void>;
+  saveRunResult(datasetId: string, runResult: PopulateRecipeRunResult): Promise<void>;
+  getActiveRecipe(datasetId: string): Promise<PopulateRecipe | undefined>;
+}
+
+export type SelfHealingPopulateAction =
+  | "active_rerun_succeeded"
+  | "generated_initial_recipe"
+  | "repaired_active_recipe"
+  | "candidate_rejected";
+
+export interface SelfHealingPopulateTickResult {
+  datasetId: string;
+  action: SelfHealingPopulateAction;
+  activeRecipe?: PopulateRecipe;
+  candidateRecipe?: PopulateRecipe;
+  activeRun?: PopulateRecipeRunResult;
+  candidateRun?: PopulateRecipeRunResult;
+  rejectionReasons: string[];
+}
+
+export class MastraPopulateRecipeRuntime implements PopulateRecipeRuntime {
+  constructor(
+    private readonly input: {
+      runPopulate?: typeof runPopulateRuntime;
+      webTools?: PopulateRuntimeWebTools;
+      agentRunner?: PopulateRuntimeAgentRunner;
+      maxRows?: number;
+    } = {}
+  ) {}
+
+  async runRecipe(input: {
+    recipe: PopulateRecipe;
+    context: DatasetContext;
+  }): Promise<PopulateRecipeRunResult> {
+    const startedAtMs = Date.now();
+    const startedAt = new Date(startedAtMs).toISOString();
+    const runtime = this.input.runPopulate ?? runPopulateRuntime;
+    const context = contextWithRecipeInstructions(input.context, input.recipe);
+    let result: PopulateRuntimeResult;
+    let failureMessage: string | undefined;
+
+    try {
+      result = await runtime({
+        context,
+        webTools: this.input.webTools,
+        agentRunner: this.input.agentRunner,
+        maxRows: this.input.maxRows,
+      });
+    } catch (error) {
+      failureMessage = error instanceof Error ? error.message : String(error);
+      result = emptyPopulateRuntimeResult([failureMessage]);
+    }
+
+    const productionValidation = validatePopulateRuntimeResult({
+      result,
+      context: input.context,
+    });
+    const artifacts = artifactsForRun({
+      result,
+      failureMessage,
+      validationIssues: result.validationIssues,
+      productionValidation,
+    });
+    const completedAt = new Date().toISOString();
+
+    return {
+      ...result,
+      recipeId: input.recipe.recipeId,
+      recipeVersion: input.recipe.version,
+      runStatus: productionValidation.isValid ? "succeeded" : "failed",
+      startedAt,
+      completedAt,
+      runtimeMs: Date.now() - startedAtMs,
+      productionValidation,
+      artifacts,
+    };
+  }
+}
+
+export class SelfHealingPopulateRecipeService {
+  constructor(
+    private readonly input: {
+      store: PopulateRecipeStore;
+      runtime: PopulateRecipeRuntime;
+      author: PopulateRecipeAuthor;
+    }
+  ) {}
+
+  async tick(input: {
+    datasetId: string;
+    context: DatasetContext;
+  }): Promise<SelfHealingPopulateTickResult> {
+    const context = {
+      ...datasetContextSchema.parse(input.context),
+      datasetId: input.datasetId,
+    };
+    const activeRecipe = await this.input.store.getActiveRecipe(input.datasetId);
+
+    if (!activeRecipe) {
+      return this.generateInitialRecipe({ datasetId: input.datasetId, context });
+    }
+
+    const activeRun = await this.input.runtime.runRecipe({
+      recipe: activeRecipe,
+      context,
+    });
+    await this.input.store.saveRunResult(input.datasetId, activeRun);
+
+    if (isHealthyRun(activeRun)) {
+      const updatedRecipe = successfulRecipe(activeRecipe, activeRun);
+      await this.input.store.saveRecipe(updatedRecipe);
+      return {
+        datasetId: input.datasetId,
+        action: "active_rerun_succeeded",
+        activeRecipe: updatedRecipe,
+        activeRun,
+        rejectionReasons: [],
+      };
+    }
+
+    const nextVersion = await this.nextVersion(input.datasetId);
+    const candidateRecipe = normalizeCandidateRecipe({
+      recipe: await this.input.author.repairRecipe({
+        context,
+        activeRecipe,
+        failedRun: activeRun,
+        nextVersion,
+      }),
+      datasetId: input.datasetId,
+      context,
+      version: nextVersion,
+    });
+    const candidateRun = await this.runCandidate({
+      recipe: candidateRecipe,
+      context,
+      datasetId: input.datasetId,
+    });
+
+    if (shouldPromoteCandidate({ activeRecipe, activeRun, candidateRun })) {
+      const retiredRecipe = { ...activeRecipe, status: "retired" as const };
+      const promotedRecipe = successfulRecipe(candidateRecipe, candidateRun);
+      await this.input.store.saveRecipe(retiredRecipe);
+      await this.input.store.saveRecipe(promotedRecipe);
+      return {
+        datasetId: input.datasetId,
+        action: "repaired_active_recipe",
+        activeRecipe: promotedRecipe,
+        candidateRecipe,
+        activeRun,
+        candidateRun,
+        rejectionReasons: [],
+      };
+    }
+
+    const rejectedRecipe = { ...candidateRecipe, status: "rejected" as const };
+    await this.input.store.saveRecipe(rejectedRecipe);
+    return {
+      datasetId: input.datasetId,
+      action: "candidate_rejected",
+      activeRecipe,
+      candidateRecipe: rejectedRecipe,
+      activeRun,
+      candidateRun,
+      rejectionReasons: rejectionReasonsForCandidate({
+        activeRecipe,
+        activeRun,
+        candidateRun,
+      }),
+    };
+  }
+
+  private async generateInitialRecipe(input: {
+    datasetId: string;
+    context: DatasetContext;
+  }): Promise<SelfHealingPopulateTickResult> {
+    const nextVersion = await this.nextVersion(input.datasetId);
+    const candidateRecipe = normalizeCandidateRecipe({
+      recipe: await this.input.author.generateRecipe({
+        context: input.context,
+        nextVersion,
+      }),
+      datasetId: input.datasetId,
+      context: input.context,
+      version: nextVersion,
+    });
+    const candidateRun = await this.runCandidate({
+      recipe: candidateRecipe,
+      context: input.context,
+      datasetId: input.datasetId,
+    });
+
+    if (candidateRun.productionValidation.isValid) {
+      const activeRecipe = successfulRecipe(candidateRecipe, candidateRun);
+      await this.input.store.saveRecipe(activeRecipe);
+      return {
+        datasetId: input.datasetId,
+        action: "generated_initial_recipe",
+        activeRecipe,
+        candidateRecipe,
+        candidateRun,
+        rejectionReasons: [],
+      };
+    }
+
+    const rejectedRecipe = { ...candidateRecipe, status: "rejected" as const };
+    await this.input.store.saveRecipe(rejectedRecipe);
+    return {
+      datasetId: input.datasetId,
+      action: "candidate_rejected",
+      candidateRecipe: rejectedRecipe,
+      candidateRun,
+      rejectionReasons: candidateRun.productionValidation.criticalIssues,
+    };
+  }
+
+  private async runCandidate(input: {
+    recipe: PopulateRecipe;
+    context: DatasetContext;
+    datasetId: string;
+  }): Promise<PopulateRecipeRunResult> {
+    await this.input.store.saveRecipe(input.recipe);
+    const runResult = await this.input.runtime.runRecipe({
+      recipe: input.recipe,
+      context: input.context,
+    });
+    await this.input.store.saveRunResult(input.datasetId, runResult);
+    return runResult;
+  }
+
+  private async nextVersion(datasetId: string): Promise<number> {
+    const snapshot = await this.input.store.loadSnapshot(datasetId);
+    return snapshot.recipes.reduce(
+      (version, recipe) => Math.max(version, recipe.version),
+      0
+    ) + 1;
+  }
+}
+
+export class InMemoryPopulateRecipeStore implements PopulateRecipeStore {
+  private readonly snapshotsByDatasetId = new Map<string, PopulateRecipeStoreSnapshot>();
+
+  async loadSnapshot(datasetId: string): Promise<PopulateRecipeStoreSnapshot> {
+    return this.snapshotFor(datasetId);
+  }
+
+  async saveRecipe(recipe: PopulateRecipe): Promise<void> {
+    const snapshot = this.snapshotFor(recipe.datasetId);
+    const existingIndex = snapshot.recipes.findIndex(
+      (storedRecipe) => storedRecipe.recipeId === recipe.recipeId
+    );
+    if (existingIndex >= 0) {
+      snapshot.recipes[existingIndex] = recipe;
+    } else {
+      snapshot.recipes.push(recipe);
+    }
+    snapshot.recipes.sort((left, right) => left.version - right.version);
+  }
+
+  async saveRunResult(
+    datasetId: string,
+    runResult: PopulateRecipeRunResult
+  ): Promise<void> {
+    this.snapshotFor(datasetId).runRecords.push(runRecordFromRunResult(runResult));
+  }
+
+  async getActiveRecipe(datasetId: string): Promise<PopulateRecipe | undefined> {
+    const snapshot = this.snapshotFor(datasetId);
+    return snapshot.recipes
+      .filter((recipe) => recipe.status === "active")
+      .sort((left, right) => right.version - left.version)[0];
+  }
+
+  private snapshotFor(datasetId: string): PopulateRecipeStoreSnapshot {
+    let snapshot = this.snapshotsByDatasetId.get(datasetId);
+    if (!snapshot) {
+      snapshot = { datasetId, recipes: [], runRecords: [] };
+      this.snapshotsByDatasetId.set(datasetId, snapshot);
+    }
+    return snapshot;
+  }
+}
+
+export class FileSystemPopulateRecipeStore implements PopulateRecipeStore {
+  constructor(private readonly rootDirectory: string) {}
+
+  async loadSnapshot(datasetId: string): Promise<PopulateRecipeStoreSnapshot> {
+    try {
+      const manifestText = await readFile(this.manifestPath(datasetId), "utf8");
+      const parsed = JSON.parse(manifestText) as PopulateRecipeStoreSnapshot;
+      return {
+        datasetId,
+        recipes: parsed.recipes ?? [],
+        runRecords: parsed.runRecords ?? [],
+      };
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return { datasetId, recipes: [], runRecords: [] };
+      }
+      throw error;
+    }
+  }
+
+  async saveRecipe(recipe: PopulateRecipe): Promise<void> {
+    const snapshot = await this.loadSnapshot(recipe.datasetId);
+    const existingIndex = snapshot.recipes.findIndex(
+      (storedRecipe) => storedRecipe.recipeId === recipe.recipeId
+    );
+    if (existingIndex >= 0) {
+      snapshot.recipes[existingIndex] = recipe;
+    } else {
+      snapshot.recipes.push(recipe);
+    }
+    snapshot.recipes.sort((left, right) => left.version - right.version);
+    await this.writeSnapshot(snapshot);
+  }
+
+  async saveRunResult(
+    datasetId: string,
+    runResult: PopulateRecipeRunResult
+  ): Promise<void> {
+    const snapshot = await this.loadSnapshot(datasetId);
+    snapshot.runRecords.push(runRecordFromRunResult(runResult));
+    await this.writeSnapshot(snapshot);
+  }
+
+  async getActiveRecipe(datasetId: string): Promise<PopulateRecipe | undefined> {
+    const snapshot = await this.loadSnapshot(datasetId);
+    return snapshot.recipes
+      .filter((recipe) => recipe.status === "active")
+      .sort((left, right) => right.version - left.version)[0];
+  }
+
+  private async writeSnapshot(snapshot: PopulateRecipeStoreSnapshot): Promise<void> {
+    await mkdir(this.datasetDirectory(snapshot.datasetId), { recursive: true });
+    await writeFile(
+      this.manifestPath(snapshot.datasetId),
+      `${JSON.stringify(snapshot, null, 2)}\n`,
+      "utf8"
+    );
+  }
+
+  private datasetDirectory(datasetId: string): string {
+    return join(this.rootDirectory, safePathSegment(datasetId));
+  }
+
+  private manifestPath(datasetId: string): string {
+    return join(this.datasetDirectory(datasetId), "manifest.json");
+  }
+}
+
+export function createPopulateRecipe(input: {
+  recipeId: string;
+  datasetId: string;
+  version: number;
+  sourceDescription: string;
+  requestedColumns: string[];
+  runtimeInstructions?: string;
+  status?: PopulateRecipeStatus;
+  createdAt?: string;
+  createdBy?: PopulateRecipe["createdBy"];
+}): PopulateRecipe {
+  return {
+    recipeId: input.recipeId,
+    datasetId: input.datasetId,
+    version: input.version,
+    status: input.status ?? "candidate",
+    runtimeInstructions: input.runtimeInstructions ?? "",
+    sourceDescription: input.sourceDescription,
+    requestedColumns: input.requestedColumns,
+    createdAt: input.createdAt ?? new Date().toISOString(),
+    createdBy: input.createdBy ?? "agent",
+  };
+}
+
+function normalizeCandidateRecipe(input: {
+  recipe: PopulateRecipe;
+  datasetId: string;
+  context: DatasetContext;
+  version: number;
+}): PopulateRecipe {
+  return {
+    ...input.recipe,
+    datasetId: input.datasetId,
+    version: input.version,
+    status: "candidate",
+    sourceDescription: input.context.description,
+    requestedColumns: input.context.columns.map((column) => column.name),
+  };
+}
+
+function contextWithRecipeInstructions(
+  context: DatasetContext,
+  recipe: PopulateRecipe
+): DatasetContext {
+  if (!recipe.runtimeInstructions.trim()) {
+    return context;
+  }
+  return {
+    ...context,
+    description: [
+      context.description,
+      "",
+      "Durable recipe instructions:",
+      recipe.runtimeInstructions.trim(),
+    ].join("\n"),
+  };
+}
+
+function validatePopulateRuntimeResult(input: {
+  result: PopulateRuntimeResult;
+  context: DatasetContext;
+}): PopulateRecipeProductionValidation {
+  const requestedColumns = input.context.columns.map((column) => column.name);
+  const expectedEntities = expectedEntitiesFromContext(input.context);
+  const entityCoverage = expectedEntityCoverage({
+    rows: input.result.rows,
+    expectedEntities,
+  });
+  const rowCount = input.result.rows.length;
+  const requestedCellCompletenessRatio = averageRatio(
+    input.result.rows.map((row) => cellCompletenessRatio(row, requestedColumns))
+  );
+  const sourceUrlCoverageRatio = averageRatio(
+    input.result.rows.map((row) => row.sourceUrls.length > 0 ? 1 : 0)
+  );
+  const evidenceCoverageRatio = averageRatio(
+    input.result.rows.map((row) => row.evidence.length > 0 ? 1 : 0)
+  );
+  const criticalIssues = criticalIssuesForRows({
+    rows: input.result.rows,
+    requestedColumns,
+    validationIssues: input.result.validationIssues,
+    missingExpectedEntities: entityCoverage.missingExpectedEntities,
+  });
+  const scoreComponents = [
+    requestedCellCompletenessRatio,
+    sourceUrlCoverageRatio,
+    evidenceCoverageRatio,
+  ];
+  if (expectedEntities.length > 0) {
+    scoreComponents.push(entityCoverage.expectedEntityCoverageRatio);
+  }
+  const score = rowCount === 0
+    ? 0
+    : averageRatio(scoreComponents);
+
+  return {
+    isValid: criticalIssues.length === 0,
+    score,
+    rowCount,
+    requestedCellCompletenessRatio,
+    sourceUrlCoverageRatio,
+    evidenceCoverageRatio,
+    expectedEntityCoverageRatio: entityCoverage.expectedEntityCoverageRatio,
+    expectedEntities,
+    missingExpectedEntities: entityCoverage.missingExpectedEntities,
+    criticalIssues,
+    warnings: input.result.validationIssues,
+  };
+}
+
+function criticalIssuesForRows(input: {
+  rows: PopulateRuntimeRow[];
+  requestedColumns: string[];
+  validationIssues: string[];
+  missingExpectedEntities: string[];
+}): string[] {
+  const issues: string[] = [];
+  if (input.rows.length === 0) {
+    issues.push("Populate runtime returned no rows.");
+  }
+  if (input.missingExpectedEntities.length > 0) {
+    issues.push(
+      `Missing expected entities: ${input.missingExpectedEntities.join(", ")}.`
+    );
+  }
+  input.rows.forEach((row, index) => {
+    const missingColumns = input.requestedColumns.filter(
+      (columnName) => isMissingCellValue(row.cells[columnName])
+    );
+    if (missingColumns.length > 0) {
+      issues.push(`Row ${index + 1} missing requested columns: ${missingColumns.join(", ")}.`);
+    }
+    if (row.sourceUrls.length === 0) {
+      issues.push(`Row ${index + 1} has no source URL.`);
+    }
+    if (row.evidence.length === 0) {
+      issues.push(`Row ${index + 1} has no evidence quote.`);
+    }
+  });
+  input.validationIssues
+    .filter((issue) =>
+      /failed|missing|no rows|not found|invented|invalid/i.test(issue) &&
+      !isNonBlockingOperationalWarning(issue)
+    )
+    .forEach((issue) => issues.push(issue));
+  return Array.from(new Set(issues));
+}
+
+function cellCompletenessRatio(
+  row: PopulateRuntimeRow,
+  requestedColumns: string[]
+): number {
+  if (requestedColumns.length === 0) {
+    return 1;
+  }
+  const filledCount = requestedColumns.filter(
+    (columnName) => !isMissingCellValue(row.cells[columnName])
+  ).length;
+  return filledCount / requestedColumns.length;
+}
+
+function expectedEntitiesFromContext(context: DatasetContext): string[] {
+  const fromSegment = context.description.match(/\bfrom\s+([^?.]+)/i)?.[1];
+  if (!fromSegment) {
+    return [];
+  }
+  const entities = fromSegment
+    .split(/,|\band\b/i)
+    .map((entity) => entity.replace(/\b(the|a|an)\b/gi, " ").trim())
+    .map((entity) => entity.replace(/\s+/g, " "))
+    .filter((entity) =>
+      entity.length >= 2 &&
+      entity.length <= 60 &&
+      /[A-Z]/.test(entity)
+    );
+  return entities.length >= 2 ? Array.from(new Set(entities)) : [];
+}
+
+function expectedEntityCoverage(input: {
+  rows: PopulateRuntimeRow[];
+  expectedEntities: string[];
+}): {
+  expectedEntityCoverageRatio: number;
+  missingExpectedEntities: string[];
+} {
+  if (input.expectedEntities.length === 0) {
+    return {
+      expectedEntityCoverageRatio: 1,
+      missingExpectedEntities: [],
+    };
+  }
+  const missingExpectedEntities = input.expectedEntities.filter(
+    (entity) => !input.rows.some((row) =>
+      rowIdentityText(row).includes(entity.toLowerCase())
+    )
+  );
+  return {
+    expectedEntityCoverageRatio: roundScore(
+      (input.expectedEntities.length - missingExpectedEntities.length) /
+      input.expectedEntities.length
+    ),
+    missingExpectedEntities,
+  };
+}
+
+function rowIdentityText(row: PopulateRuntimeRow): string {
+  return [
+    row.cells.entity_name,
+    row.cells.company_name,
+    row.cells.provider_name,
+    row.cells.product_name,
+    row.cells.name,
+  ]
+    .filter((value) => typeof value === "string" && value.trim())
+    .join(" ")
+    .toLowerCase();
+}
+
+function isNonBlockingOperationalWarning(issue: string): boolean {
+  return /^Structured fallback (search|fetch) failed/i.test(issue);
+}
+
+function isMissingCellValue(value: unknown): boolean {
+  return value === undefined || value === null || value === "";
+}
+
+function averageRatio(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  return roundScore(values.reduce((sum, value) => sum + value, 0) / values.length);
+}
+
+function roundScore(value: number): number {
+  return Math.round(value * 1_000) / 1_000;
+}
+
+function artifactsForRun(input: {
+  result: PopulateRuntimeResult;
+  failureMessage?: string;
+  validationIssues: string[];
+  productionValidation: PopulateRecipeProductionValidation;
+}): PopulateRecipeArtifact[] {
+  const artifacts: PopulateRecipeArtifact[] = [];
+  const debugNotes = input.result.debug?.notes ?? [];
+  if (input.failureMessage) {
+    artifacts.push({
+      kind: "stderr",
+      label: "populate-runtime-error",
+      content: input.failureMessage,
+    });
+  }
+  if (input.validationIssues.length > 0 || input.productionValidation.criticalIssues.length > 0) {
+    artifacts.push({
+      kind: "text",
+      label: "populate-validation",
+      content: [
+        ...input.validationIssues,
+        ...input.productionValidation.criticalIssues,
+      ].join("\n"),
+    });
+  }
+  if (debugNotes.length > 0) {
+    artifacts.push({
+      kind: "text",
+      label: "populate-debug-notes",
+      content: debugNotes.join("\n").slice(0, MAX_ARTIFACT_TEXT_LENGTH),
+    });
+  }
+  const capturedSources = input.result.debug?.capturedSources ?? [];
+  const capturedRows = input.result.debug?.capturedRows ?? [];
+  if (capturedSources.length > 0) {
+    artifacts.push({
+      kind: "source-transcript",
+      label: "populate-source-transcript",
+      content: capturedSources
+        .map((source, index) => [
+          `SOURCE ${index + 1}`,
+          `URL: ${source.url}`,
+          "TEXT:",
+          source.text,
+        ].join("\n"))
+        .join("\n\n")
+        .slice(0, MAX_ARTIFACT_TEXT_LENGTH),
+    });
+  }
+  if (capturedRows.length > 0) {
+    artifacts.push({
+      kind: "captured-rows",
+      label: "populate-captured-rows",
+      content: JSON.stringify(capturedRows, null, 2)
+        .slice(0, MAX_ARTIFACT_TEXT_LENGTH),
+    });
+  }
+  return artifacts;
+}
+
+function emptyPopulateRuntimeResult(validationIssues: string[]): PopulateRuntimeResult {
+  return {
+    rows: [],
+    validationIssues,
+    usage: {
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+    },
+    metrics: {
+      searchCalls: 0,
+      fetchCalls: 0,
+      browserCalls: 0,
+      agentRuns: 0,
+      agentSteps: 0,
+    },
+    debug: {
+      capturedRows: [],
+      capturedSources: [],
+      selectedRowSource: "none",
+      notes: [],
+    },
+  };
+}
+
+function isHealthyRun(runResult: PopulateRecipeRunResult): boolean {
+  return runResult.runStatus === "succeeded" &&
+    runResult.productionValidation.isValid;
+}
+
+function shouldPromoteCandidate(input: {
+  activeRecipe: PopulateRecipe;
+  activeRun: PopulateRecipeRunResult;
+  candidateRun: PopulateRecipeRunResult;
+}): boolean {
+  const baselineScore =
+    input.activeRecipe.lastValidationScore ??
+    input.activeRun.productionValidation.score;
+  return input.candidateRun.productionValidation.isValid &&
+    input.candidateRun.productionValidation.score >=
+      baselineScore;
+}
+
+function rejectionReasonsForCandidate(input: {
+  activeRecipe: PopulateRecipe;
+  activeRun: PopulateRecipeRunResult;
+  candidateRun: PopulateRecipeRunResult;
+}): string[] {
+  const reasons = [...input.candidateRun.productionValidation.criticalIssues];
+  const baselineScore =
+    input.activeRecipe.lastValidationScore ??
+    input.activeRun.productionValidation.score;
+  if (
+    input.candidateRun.productionValidation.score <
+    baselineScore
+  ) {
+    reasons.push("Candidate validation score is below the active recipe baseline.");
+  }
+  return Array.from(new Set(reasons));
+}
+
+function successfulRecipe(
+  recipe: PopulateRecipe,
+  runResult: PopulateRecipeRunResult
+): PopulateRecipe {
+  return {
+    ...recipe,
+    status: "active",
+    lastSuccessfulRunAt: runResult.completedAt,
+    lastValidationScore: runResult.productionValidation.score,
+  };
+}
+
+function runRecordFromRunResult(
+  runResult: PopulateRecipeRunResult
+): StoredPopulateRecipeRunRecord {
+  return {
+    recipeId: runResult.recipeId,
+    recipeVersion: runResult.recipeVersion,
+    runStatus: runResult.runStatus,
+    completedAt: runResult.completedAt,
+    productionValidation: runResult.productionValidation,
+  };
+}
+
+function safePathSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/backend/src/pipeline/populate-self-healing.ts
+++ b/backend/src/pipeline/populate-self-healing.ts
@@ -167,30 +167,48 @@ export class MastraPopulateRecipeRuntime implements PopulateRecipeRuntime {
       result = emptyPopulateRuntimeResult([failureMessage]);
     }
 
-    const productionValidation = validatePopulateRuntimeResult({
-      result,
+    return populateRecipeRunResultFromRuntimeResult({
+      recipe: input.recipe,
       context: input.context,
-    });
-    const artifacts = artifactsForRun({
       result,
       failureMessage,
-      validationIssues: result.validationIssues,
-      productionValidation,
-    });
-    const completedAt = new Date().toISOString();
-
-    return {
-      ...result,
-      recipeId: input.recipe.recipeId,
-      recipeVersion: input.recipe.version,
-      runStatus: productionValidation.isValid ? "succeeded" : "failed",
       startedAt,
-      completedAt,
-      runtimeMs: Date.now() - startedAtMs,
-      productionValidation,
-      artifacts,
-    };
+      startedAtMs,
+    });
   }
+}
+
+export function populateRecipeRunResultFromRuntimeResult(input: {
+  recipe: PopulateRecipe;
+  context: DatasetContext;
+  result: PopulateRuntimeResult;
+  failureMessage?: string;
+  startedAt: string;
+  startedAtMs: number;
+}): PopulateRecipeRunResult {
+  const productionValidation = validatePopulateRuntimeResult({
+    result: input.result,
+    context: input.context,
+  });
+  const artifacts = artifactsForRun({
+    result: input.result,
+    failureMessage: input.failureMessage,
+    validationIssues: input.result.validationIssues,
+    productionValidation,
+  });
+  const completedAt = new Date().toISOString();
+
+  return {
+    ...input.result,
+    recipeId: input.recipe.recipeId,
+    recipeVersion: input.recipe.version,
+    runStatus: productionValidation.isValid ? "succeeded" : "failed",
+    startedAt: input.startedAt,
+    completedAt,
+    runtimeMs: Date.now() - input.startedAtMs,
+    productionValidation,
+    artifacts,
+  };
 }
 
 export class DefaultPopulateRecipeAuthor implements PopulateRecipeAuthor {
@@ -836,7 +854,7 @@ function artifactsForRun(input: {
   return artifacts;
 }
 
-function emptyPopulateRuntimeResult(validationIssues: string[]): PopulateRuntimeResult {
+export function emptyPopulateRuntimeResult(validationIssues: string[]): PopulateRuntimeResult {
   return {
     rows: [],
     validationIssues,

--- a/backend/src/pipeline/populate-self-healing.ts
+++ b/backend/src/pipeline/populate-self-healing.ts
@@ -193,6 +193,36 @@ export class MastraPopulateRecipeRuntime implements PopulateRecipeRuntime {
   }
 }
 
+export class DefaultPopulateRecipeAuthor implements PopulateRecipeAuthor {
+  async generateRecipe(
+    input: PopulateRecipeAuthorGenerateInput
+  ): Promise<PopulateRecipe> {
+    return createPopulateRecipe({
+      recipeId: populateRecipeId(input.context.datasetId, input.nextVersion),
+      datasetId: input.context.datasetId,
+      version: input.nextVersion,
+      sourceDescription: input.context.description,
+      requestedColumns: requestedColumnNames(input.context),
+      runtimeInstructions: initialRuntimeInstructions(input.context),
+      createdBy: "system",
+    });
+  }
+
+  async repairRecipe(
+    input: PopulateRecipeAuthorRepairInput
+  ): Promise<PopulateRecipe> {
+    return createPopulateRecipe({
+      recipeId: populateRecipeId(input.context.datasetId, input.nextVersion),
+      datasetId: input.context.datasetId,
+      version: input.nextVersion,
+      sourceDescription: input.context.description,
+      requestedColumns: requestedColumnNames(input.context),
+      runtimeInstructions: repairRuntimeInstructions(input),
+      createdBy: "system",
+    });
+  }
+}
+
 export class SelfHealingPopulateRecipeService {
   constructor(
     private readonly input: {
@@ -502,6 +532,50 @@ function normalizeCandidateRecipe(input: {
     sourceDescription: input.context.description,
     requestedColumns: input.context.columns.map((column) => column.name),
   };
+}
+
+function populateRecipeId(datasetId: string, version: number): string {
+  return `${safePathSegment(datasetId)}-recipe-v${version}`;
+}
+
+function requestedColumnNames(context: DatasetContext): string[] {
+  return context.columns.map((column) => column.name);
+}
+
+function initialRuntimeInstructions(context: DatasetContext): string {
+  return [
+    "Use search_web before fetch_page unless an official source URL is already obvious.",
+    "Prefer official docs, pricing, blog, product, or company pages over third-party summaries.",
+    "Every inserted row must include source_url and evidence_quote cells when those columns exist.",
+    "Every inserted row must include at least one source URL and one evidence quote.",
+    `Requested columns: ${requestedColumnNames(context).join(", ")}.`,
+  ].join("\n");
+}
+
+function repairRuntimeInstructions(input: PopulateRecipeAuthorRepairInput): string {
+  const failureSummary = [
+    ...input.failedRun.productionValidation.criticalIssues,
+    ...input.failedRun.validationIssues,
+  ]
+    .map((issue) => issue.trim())
+    .filter(Boolean)
+    .slice(0, 8);
+  const priorInstructions = input.activeRecipe.runtimeInstructions.trim();
+  return [
+    priorInstructions || initialRuntimeInstructions(input.context),
+    "",
+    "Repair focus from previous failed run:",
+    ...failureSummary.map((issue) => `- ${truncateInstruction(issue, 240)}`),
+    "- Do not reuse rows that failed validation without fixing source URL and evidence quote coverage.",
+    "- If expected entities were missing, collect one source-backed row per missing entity before returning.",
+  ].join("\n");
+}
+
+function truncateInstruction(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength - 12)} [truncated]`;
 }
 
 function contextWithRecipeInstructions(

--- a/backend/src/pipeline/populate-source-status.ts
+++ b/backend/src/pipeline/populate-source-status.ts
@@ -1,0 +1,23 @@
+import {
+  populateSourceStatusSchema,
+  type PopulateSourceStatus,
+} from "./types.js";
+
+export type { PopulateSourceStatus } from "./types.js";
+export { populateSourceStatusSchema } from "./types.js";
+
+export const AGENT_TRIAGE_STATUSES: PopulateSourceStatus[] = [
+  "requires_navigation",
+  "requires_form_submission",
+  "requires_detail_page_followup",
+];
+
+export function statusNeedsTinyfishAgent(status: PopulateSourceStatus): boolean {
+  return AGENT_TRIAGE_STATUSES.includes(status);
+}
+
+export function parsePopulateSourceStatus(
+  value: string
+): PopulateSourceStatus {
+  return populateSourceStatusSchema.parse(value);
+}

--- a/backend/src/pipeline/populate-tinyfish-agent.ts
+++ b/backend/src/pipeline/populate-tinyfish-agent.ts
@@ -1,0 +1,125 @@
+import { RunStatus, TinyFish } from "@tiny-fish/sdk";
+
+import type {
+  BrowserAgentJob,
+  BrowserAgentRunResult,
+} from "./populate-browser-agent.js";
+import type { PopulateExtractionSpec } from "./populate-extraction-spec.js";
+import type { PopulateSourceTriageResult } from "./types.js";
+import {
+  resolvePopulateTinyfishAgentConfig,
+  type PopulateTinyfishAgentConfig,
+} from "./populate-parallel-config.js";
+
+export type TinyfishAgentRunResult = BrowserAgentRunResult;
+export type TinyfishAgentJob = BrowserAgentJob;
+
+let client: TinyFish | null = null;
+
+function getClient(apiKey: string): TinyFish {
+  if (!client) {
+    client = new TinyFish({ apiKey });
+  }
+  return client;
+}
+
+function requiredTinyfishApiKey(): string {
+  const apiKey = process.env.TINYFISH_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error("Missing required environment variable: TINYFISH_API_KEY");
+  }
+  return apiKey;
+}
+
+export function buildTinyfishAgentGoal(input: {
+  userPrompt: string;
+  spec: PopulateExtractionSpec;
+  triage: PopulateSourceTriageResult;
+}): string {
+  const columnHints = input.spec.columns
+    .map((column) => `${column.name}: ${column.description}`)
+    .join("; ");
+  const action =
+    input.triage.suggested_action?.trim() ||
+    "navigate the page and extract the requested fields";
+  return `Goal: ${input.userPrompt}. Make sure to gather data for ${columnHints}. You may ${action}.`;
+}
+
+export function agentPriorityScore(triage: PopulateSourceTriageResult): number {
+  const yieldScore =
+    triage.expected_yield === "complete"
+      ? 1
+      : triage.expected_yield === "partial"
+        ? 0.5
+        : 0;
+  return (triage.source_data_confidence + yieldScore) / 2;
+}
+
+async function pollUntilDone(
+  runId: string,
+  config: PopulateTinyfishAgentConfig
+): Promise<TinyfishAgentRunResult> {
+  const apiKey = requiredTinyfishApiKey();
+  const startedAt = Date.now();
+  let lastStatus = RunStatus.PENDING;
+
+  while (true) {
+    const run = await getClient(apiKey).runs.get(runId);
+    lastStatus = run.status;
+    if (
+      run.status === RunStatus.COMPLETED ||
+      run.status === RunStatus.FAILED ||
+      run.status === RunStatus.CANCELLED
+    ) {
+      return {
+        run_id: run.run_id,
+        status: run.status,
+        result: (run.result as Record<string, unknown> | null) ?? null,
+        error: run.error?.message ?? null,
+      };
+    }
+    if (Date.now() - startedAt >= config.pollTimeoutMs) {
+      return {
+        run_id: runId,
+        status: "TIMEOUT",
+        result: null,
+        error: `Agent run timed out after ${config.pollTimeoutMs}ms (last status: ${lastStatus})`,
+      };
+    }
+    await sleep(config.pollIntervalMs);
+  }
+}
+
+export async function runTinyfishAgent(
+  job: TinyfishAgentJob,
+  config: PopulateTinyfishAgentConfig = resolvePopulateTinyfishAgentConfig()
+): Promise<TinyfishAgentRunResult> {
+  const apiKey = requiredTinyfishApiKey();
+  const queued = await getClient(apiKey).agent.queue({
+    url: job.url,
+    goal: job.goal,
+  });
+  if (queued.error || !queued.run_id) {
+    return {
+      run_id: null,
+      status: RunStatus.FAILED,
+      result: null,
+      error: queued.error?.message ?? "Failed to queue Tinyfish agent run",
+    };
+  }
+  return pollUntilDone(queued.run_id, config);
+}
+
+export async function runTinyfishAgentsBatch(
+  jobs: TinyfishAgentJob[],
+  config: PopulateTinyfishAgentConfig = resolvePopulateTinyfishAgentConfig()
+): Promise<TinyfishAgentRunResult[]> {
+  if (jobs.length === 0) {
+    return [];
+  }
+  return Promise.all(jobs.map((job) => runTinyfishAgent(job, config)));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/backend/src/pipeline/populate-triage-extract.ts
+++ b/backend/src/pipeline/populate-triage-extract.ts
@@ -1,0 +1,97 @@
+import {
+  buildPopulateTriageExtractSchema,
+  populateSourceTriageResultSchema,
+  type PopulateSourceTriageResult,
+} from "./types.js";
+import { completePopulateJson } from "./populate-llm-json.js";
+import type { PopulateExtractionSpec } from "./populate-extraction-spec.js";
+import { parsePopulateSourceStatus } from "./populate-source-status.js";
+import type { PopulateFetchedPage } from "./populate-web-types.js";
+import {
+  finalizePopulateLlmRecords,
+  type PopulateLlmExtractionRecord,
+} from "./populate-extract-records.js";
+import type { PopulateCandidateRow } from "./populate-row.js";
+
+const TRIAGE_EXTRACT_PAGE_CHAR_LIMIT = 24_000;
+
+const COMBINED_TRIAGE_EXTRACT_SYSTEM = `You are the Source Triage + Extraction Agent for a dataset populate pipeline.
+
+Return JSON with exactly:
+- triage_results (required)
+- extraction_results (required; use empty records when not extracting)
+
+Triage status:
+- extract_now: Page has usable inline data — extract rows in this same response.
+- requires_navigation / requires_form_submission / requires_detail_page_followup: Do NOT extract; suggest_action should describe what a browser agent should do.
+- irrelevant / duplicate / blocked / low_value: Do NOT extract.
+
+Triage fields: url, final_url, title, status, confidence, source_data_confidence, expected_yield (complete|partial|none), reasoning, optional suggested_action.
+
+When status is extract_now:
+- Extract only facts from page text. row keys must match spec column names.
+- evidence: field, quote, optional url; extraction_confidence per record.
+
+When status is NOT extract_now: extraction_results.records must be [].
+
+Return ONLY JSON.`;
+
+export interface TriageAndExtractPageResult {
+  triage: PopulateSourceTriageResult;
+  records: PopulateCandidateRow[];
+}
+
+export async function triageAndExtractPage(input: {
+  userPrompt: string;
+  spec: PopulateExtractionSpec;
+  page: PopulateFetchedPage;
+}): Promise<TriageAndExtractPageResult> {
+  const pageUrl = input.page.final_url || input.page.url;
+  const columnNames = input.spec.columns.map((column) => column.name);
+  const schema = buildPopulateTriageExtractSchema(columnNames);
+
+  const combined = await completePopulateJson({
+    label: `populate-triage-extract:${pageUrl}`,
+    schema,
+    system: COMBINED_TRIAGE_EXTRACT_SYSTEM,
+    user: JSON.stringify({
+      user_prompt: input.userPrompt,
+      dataset_spec: input.spec,
+      page: {
+        url: pageUrl,
+        title: input.page.title,
+        text: truncatePageText(input.page.text),
+      },
+      required_output_shape: {
+        triage_results: "see system prompt",
+        extraction_results: { records: "[] or row objects when extract_now" },
+      },
+    }),
+  });
+
+  const triage: PopulateSourceTriageResult = {
+    ...combined.triage_results,
+    url: input.page.url,
+    final_url: pageUrl,
+    title: input.page.title || combined.triage_results.title,
+    status: parsePopulateSourceStatus(combined.triage_results.status),
+  };
+
+  let records: PopulateCandidateRow[] = [];
+  if (triage.status === "extract_now") {
+    records = finalizePopulateLlmRecords({
+      records: combined.extraction_results.records as PopulateLlmExtractionRecord[],
+      pageUrl,
+      spec: input.spec,
+    });
+  }
+
+  return { triage, records };
+}
+
+function truncatePageText(text: string): string {
+  if (text.length <= TRIAGE_EXTRACT_PAGE_CHAR_LIMIT) {
+    return text;
+  }
+  return `${text.slice(0, TRIAGE_EXTRACT_PAGE_CHAR_LIMIT)}\n\n[truncated]`;
+}

--- a/backend/src/pipeline/populate-url-utils.ts
+++ b/backend/src/pipeline/populate-url-utils.ts
@@ -1,0 +1,45 @@
+/** True when value is a non-empty http(s) URL string. */
+export function isHttpUrl(value: unknown): value is string {
+  return typeof value === "string" && /^https?:\/\//i.test(value.trim());
+}
+
+/** Coerces LLM/tool output into a single http(s) URL, or null when not URL-like. */
+export function coerceHttpUrl(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return /^https?:\/\//i.test(trimmed) ? trimmed : null;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const coerced = coerceHttpUrl(item);
+      if (coerced) {
+        return coerced;
+      }
+    }
+    return null;
+  }
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    for (const key of ["url", "href", "link"] as const) {
+      const coerced = coerceHttpUrl(record[key]);
+      if (coerced) {
+        return coerced;
+      }
+    }
+  }
+  return null;
+}
+
+export function uniqueHttpUrls(urls: unknown[]): string[] {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const url of urls) {
+    const coerced = coerceHttpUrl(url);
+    if (!coerced || seen.has(coerced)) {
+      continue;
+    }
+    seen.add(coerced);
+    unique.push(coerced);
+  }
+  return unique;
+}

--- a/backend/src/pipeline/populate-web-types.ts
+++ b/backend/src/pipeline/populate-web-types.ts
@@ -1,0 +1,24 @@
+export interface PopulateWebSearchResult {
+  title: string;
+  snippet?: string;
+  url: string;
+  site_name?: string;
+  expectation_score?: number;
+}
+
+export interface PopulateFetchedPage {
+  url: string;
+  final_url?: string;
+  title?: string;
+  text?: string;
+}
+
+export interface PopulateRuntimeWebTools {
+  search(input: { query: string }): Promise<PopulateWebSearchResult[]>;
+  fetch(input: { url: string }): Promise<PopulateFetchedPage>;
+}
+
+export interface PopulateRuntimeCapturedSource {
+  url: string;
+  text: string;
+}

--- a/backend/src/pipeline/populate.ts
+++ b/backend/src/pipeline/populate.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const populateColumnSchema = z.object({
+  name: z.string(),
+  type: z.enum(["text", "number", "boolean", "url", "date"]),
+  description: z.optional(z.string()),
+});
+export type PopulateColumn = z.infer<typeof populateColumnSchema>;
+
+export const datasetContextSchema = z.object({
+  datasetId: z.string().min(1),
+  datasetName: z.string(),
+  description: z.string(),
+  columns: z.array(populateColumnSchema).min(1),
+});
+export type DatasetContext = z.infer<typeof datasetContextSchema>;

--- a/backend/src/pipeline/schema-inference.ts
+++ b/backend/src/pipeline/schema-inference.ts
@@ -54,7 +54,7 @@ async function callOnce(
     model,
     output: Output.object({ schema: datasetSchemaSchema }),
     system: SYSTEM_PROMPT,
-    maxTokens: 4096,
+    maxOutputTokens: 4096,
     prompt,
   });
   if (!output) throw new Error("Model did not generate a valid schema object");

--- a/backend/src/pipeline/schema-inference.ts
+++ b/backend/src/pipeline/schema-inference.ts
@@ -1,46 +1,114 @@
 import { generateText, Output, NoObjectGeneratedError } from "ai";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 
+import {
+  SCHEMA_INFERENCE_OPENROUTER_MODEL_ID,
+  requiredOpenRouterApiKey,
+} from "../openrouter-models.js";
+import { recordLanguageModelUsage } from "./llm-usage.js";
 import { datasetSchemaSchema, type DatasetSchema } from "./types.js";
 
-const SYSTEM_PROMPT = `You are a data engineering assistant that converts natural-language prompts into structured dataset schemas. Given a user prompt describing a dataset they want to build, you produce a precise schema definition.
+export interface InferSchemaOptions {
+  searchQueryCount?: number;
+}
+
+export function resolveInitialSearchQueryCap(maxSearchCalls: number): number {
+  return Math.max(1, Math.floor(maxSearchCalls / 2));
+}
+
+function initialQueriesFromDataSpec(
+  dataSpec: DatasetSchema,
+  expectedCount: number
+): string[] {
+  const queries = dataSpec.search_queries
+    .map((query) => query.trim())
+    .filter(Boolean);
+  if (queries.length !== expectedCount) {
+    throw new Error(
+      `Data spec must include exactly ${expectedCount} search_queries (got ${queries.length}).`
+    );
+  }
+  return queries;
+}
+
+export async function resolvePopulateDataSpec(input: {
+  prompt: string;
+  dataSpec?: DatasetSchema;
+  maxSearchCalls: number;
+  inferSchemaFn?: typeof inferSchema;
+}): Promise<{ dataSpec: DatasetSchema; initialQueries: string[] }> {
+  const expectedQueryCount = resolveInitialSearchQueryCap(input.maxSearchCalls);
+  const infer = input.inferSchemaFn ?? inferSchema;
+  let dataSpec = input.dataSpec;
+
+  if (!dataSpec || dataSpec.search_queries.length !== expectedQueryCount) {
+    dataSpec = await infer(input.prompt, {
+      searchQueryCount: expectedQueryCount,
+    });
+  }
+
+  return {
+    dataSpec,
+    initialQueries: initialQueriesFromDataSpec(dataSpec, expectedQueryCount),
+  };
+}
+
+function buildSystemPrompt(searchQueryCount?: number): string {
+  const searchQueryRule =
+    searchQueryCount === undefined
+      ? "Provide a diverse `search_queries` array (at least one) of web search strings to discover source pages for this dataset. Each query must be distinct and tailored to the user prompt and columns."
+      : `Provide exactly ${searchQueryCount} items in \`search_queries\`: diverse, non-overlapping web search strings to discover source pages for this dataset. Each query must be distinct, specific to the user prompt and columns, and use site: operators when a domain is obvious. Do not return fewer or more than ${searchQueryCount} queries.`;
+
+  return `You are a data engineering assistant that converts natural-language prompts into structured dataset schemas. Given a user prompt describing a dataset they want to build, you produce a precise schema definition.
 
 Your job is to:
 
 1. Identify the universe of entities the user wants to collect. Each entity becomes one row in the dataset.
 2. Pick a clear primary key — the column whose values uniquely identify each row. This is usually a name, ID, or canonical URL. Exactly one column must have \`is_primary_key: true\`, and its \`name\` must equal \`primary_key\`. The primary key column must have \`nullable: false\` and \`is_enumerable: true\`.
-3. Choose useful columns. Each column captures one fact about the entity. Use snake_case names. Mark \`is_enumerable: true\` only on columns whose values can be used to list all rows (typically just the primary key, and occasionally one or two others when a source page lists them alongside the primary key).
-4. Set \`retrieval_strategy\`:
-   - \`search_fetch\` — the data lives on a static page or sitemap that can be fetched as HTML.
-   - \`browser\` — the source is a JavaScript-heavy SPA, requires scroll/click to reveal items, or paginates client-side.
-   - \`hybrid\` — unclear; the pipeline will try search_fetch first and fall back to browser.
-5. Set \`source_hint\` to a specific URL whenever possible (e.g. \`https://www.ycombinator.com/companies?industry=Fintech\`). Avoid vague descriptions.
-6. Write a \`retrieval_hint\` for each column describing where/how the value can be found later. Downstream agents will use this to fill the column for each row.
+3. Infer columns from the user prompt — include the facts they asked for as columns. Use snake_case names. Mark \`is_enumerable: true\` only on columns whose values can be used to list all rows (typically just the primary key, and occasionally one or two others when a source page lists them alongside the primary key).
+4. Write a short \`description\` for each column explaining what the column represents (not where to find the value on the web).
+5. ${searchQueryRule}
+
+Do not set retrieval strategy or source URLs — search and fetch decisions happen later after results are available.
 
 Rules:
 
 - \`dataset_name\` must be snake_case.
 - All column \`name\` values must be snake_case and unique.
 - Prefer concrete column choices over speculative ones — better to omit a column than guess wildly.`;
-
-function getModel() {
-  const apiKey = process.env.OPENROUTER_API_KEY;
-  if (!apiKey) {
-    throw new Error("Missing required environment variable: OPENROUTER_API_KEY");
-  }
-  const openrouter = createOpenRouter({ apiKey });
-  return openrouter("anthropic/claude-sonnet-4-6");
 }
 
-export async function inferSchema(prompt: string): Promise<DatasetSchema> {
-  const model = getModel();
+function outputSchemaForOptions(options?: InferSchemaOptions) {
+  const expectedCount = options?.searchQueryCount;
+  if (expectedCount === undefined) {
+    return datasetSchemaSchema;
+  }
+
+  return datasetSchemaSchema.superRefine((data, ctx) => {
+    if (data.search_queries.length !== expectedCount) {
+      ctx.addIssue({
+        code: "custom",
+        message: `search_queries must contain exactly ${expectedCount} items`,
+        path: ["search_queries"],
+      });
+    }
+  });
+}
+
+export async function inferSchema(
+  prompt: string,
+  options?: InferSchemaOptions
+): Promise<DatasetSchema> {
+  const model = createOpenRouter({ apiKey: requiredOpenRouterApiKey() })(
+    SCHEMA_INFERENCE_OPENROUTER_MODEL_ID
+  );
   try {
-    return await callOnce(model, prompt);
+    return await callOnce(model, prompt, options);
   } catch (error) {
     if (NoObjectGeneratedError.isInstance(error)) {
       const detail = error.cause ? String(error.cause) : error.text;
       const retry = `${prompt}\n\nYour previous output failed validation:\n${detail}\n\nReturn a corrected DatasetSchema.`;
-      return await callOnce(model, retry);
+      return await callOnce(model, retry, options);
     }
     throw error;
   }
@@ -49,14 +117,20 @@ export async function inferSchema(prompt: string): Promise<DatasetSchema> {
 async function callOnce(
   model: Parameters<typeof generateText>[0]["model"],
   prompt: string,
+  options?: InferSchemaOptions
 ): Promise<DatasetSchema> {
-  const { output } = await generateText({
+  const schema = outputSchemaForOptions(options);
+  const result = await generateText({
     model,
-    output: Output.object({ schema: datasetSchemaSchema }),
-    system: SYSTEM_PROMPT,
+    output: Output.object({ schema }),
+    system: buildSystemPrompt(options?.searchQueryCount),
     maxOutputTokens: 4096,
     prompt,
   });
-  if (!output) throw new Error("Model did not generate a valid schema object");
+  recordLanguageModelUsage(result.usage);
+  const { output } = result;
+  if (!output) {
+    throw new Error("Model did not generate a valid schema object");
+  }
   return output;
 }

--- a/backend/src/pipeline/types.ts
+++ b/backend/src/pipeline/types.ts
@@ -10,13 +10,6 @@ export const columnTypeSchema = z.enum([
 ]);
 export type ColumnType = z.infer<typeof columnTypeSchema>;
 
-export const retrievalStrategySchema = z.enum([
-  "search_fetch",
-  "browser",
-  "hybrid",
-]);
-export type RetrievalStrategy = z.infer<typeof retrievalStrategySchema>;
-
 const snakeCase = /^[a-z][a-z0-9_]*$/;
 
 export const columnDefinitionSchema = z.object({
@@ -25,7 +18,7 @@ export const columnDefinitionSchema = z.object({
   type: columnTypeSchema,
   is_primary_key: z.boolean(),
   is_enumerable: z.boolean(),
-  retrieval_hint: z.string(),
+  description: z.string().min(1),
   nullable: z.boolean(),
 });
 export type ColumnDefinition = z.infer<typeof columnDefinitionSchema>;
@@ -36,8 +29,7 @@ export const datasetSchemaSchema = z
     description: z.string().min(1),
     columns: z.array(columnDefinitionSchema).min(1),
     primary_key: z.string(),
-    retrieval_strategy: retrievalStrategySchema,
-    source_hint: z.string().min(1),
+    search_queries: z.array(z.string().min(1)).min(1),
   })
   .superRefine((data, ctx) => {
     const names = data.columns.map((c) => c.name);
@@ -114,3 +106,124 @@ export const runManifestSchema = z.object({
   endpoints_called: z.array(endpointCallSchema),
 });
 export type RunManifest = z.infer<typeof runManifestSchema>;
+
+/** Per-URL score returned by the search acquisition agent. */
+export const searchAcquisitionScoredUrlSchema = z.object({
+  url: z.string().min(1),
+  expectation_score: z.number().int().min(1).max(5),
+});
+export type AgentSearchScore = z.infer<typeof searchAcquisitionScoredUrlSchema>;
+
+/** Structured completion from the search acquisition agent. */
+export const searchAcquisitionCompletionSchema = z.object({
+  scored_urls: z.array(searchAcquisitionScoredUrlSchema),
+  validation_issues: z.array(z.string()).default([]),
+});
+export type SearchAcquisitionCompletion = z.infer<
+  typeof searchAcquisitionCompletionSchema
+>;
+
+/** Scored URL after acquisition + prioritization (includes search_query). */
+export const acquisitionScoredUrlSchema = z.object({
+  url: z.string(),
+  expectation_score: z.number().int().min(1).max(5),
+  search_query: z.string(),
+});
+export type AcquisitionScoredUrl = z.infer<typeof acquisitionScoredUrlSchema>;
+
+export const populateAcquisitionResultSchema = z.object({
+  prioritizedUrls: z.array(z.string()),
+  scoredUrls: z.array(acquisitionScoredUrlSchema),
+  initialQueries: z.array(z.string()),
+  validationIssues: z.array(z.string()),
+});
+export type PopulateAcquisitionResult = z.infer<
+  typeof populateAcquisitionResultSchema
+>;
+
+export const structuredPopulateEvidenceSchema = z.object({
+  columnName: z.string().optional(),
+  sourceUrl: z.string().optional(),
+  quote: z.string(),
+});
+
+export const structuredPopulateOutputSchema = z.object({
+  rows: z
+    .array(
+      z.object({
+        cells: z.record(z.string(), z.any()),
+        sourceUrls: z.array(z.string()).optional(),
+        evidence: z.array(structuredPopulateEvidenceSchema).optional(),
+        needsReview: z.boolean().optional(),
+      })
+    )
+    .default([]),
+  validationIssues: z.array(z.string()).default([]),
+});
+export type StructuredPopulateOutput = z.infer<
+  typeof structuredPopulateOutputSchema
+>;
+
+export const populateSourceStatusSchema = z.enum([
+  "extract_now",
+  "requires_navigation",
+  "requires_form_submission",
+  "requires_detail_page_followup",
+  "irrelevant",
+  "duplicate",
+  "blocked",
+  "low_value",
+]);
+export type PopulateSourceStatus = z.infer<typeof populateSourceStatusSchema>;
+
+export const populateExpectedYieldSchema = z.enum([
+  "complete",
+  "partial",
+  "none",
+]);
+export type PopulateExpectedYield = z.infer<typeof populateExpectedYieldSchema>;
+
+export const populateSourceTriageResultSchema = z.object({
+  url: z.string(),
+  final_url: z.string(),
+  title: z.string(),
+  status: populateSourceStatusSchema,
+  confidence: z.number().min(0).max(1),
+  source_data_confidence: z.number().min(0).max(1),
+  expected_yield: populateExpectedYieldSchema,
+  reasoning: z.string(),
+  suggested_action: z.string().optional(),
+});
+export type PopulateSourceTriageResult = z.infer<
+  typeof populateSourceTriageResultSchema
+>;
+
+const populateLlmEvidenceSchema = z.object({
+  field: z.string(),
+  quote: z.string(),
+  url: z.string().optional(),
+});
+
+export function buildPopulateLlmExtractionSchema(columnNames: string[]) {
+  const rowShape: Record<string, z.ZodTypeAny> = {};
+  for (const name of columnNames) {
+    rowShape[name] = z.union([z.string(), z.number(), z.boolean(), z.null()]);
+  }
+  return z.object({
+    records: z.array(
+      z.object({
+        row: z.object(rowShape),
+        evidence: z.array(populateLlmEvidenceSchema).default([]),
+        extraction_confidence: z.number().min(0).max(1).optional(),
+      })
+    ),
+    notes: z.string().optional(),
+  });
+}
+
+export function buildPopulateTriageExtractSchema(columnNames: string[]) {
+  return z.object({
+    triage_results: populateSourceTriageResultSchema,
+    extraction_results: buildPopulateLlmExtractionSchema(columnNames),
+  });
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,186 @@
+import Fastify, {
+  type FastifyInstance,
+  type FastifyPluginAsync,
+  type FastifyReply,
+  type FastifyRequest,
+} from "fastify";
+import fastifyCors from "@fastify/cors";
+
+import { inferSchema } from "./pipeline/schema-inference.js";
+import { datasetContextSchema } from "./pipeline/populate.js";
+import { populateRuntimePrerequisiteError } from "./pipeline/populate-runtime-prerequisites.js";
+import {
+  runSelfHealingPopulate,
+  type PopulateDatasetRowWriter,
+} from "./pipeline/populate-self-healing-runner.js";
+import {
+  createPopulateRecipeRuntime,
+  type CreatePopulateRecipeRuntimeInput,
+} from "./pipeline/populate-runtime-selection.js";
+
+export interface BigSetServerEnv {
+  CLIENT_ORIGIN: string;
+  CONVEX_URL: string;
+  CONVEX_ADMIN_KEY?: string;
+  OPENROUTER_API_KEY?: string;
+  TINYFISH_API_KEY?: string;
+  POPULATE_RECIPE_STORE_DIR: string;
+}
+
+export interface BigSetPopulateDataset {
+  ownerId: string;
+}
+
+export interface CreateBigSetServerInput {
+  env: BigSetServerEnv;
+  authPlugin?: FastifyPluginAsync;
+  authPreHandler: (
+    request: FastifyRequest,
+    reply: FastifyReply
+  ) => Promise<void> | void;
+  getDatasetById: (datasetId: string) => Promise<BigSetPopulateDataset | null>;
+  populateRowWriter: PopulateDatasetRowWriter;
+  runtimeEnv?: NodeJS.ProcessEnv;
+  inferSchemaFn?: typeof inferSchema;
+  runSelfHealing?: typeof runSelfHealingPopulate;
+  createRuntime?: (
+    input: CreatePopulateRecipeRuntimeInput
+  ) => Promise<CreatePopulateRecipeRuntimeResult>;
+}
+
+type CreatePopulateRecipeRuntimeResult = Awaited<
+  ReturnType<typeof createPopulateRecipeRuntime>
+>;
+
+export async function createBigSetServer(
+  input: CreateBigSetServerInput
+): Promise<FastifyInstance> {
+  const fastify = Fastify({ logger: true });
+  const inferSchemaForRequest = input.inferSchemaFn ?? inferSchema;
+  const runSelfHealing = input.runSelfHealing ?? runSelfHealingPopulate;
+  const createRuntime = input.createRuntime ?? createPopulateRecipeRuntime;
+
+  await fastify.register(fastifyCors, {
+    origin: input.env.CLIENT_ORIGIN,
+    methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allowedHeaders: ["Content-Type", "Authorization", "Cookie"],
+    credentials: true,
+    maxAge: 86400,
+  });
+
+  if (input.authPlugin) {
+    await fastify.register(input.authPlugin);
+  }
+
+  fastify.get("/health", async () => ({ status: "ok" }));
+
+  await fastify.register(async (instance) => {
+    instance.addHook("preHandler", input.authPreHandler);
+
+    instance.post("/infer-schema", async (req, reply) => {
+      const body = req.body as { prompt?: string };
+      if (!body?.prompt || typeof body.prompt !== "string" || !body.prompt.trim()) {
+        return reply.code(400).send({ error: "prompt is required" });
+      }
+
+      try {
+        const schema = await inferSchemaForRequest(body.prompt.trim());
+        return schema;
+      } catch (err) {
+        req.log.error(err, "Schema inference failed");
+        return reply.code(502).send({ error: "Schema inference failed. Please try again." });
+      }
+    });
+
+    instance.post("/populate", async (req, reply) => {
+      const parsed = datasetContextSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return reply.code(400).send({
+          error: "Invalid request",
+          details: parsed.error.flatten().fieldErrors,
+        });
+      }
+
+      try {
+        const dataset = await input.getDatasetById(parsed.data.datasetId);
+        if (!dataset) {
+          return reply.code(404).send({ error: "Dataset not found" });
+        }
+        const authenticatedUserId = req.auth?.userId;
+        if (!authenticatedUserId) {
+          return reply.code(401).send({ error: "Unauthenticated" });
+        }
+        if (dataset.ownerId !== authenticatedUserId) {
+          return reply.code(403).send({ error: "Not authorized to populate this dataset" });
+        }
+        const prerequisiteError = populateRuntimePrerequisiteError({
+          convexUrl: input.env.CONVEX_URL,
+          convexAdminKey: input.env.CONVEX_ADMIN_KEY,
+          openRouterApiKey: input.env.OPENROUTER_API_KEY,
+          tinyFishApiKey: input.env.TINYFISH_API_KEY,
+        });
+        if (prerequisiteError) {
+          return reply.code(500).send({
+            error: prerequisiteError,
+          });
+        }
+
+        const runtime = await createRuntime({
+          env: input.runtimeEnv ?? process.env,
+        });
+        const result = await runSelfHealing({
+          context: parsed.data,
+          recipeStoreDirectory: input.env.POPULATE_RECIPE_STORE_DIR,
+          rowWriter: input.populateRowWriter,
+          shouldCommitRows: true,
+          runtime,
+        });
+
+        req.log.info({
+          action: result.action,
+          datasetId: result.datasetId,
+          committedRows: result.committedRows?.insertedRowCount ?? 0,
+          validationIssues: result.validationIssues.slice(0, 5),
+        }, "Self-healing populate completed");
+
+        if (!result.success) {
+          return reply.code(422).send({
+            error: "Self-healing populate failed validation.",
+            result: responseSafePopulateResult(result),
+          });
+        }
+
+        return {
+          success: true,
+          result: responseSafePopulateResult(result),
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("validator") || msg.includes("Invalid")) {
+          return reply.code(400).send({ error: "Invalid datasetId" });
+        }
+        req.log.error(err, "Populate failed");
+        return reply.code(502).send({ error: "Failed to populate dataset. Please try again." });
+      }
+    });
+  });
+
+  return fastify;
+}
+
+function responseSafePopulateResult(
+  result: Awaited<ReturnType<typeof runSelfHealingPopulate>>
+) {
+  const diagnosticRun = result.selectedRun ?? result.diagnosticRun;
+  return {
+    action: result.action,
+    datasetId: result.datasetId,
+    success: result.success,
+    committedRows: result.committedRows,
+    rejectionReasons: result.rejectionReasons,
+    validationIssues: result.validationIssues,
+    productionValidation: diagnosticRun?.productionValidation,
+    metrics: diagnosticRun?.metrics,
+    rowCount: diagnosticRun?.rows.length ?? 0,
+  };
+}

--- a/backend/test/collection-agent-runner.test.ts
+++ b/backend/test/collection-agent-runner.test.ts
@@ -14,7 +14,7 @@ test("collection agent runner maps vendored pipeline output into populate runtim
   delete process.env.COLLECTION_AGENT_ENABLE_AGENT;
   delete process.env.COLLECTION_AGENT_POLL_TIMEOUT_MS;
   process.env.COLLECTION_AGENT_PIPELINE_MODULE = fakeCollectionPipelineModuleUrl({
-    expectedAgentEnabled: false,
+    expectedCalls: [{ agentEnabled: false }],
   });
   try {
     const result = await runCollectionPopulatePipeline(collectionPipelineInput());
@@ -41,7 +41,7 @@ test("collection agent runner maps vendored pipeline output into populate runtim
   }
 });
 
-test("collection agent runner requires explicit Agent opt-in and caps poll timeout", async () => {
+test("collection agent runner requires explicit Agent opt-in and caps poll timeout per warm process call", async () => {
   const previousEnv = snapshotEnv([
     "AGENT_POLL_TIMEOUT_MS",
     "COLLECTION_AGENT_ENABLE_AGENT",
@@ -49,16 +49,35 @@ test("collection agent runner requires explicit Agent opt-in and caps poll timeo
     "COLLECTION_AGENT_POLL_TIMEOUT_MS",
   ]);
   delete process.env.AGENT_POLL_TIMEOUT_MS;
-  process.env.COLLECTION_AGENT_ENABLE_AGENT = "true";
-  process.env.COLLECTION_AGENT_POLL_TIMEOUT_MS = "12345";
+  delete process.env.COLLECTION_AGENT_ENABLE_AGENT;
+  delete process.env.COLLECTION_AGENT_POLL_TIMEOUT_MS;
   process.env.COLLECTION_AGENT_PIPELINE_MODULE = fakeCollectionPipelineModuleUrl({
-    expectedAgentEnabled: true,
-    expectedPollTimeoutMs: "12345",
+    expectedModuleLoadPollTimeoutMs: null,
+    expectedCalls: [
+      { agentEnabled: false },
+      { agentEnabled: true, pollTimeoutMs: 12345 },
+      { agentEnabled: true, pollTimeoutMs: 23456 },
+    ],
   });
 
   try {
-    const result = await runCollectionPopulatePipeline(collectionPipelineInput());
-    assert.equal(result.rows.length, 1);
+    assert.equal(
+      (await runCollectionPopulatePipeline(collectionPipelineInput())).rows.length,
+      1
+    );
+
+    process.env.COLLECTION_AGENT_ENABLE_AGENT = "true";
+    process.env.COLLECTION_AGENT_POLL_TIMEOUT_MS = "12345";
+    assert.equal(
+      (await runCollectionPopulatePipeline(collectionPipelineInput())).rows.length,
+      1
+    );
+
+    process.env.COLLECTION_AGENT_POLL_TIMEOUT_MS = "23456";
+    assert.equal(
+      (await runCollectionPopulatePipeline(collectionPipelineInput())).rows.length,
+      1
+    );
   } finally {
     restoreEnv(previousEnv);
   }
@@ -92,15 +111,30 @@ function collectionPipelineInput() {
 }
 
 function fakeCollectionPipelineModuleUrl(input: {
-  expectedAgentEnabled: boolean;
-  expectedPollTimeoutMs?: string;
+  expectedModuleLoadPollTimeoutMs?: string | null;
+  expectedCalls: Array<{
+    agentEnabled: boolean;
+    pollTimeoutMs?: number;
+  }>;
 }): string {
   const source = `
+    const moduleLoadPollTimeoutMs = process.env.AGENT_POLL_TIMEOUT_MS ?? null;
+    const expectedModuleLoadPollTimeoutMs = ${JSON.stringify(input.expectedModuleLoadPollTimeoutMs ?? null)};
+    const expectedCalls = ${JSON.stringify(input.expectedCalls)};
+    let callIndex = 0;
+
     export async function runPipeline(options) {
-      if (options.enableTinyfishAgent !== ${JSON.stringify(input.expectedAgentEnabled)}) {
+      if (moduleLoadPollTimeoutMs !== expectedModuleLoadPollTimeoutMs) {
+        throw new Error("unexpected module-load poll timeout");
+      }
+      const expected = expectedCalls[callIndex++];
+      if (!expected) {
+        throw new Error("unexpected extra pipeline call");
+      }
+      if (options.enableTinyfishAgent !== expected.agentEnabled) {
         throw new Error("unexpected TinyFish Agent setting");
       }
-      if (${JSON.stringify(input.expectedPollTimeoutMs ?? null)} !== null && process.env.AGENT_POLL_TIMEOUT_MS !== ${JSON.stringify(input.expectedPollTimeoutMs ?? null)}) {
+      if ((options.agentPollTimeoutMs ?? null) !== (expected.pollTimeoutMs ?? null)) {
         throw new Error("bounded agent poll timeout missing");
       }
       if (!options.prompt.includes("Durable recipe instructions")) {

--- a/backend/test/collection-agent-runner.test.ts
+++ b/backend/test/collection-agent-runner.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { runCollectionPopulatePipeline } from "../src/pipeline/collection-agent-runner.js";
+
+test("collection agent runner maps vendored pipeline output into populate runtime result", async () => {
+  const previousModule = process.env.COLLECTION_AGENT_PIPELINE_MODULE;
+  process.env.COLLECTION_AGENT_PIPELINE_MODULE = fakeCollectionPipelineModuleUrl();
+  try {
+    const result = await runCollectionPopulatePipeline({
+      datasetId: "dataset-ai-posts",
+      datasetName: "AI posts",
+      description: "Find latest AI blog posts.",
+      columns: [
+        { name: "entity_name", type: "text" },
+        { name: "source_url", type: "url" },
+        { name: "evidence_quote", type: "text" },
+      ],
+      requiredColumns: ["entity_name", "source_url", "evidence_quote"],
+      prompt: [
+        "Dataset: AI posts",
+        "Task: Find latest AI blog posts.",
+        "",
+        "Durable recipe instructions:",
+        "Prefer official source pages.",
+      ].join("\n"),
+      recipeInstructions: "Prefer official source pages.",
+      targetRows: 3,
+      promptId: "latest-ai-blog-posts",
+      promptQuality: "easy",
+      persona: "technical operator",
+      expectedStress: "Latest dated source pages.",
+    });
+
+    assert.equal(result.rows.length, 1);
+    assert.equal(result.rows[0]?.cells.entity_name, "OpenAI");
+    assert.equal(result.rows[0]?.cells.evidence_quote, "technical operator");
+    assert.deepEqual(result.rows[0]?.sourceUrls, ["https://openai.com/news"]);
+    assert.equal(result.rows[0]?.evidence[0]?.columnName, "entity_name");
+    assert.equal(result.rows[0]?.needsReview, true);
+    assert.deepEqual(result.validationIssues, []);
+    assert.deepEqual(result.usage, {
+      promptTokens: 11,
+      completionTokens: 7,
+      totalTokens: 18,
+    });
+    assert.equal(result.metrics.searchCalls, 2);
+    assert.equal(result.metrics.fetchCalls, 3);
+    assert.equal(result.metrics.browserCalls, 1);
+  } finally {
+    if (previousModule === undefined) {
+      delete process.env.COLLECTION_AGENT_PIPELINE_MODULE;
+    } else {
+      process.env.COLLECTION_AGENT_PIPELINE_MODULE = previousModule;
+    }
+  }
+});
+
+function fakeCollectionPipelineModuleUrl(): string {
+  const source = `
+    export async function runPipeline(options) {
+      if (!options.prompt.includes("Durable recipe instructions")) {
+        throw new Error("recipe instructions missing from prompt");
+      }
+      if (!options.memoryDir || !options.memoryDir.includes("memory")) {
+        throw new Error("isolated memory dir missing");
+      }
+      if (options.benchmark?.promptId !== "latest-ai-blog-posts") {
+        throw new Error("prompt id missing from benchmark context");
+      }
+      if (options.benchmark?.persona !== "technical operator") {
+        throw new Error("persona missing from benchmark context");
+      }
+      if (options.benchmark?.requiredColumns?.join(",") !== "entity_name,source_url,evidence_quote") {
+        throw new Error("required columns missing from benchmark context");
+      }
+      return {
+        report: {
+          errors: [],
+          dataset_spec: {
+            columns: [{ name: "entity_name" }],
+            dedupe_keys: ["entity_name"],
+          },
+          stats: {
+            search_queries_executed: 2,
+            pages_fetched: 3,
+            triage: {
+              agent_dispatched: 1,
+              agent_succeeded: 1,
+              agent_failed: 0,
+            },
+          },
+          initial: {
+            triage: {
+              agent_dispatched: 1,
+              agent_succeeded: 1,
+              agent_failed: 0,
+            },
+          },
+          repair: {
+            stats: {
+              triage: {
+                agent_dispatched: 0,
+                agent_succeeded: 0,
+                agent_failed: 0,
+              },
+            },
+          },
+          quality: {
+            records: [{ record_id: "pk:openai", needs_review: true }],
+          },
+          llm_usage: {
+            prompt_tokens: 1,
+            completion_tokens: 1,
+            total_tokens: 2,
+          },
+        },
+        records: [{
+          row: {
+            entity_name: "OpenAI",
+            source_url: "https://openai.com/news",
+            evidence_quote: options.benchmark.persona,
+          },
+          source_urls: ["https://openai.com/news"],
+          evidence: [{
+            field: "entity_name",
+            url: "https://openai.com/news",
+            quote: options.benchmark.expectedStress,
+          }],
+        }],
+        llmUsage: {
+          promptTokens: 11,
+          completionTokens: 7,
+          totalTokens: 18,
+        },
+      };
+    }
+  `;
+  return `data:text/javascript,${encodeURIComponent(source)}`;
+}

--- a/backend/test/collection-agent-runner.test.ts
+++ b/backend/test/collection-agent-runner.test.ts
@@ -83,6 +83,54 @@ test("collection agent runner requires explicit Agent opt-in and caps poll timeo
   }
 });
 
+test("collection agent runner surfaces Agent-required capability diagnostics from source outcomes", async () => {
+  const previousEnv = snapshotEnv([
+    "AGENT_POLL_TIMEOUT_MS",
+    "COLLECTION_AGENT_ENABLE_AGENT",
+    "COLLECTION_AGENT_PIPELINE_MODULE",
+    "COLLECTION_AGENT_POLL_TIMEOUT_MS",
+  ]);
+  delete process.env.AGENT_POLL_TIMEOUT_MS;
+  delete process.env.COLLECTION_AGENT_ENABLE_AGENT;
+  delete process.env.COLLECTION_AGENT_POLL_TIMEOUT_MS;
+  process.env.COLLECTION_AGENT_PIPELINE_MODULE = fakeCollectionPipelineModuleUrl({
+    expectedCalls: [{ agentEnabled: false }],
+    sources: {
+      outcomes: [
+        {
+          outcome: "agent_deferred",
+          triage_status: "requires_navigation",
+        },
+        {
+          outcome: "no_records",
+          triage_status: "requires_form_submission",
+        },
+        {
+          outcome: "success",
+          triage_status: "requires_detail_page_followup",
+        },
+      ],
+    },
+  });
+
+  try {
+    const result = await runCollectionPopulatePipeline(collectionPipelineInput());
+    const diagnostic = result.validationIssues.join("\n");
+
+    assert.equal(result.rows.length, 1);
+    assert.match(diagnostic, /Capability diagnostic: TinyFish Agent disabled/);
+    assert.match(diagnostic, /2 page\(s\)/);
+    assert.match(diagnostic, /requires_navigation=1/);
+    assert.match(diagnostic, /requires_form_submission=1/);
+    assert.doesNotMatch(
+      diagnostic,
+      /failed|missing|no rows|not found|invented|invalid/i
+    );
+  } finally {
+    restoreEnv(previousEnv);
+  }
+});
+
 function collectionPipelineInput() {
   return {
     datasetId: "dataset-ai-posts",
@@ -116,6 +164,7 @@ function fakeCollectionPipelineModuleUrl(input: {
     agentEnabled: boolean;
     pollTimeoutMs?: number;
   }>;
+  sources?: unknown;
 }): string {
   const source = `
     const moduleLoadPollTimeoutMs = process.env.AGENT_POLL_TIMEOUT_MS ?? null;
@@ -187,6 +236,7 @@ function fakeCollectionPipelineModuleUrl(input: {
           quality: {
             records: [{ record_id: "pk:openai", needs_review: true }],
           },
+          sources: ${JSON.stringify(input.sources ?? { outcomes: [] })},
           llm_usage: {
             prompt_tokens: 1,
             completion_tokens: 1,

--- a/backend/test/collection-agent-runner.test.ts
+++ b/backend/test/collection-agent-runner.test.ts
@@ -4,33 +4,20 @@ import { test } from "node:test";
 import { runCollectionPopulatePipeline } from "../src/pipeline/collection-agent-runner.js";
 
 test("collection agent runner maps vendored pipeline output into populate runtime result", async () => {
-  const previousModule = process.env.COLLECTION_AGENT_PIPELINE_MODULE;
-  process.env.COLLECTION_AGENT_PIPELINE_MODULE = fakeCollectionPipelineModuleUrl();
+  const previousEnv = snapshotEnv([
+    "AGENT_POLL_TIMEOUT_MS",
+    "COLLECTION_AGENT_ENABLE_AGENT",
+    "COLLECTION_AGENT_PIPELINE_MODULE",
+    "COLLECTION_AGENT_POLL_TIMEOUT_MS",
+  ]);
+  delete process.env.AGENT_POLL_TIMEOUT_MS;
+  delete process.env.COLLECTION_AGENT_ENABLE_AGENT;
+  delete process.env.COLLECTION_AGENT_POLL_TIMEOUT_MS;
+  process.env.COLLECTION_AGENT_PIPELINE_MODULE = fakeCollectionPipelineModuleUrl({
+    expectedAgentEnabled: false,
+  });
   try {
-    const result = await runCollectionPopulatePipeline({
-      datasetId: "dataset-ai-posts",
-      datasetName: "AI posts",
-      description: "Find latest AI blog posts.",
-      columns: [
-        { name: "entity_name", type: "text" },
-        { name: "source_url", type: "url" },
-        { name: "evidence_quote", type: "text" },
-      ],
-      requiredColumns: ["entity_name", "source_url", "evidence_quote"],
-      prompt: [
-        "Dataset: AI posts",
-        "Task: Find latest AI blog posts.",
-        "",
-        "Durable recipe instructions:",
-        "Prefer official source pages.",
-      ].join("\n"),
-      recipeInstructions: "Prefer official source pages.",
-      targetRows: 3,
-      promptId: "latest-ai-blog-posts",
-      promptQuality: "easy",
-      persona: "technical operator",
-      expectedStress: "Latest dated source pages.",
-    });
+    const result = await runCollectionPopulatePipeline(collectionPipelineInput());
 
     assert.equal(result.rows.length, 1);
     assert.equal(result.rows[0]?.cells.entity_name, "OpenAI");
@@ -50,17 +37,72 @@ test("collection agent runner maps vendored pipeline output into populate runtim
     assert.equal(result.metrics.agentRuns, 3);
     assert.equal(result.metrics.agentSteps, 3);
   } finally {
-    if (previousModule === undefined) {
-      delete process.env.COLLECTION_AGENT_PIPELINE_MODULE;
-    } else {
-      process.env.COLLECTION_AGENT_PIPELINE_MODULE = previousModule;
-    }
+    restoreEnv(previousEnv);
   }
 });
 
-function fakeCollectionPipelineModuleUrl(): string {
+test("collection agent runner requires explicit Agent opt-in and caps poll timeout", async () => {
+  const previousEnv = snapshotEnv([
+    "AGENT_POLL_TIMEOUT_MS",
+    "COLLECTION_AGENT_ENABLE_AGENT",
+    "COLLECTION_AGENT_PIPELINE_MODULE",
+    "COLLECTION_AGENT_POLL_TIMEOUT_MS",
+  ]);
+  delete process.env.AGENT_POLL_TIMEOUT_MS;
+  process.env.COLLECTION_AGENT_ENABLE_AGENT = "true";
+  process.env.COLLECTION_AGENT_POLL_TIMEOUT_MS = "12345";
+  process.env.COLLECTION_AGENT_PIPELINE_MODULE = fakeCollectionPipelineModuleUrl({
+    expectedAgentEnabled: true,
+    expectedPollTimeoutMs: "12345",
+  });
+
+  try {
+    const result = await runCollectionPopulatePipeline(collectionPipelineInput());
+    assert.equal(result.rows.length, 1);
+  } finally {
+    restoreEnv(previousEnv);
+  }
+});
+
+function collectionPipelineInput() {
+  return {
+    datasetId: "dataset-ai-posts",
+    datasetName: "AI posts",
+    description: "Find latest AI blog posts.",
+    columns: [
+      { name: "entity_name", type: "text" as const },
+      { name: "source_url", type: "url" as const },
+      { name: "evidence_quote", type: "text" as const },
+    ],
+    requiredColumns: ["entity_name", "source_url", "evidence_quote"],
+    prompt: [
+      "Dataset: AI posts",
+      "Task: Find latest AI blog posts.",
+      "",
+      "Durable recipe instructions:",
+      "Prefer official source pages.",
+    ].join("\n"),
+    recipeInstructions: "Prefer official source pages.",
+    targetRows: 3,
+    promptId: "latest-ai-blog-posts",
+    promptQuality: "easy",
+    persona: "technical operator",
+    expectedStress: "Latest dated source pages.",
+  };
+}
+
+function fakeCollectionPipelineModuleUrl(input: {
+  expectedAgentEnabled: boolean;
+  expectedPollTimeoutMs?: string;
+}): string {
   const source = `
     export async function runPipeline(options) {
+      if (options.enableTinyfishAgent !== ${JSON.stringify(input.expectedAgentEnabled)}) {
+        throw new Error("unexpected TinyFish Agent setting");
+      }
+      if (${JSON.stringify(input.expectedPollTimeoutMs ?? null)} !== null && process.env.AGENT_POLL_TIMEOUT_MS !== ${JSON.stringify(input.expectedPollTimeoutMs ?? null)}) {
+        throw new Error("bounded agent poll timeout missing");
+      }
       if (!options.prompt.includes("Durable recipe instructions")) {
         throw new Error("recipe instructions missing from prompt");
       }
@@ -139,4 +181,18 @@ function fakeCollectionPipelineModuleUrl(): string {
     }
   `;
   return `data:text/javascript,${encodeURIComponent(source)}`;
+}
+
+function snapshotEnv(names: string[]): Map<string, string | undefined> {
+  return new Map(names.map((name) => [name, process.env[name]]));
+}
+
+function restoreEnv(snapshot: Map<string, string | undefined>): void {
+  for (const [name, value] of snapshot) {
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  }
 }

--- a/backend/test/collection-agent-runner.test.ts
+++ b/backend/test/collection-agent-runner.test.ts
@@ -46,7 +46,9 @@ test("collection agent runner maps vendored pipeline output into populate runtim
     });
     assert.equal(result.metrics.searchCalls, 2);
     assert.equal(result.metrics.fetchCalls, 3);
-    assert.equal(result.metrics.browserCalls, 1);
+    assert.equal(result.metrics.browserCalls, 3);
+    assert.equal(result.metrics.agentRuns, 3);
+    assert.equal(result.metrics.agentSteps, 3);
   } finally {
     if (previousModule === undefined) {
       delete process.env.COLLECTION_AGENT_PIPELINE_MODULE;
@@ -100,9 +102,9 @@ function fakeCollectionPipelineModuleUrl(): string {
           repair: {
             stats: {
               triage: {
-                agent_dispatched: 0,
-                agent_succeeded: 0,
-                agent_failed: 0,
+                agent_dispatched: 2,
+                agent_succeeded: 1,
+                agent_failed: 1,
               },
             },
           },

--- a/backend/test/collection-extract-finalize.test.ts
+++ b/backend/test/collection-extract-finalize.test.ts
@@ -59,3 +59,72 @@ test("collection extraction adds URL cell evidence when model omits evidence", (
     "https://developers.cloudflare.com/agents/guides/remote-mcp-server/",
   ]);
 });
+
+test("collection extraction treats official website cells as source URLs", () => {
+  const spec: DatasetSpec = {
+    intent_summary: "Official company websites.",
+    target_row_count: 1,
+    row_grain: "one row per company",
+    columns: [
+      {
+        name: "entity_name",
+        type: "string",
+        description: "Company name.",
+        required: true,
+      },
+      {
+        name: "official_website",
+        type: "string",
+        description: "Official website URL.",
+        required: true,
+      },
+      {
+        name: "description",
+        type: "string",
+        description: "Company description.",
+        required: true,
+      },
+      {
+        name: "source_url",
+        type: "string",
+        description: "Where the row facts were found.",
+        required: true,
+      },
+    ],
+    dedupe_keys: ["entity_name"],
+    search_queries: ["Vietnam fintech official websites"],
+    extraction_hints: "Prefer official company websites.",
+  };
+
+  const record = finalizeExtractedRecord(
+    {
+      row: {
+        entity_name: "MoMo",
+        official_website: "https://momo.vn",
+        description: "Vietnamese fintech wallet.",
+        source_url: "https://www.startupblink.com/top-startups/vietnam",
+      },
+      evidence: [
+        {
+          field: "description",
+          quote: "MoMo is a FinTech startup.",
+        },
+      ],
+      extraction_confidence: 0.8,
+    },
+    "https://www.startupblink.com/top-startups/vietnam",
+    spec,
+  );
+
+  assert.deepEqual(record.source_urls, [
+    "https://www.startupblink.com/top-startups/vietnam",
+    "https://momo.vn",
+  ]);
+  assert.ok(
+    record.evidence.some((item) =>
+      item.field === "official_website" &&
+      item.url === "https://momo.vn" &&
+      item.quote === "https://momo.vn"
+    ),
+  );
+});

--- a/backend/test/collection-extract-finalize.test.ts
+++ b/backend/test/collection-extract-finalize.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { finalizeExtractedRecord } from "../BigSet_Data_Collection_Agent/src/agents/extract.js";
+import type { DatasetSpec } from "../BigSet_Data_Collection_Agent/src/models/schemas.js";
+
+const docsSpec: DatasetSpec = {
+  intent_summary: "Official docs pages.",
+  target_row_count: 1,
+  row_grain: "one row per docs page",
+  columns: [
+    {
+      name: "entity_name",
+      type: "string",
+      description: "Vendor name.",
+      required: true,
+    },
+    {
+      name: "docs_url",
+      type: "string",
+      description: "Official docs URL.",
+      required: true,
+    },
+    {
+      name: "summary",
+      type: "string",
+      description: "What the page covers.",
+      required: true,
+    },
+  ],
+  dedupe_keys: ["entity_name"],
+  search_queries: ["Cloudflare MCP docs"],
+  extraction_hints: "Prefer official docs pages.",
+};
+
+test("collection extraction adds URL cell evidence when model omits evidence", () => {
+  const record = finalizeExtractedRecord(
+    {
+      row: {
+        entity_name: "Cloudflare",
+        docs_url: "https://developers.cloudflare.com/agents/guides/remote-mcp-server/",
+        summary: "Remote MCP server docs.",
+      },
+      evidence: [],
+      extraction_confidence: 0.8,
+    },
+    "https://developers.cloudflare.com/agents/guides/remote-mcp-server/",
+    docsSpec,
+  );
+
+  assert.deepEqual(record.evidence, [
+    {
+      field: "docs_url",
+      url: "https://developers.cloudflare.com/agents/guides/remote-mcp-server/",
+      quote: "https://developers.cloudflare.com/agents/guides/remote-mcp-server/",
+    },
+  ]);
+  assert.deepEqual(record.source_urls, [
+    "https://developers.cloudflare.com/agents/guides/remote-mcp-server/",
+  ]);
+});

--- a/backend/test/collection-memory.test.ts
+++ b/backend/test/collection-memory.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import {
+  createEmptyCollectionMemory,
+  latestTinyfishEmittedProcess,
+  loadCollectionMemory,
+  recordAgentVisitedUrl,
+  saveCollectionMemory,
+} from "../src/pipeline/collection-memory/index.js";
+import { extractEmittedProcessFromAgentResult } from "../src/pipeline/populate-browser-agent.js";
+
+test("collection memory persists agent visits with emitted process", async () => {
+  const memoryDir = await mkdtemp(join(tmpdir(), "bigset-memory-"));
+  try {
+    let memory = createEmptyCollectionMemory({
+      datasetId: "dataset-test",
+      userPrompt: "Top AI companies",
+    });
+
+    memory = recordAgentVisitedUrl(memory, {
+      url: "https://openai.com/about",
+      provider: "tinyfish",
+      goal: "Extract company fields",
+      run: {
+        run_id: "run_123",
+        status: "COMPLETED",
+        result: {
+          emitted_process: {
+            steps: [{ action: "click", selector: "#about" }],
+          },
+          summary: "done",
+        },
+        error: null,
+      },
+    });
+
+    await saveCollectionMemory(memoryDir, memory);
+    const loaded = await loadCollectionMemory(memoryDir, "dataset-test");
+    assert.ok(loaded);
+    assert.equal(loaded.agent_visited_urls.length, 1);
+    assert.equal(loaded.agent_visited_urls[0]?.provider, "tinyfish");
+    assert.deepEqual(loaded.agent_visited_urls[0]?.emitted_process, {
+      steps: [{ action: "click", selector: "#about" }],
+    });
+
+    const process = latestTinyfishEmittedProcess(loaded, "https://openai.com/about");
+    assert.ok(process);
+    assert.ok(Array.isArray((process as { steps: unknown[] }).steps));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("extractEmittedProcessFromAgentResult falls back to full result", () => {
+  const extracted = extractEmittedProcessFromAgentResult({
+    answer: "42",
+    nested: { ok: true },
+  });
+  assert.deepEqual(extracted, { answer: "42", nested: { ok: true } });
+});
+
+test("collection memory file is written per dataset id", async () => {
+  const memoryDir = await mkdtemp(join(tmpdir(), "bigset-memory-"));
+  try {
+    const memory = createEmptyCollectionMemory({
+      datasetId: "dataset-abc",
+      userPrompt: "prompt",
+    });
+    await saveCollectionMemory(memoryDir, memory);
+    const raw = await readFile(join(memoryDir, "dataset-abc.json"), "utf8");
+    const parsed = JSON.parse(raw) as { dataset_id: string; repair_loop: { status: string } };
+    assert.equal(parsed.dataset_id, "dataset-abc");
+    assert.equal(parsed.repair_loop.status, "idle");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/backend/test/collection-record-merge.test.ts
+++ b/backend/test/collection-record-merge.test.ts
@@ -1,0 +1,476 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  mergePair,
+  mergeRecords,
+} from "../BigSet_Data_Collection_Agent/src/merge/records.js";
+import type {
+  DatasetSpec,
+  ExtractedRecord,
+} from "../BigSet_Data_Collection_Agent/src/models/schemas.js";
+
+const docsSpec: DatasetSpec = {
+  intent_summary: "Official MCP docs pages.",
+  target_row_count: 3,
+  row_grain: "one row per vendor",
+  columns: [
+    {
+      name: "entity_name",
+      type: "string",
+      description: "Vendor name.",
+      required: true,
+    },
+    {
+      name: "docs_title",
+      type: "string",
+      description: "Docs page title.",
+      required: true,
+    },
+    {
+      name: "docs_url",
+      type: "string",
+      description: "Official docs page URL.",
+      required: true,
+    },
+    {
+      name: "summary",
+      type: "string",
+      description: "What the page covers.",
+      required: true,
+    },
+  ],
+  dedupe_keys: ["entity_name"],
+  search_queries: ["MCP docs"],
+  extraction_hints: "Prefer official docs pages.",
+};
+
+test("collection record merge does not attach evidence from conflicting duplicate rows", () => {
+  const officialRecord = record({
+    row: {
+      entity_name: "Cloudflare",
+      docs_title: "Connect to an MCP server",
+      docs_url: "https://developers.cloudflare.com/agents/guides/connect-mcp-client/",
+      summary: "Official docs for connecting an MCP client.",
+    },
+    evidence: [
+      evidence(
+        "summary",
+        "https://developers.cloudflare.com/agents/guides/connect-mcp-client/",
+        "Connect to an MCP server."
+      ),
+    ],
+    sourceUrls: [
+      "https://developers.cloudflare.com/agents/guides/connect-mcp-client/",
+    ],
+  });
+  const blogRecord = record({
+    row: {
+      entity_name: "Cloudflare",
+      docs_title: "Code Mode: the better way to use MCP",
+      docs_url: "https://blog.cloudflare.com/code-mode/",
+      summary: "Blog post about code mode.",
+    },
+    evidence: [
+      evidence(
+        "docs_title",
+        "https://blog.cloudflare.com/code-mode/",
+        "Code Mode: the better way to use MCP"
+      ),
+      evidence(
+        "docs_url",
+        "https://blog.cloudflare.com/code-mode/",
+        "https://blog.cloudflare.com/code-mode/"
+      ),
+    ],
+    sourceUrls: ["https://blog.cloudflare.com/code-mode/"],
+  });
+
+  const merged = mergePair(officialRecord, blogRecord, docsSpec);
+
+  assert.equal(
+    merged.row.docs_url,
+    "https://developers.cloudflare.com/agents/guides/connect-mcp-client/"
+  );
+  assert.deepEqual(
+    merged.evidence.map((item) => item.url),
+    ["https://developers.cloudflare.com/agents/guides/connect-mcp-client/"]
+  );
+  assert.deepEqual(merged.source_urls, [
+    "https://developers.cloudflare.com/agents/guides/connect-mcp-client/",
+  ]);
+});
+
+test("collection record merge keeps incoming evidence when it fills a missing field", () => {
+  const partialRecord = record({
+    row: {
+      entity_name: "OpenAI",
+      docs_title: "MCP and Connectors",
+      docs_url: null,
+      summary: "OpenAI MCP docs.",
+    },
+    evidence: [
+      evidence(
+        "summary",
+        "https://developers.openai.com/api/docs/guides/tools-connectors-mcp",
+        "remote MCP servers and connectors"
+      ),
+    ],
+    sourceUrls: [
+      "https://developers.openai.com/api/docs/guides/tools-connectors-mcp",
+    ],
+  });
+  const urlRecord = record({
+    row: {
+      entity_name: "OpenAI",
+      docs_title: "MCP and Connectors",
+      docs_url: "https://developers.openai.com/api/docs/guides/tools-connectors-mcp",
+      summary: null,
+    },
+    evidence: [
+      evidence(
+        "docs_url",
+        "https://developers.openai.com/api/docs/guides/tools-connectors-mcp",
+        "https://developers.openai.com/api/docs/guides/tools-connectors-mcp"
+      ),
+    ],
+    sourceUrls: [
+      "https://developers.openai.com/api/docs/guides/tools-connectors-mcp",
+    ],
+  });
+
+  const merged = mergePair(partialRecord, urlRecord, docsSpec);
+
+  assert.equal(
+    merged.row.docs_url,
+    "https://developers.openai.com/api/docs/guides/tools-connectors-mcp"
+  );
+  assert.deepEqual(
+    merged.evidence.map((item) => item.field),
+    ["summary", "docs_url"]
+  );
+  assert.deepEqual(merged.source_urls, [
+    "https://developers.openai.com/api/docs/guides/tools-connectors-mcp",
+  ]);
+});
+
+test("collection record merge keeps same-value supplemental evidence", () => {
+  const merged = mergeRecords(docsSpec, [
+    record({
+      row: {
+        entity_name: "Anthropic",
+        docs_title: "Model Context Protocol connector",
+        docs_url: "https://docs.anthropic.com/en/docs/agents-and-tools/mcp-connector",
+        summary: "Connector docs.",
+      },
+      evidence: [
+        evidence(
+          "summary",
+          "https://docs.anthropic.com/en/docs/agents-and-tools/mcp-connector",
+          "MCP connector"
+        ),
+      ],
+      sourceUrls: [
+        "https://docs.anthropic.com/en/docs/agents-and-tools/mcp-connector",
+      ],
+    }),
+    record({
+      row: {
+        entity_name: "Anthropic",
+        docs_title: "Model Context Protocol connector",
+        docs_url: "https://docs.anthropic.com/en/docs/agents-and-tools/mcp-connector",
+        summary: "Connector docs.",
+      },
+      evidence: [
+        evidence(
+          "docs_title",
+          "https://docs.anthropic.com/en/docs/agents-and-tools/mcp-connector",
+          "Model Context Protocol connector"
+        ),
+      ],
+      sourceUrls: [
+        "https://docs.anthropic.com/en/docs/agents-and-tools/mcp-connector",
+      ],
+    }),
+  ]).records;
+
+  assert.equal(merged.length, 1);
+  assert.deepEqual(
+    merged[0]?.evidence.map((item) => item.field),
+    ["summary", "docs_title"]
+  );
+});
+
+test("collection record merge replaces weak docs URLs with stronger docs surfaces", () => {
+  const merged = mergePair(
+    record({
+      row: {
+        entity_name: "Cloudflare",
+        docs_title: "Code Mode: the better way to use MCP",
+        docs_url: "https://blog.cloudflare.com/code-mode/",
+        summary: "Blog post about MCP code mode.",
+      },
+      evidence: [
+        evidence(
+          "docs_url",
+          "https://blog.cloudflare.com/code-mode/",
+          "https://blog.cloudflare.com/code-mode/"
+        ),
+      ],
+      sourceUrls: ["https://blog.cloudflare.com/code-mode/"],
+    }),
+    record({
+      row: {
+        entity_name: "Cloudflare",
+        docs_title: "Model Context Protocol",
+        docs_url: "https://developers.cloudflare.com/agents/model-context-protocol/",
+        summary: "Official docs for Cloudflare MCP servers.",
+      },
+      evidence: [
+        evidence(
+          "docs_title",
+          "https://developers.cloudflare.com/agents/model-context-protocol/",
+          "Model Context Protocol"
+        ),
+        evidence(
+          "docs_url",
+          "https://developers.cloudflare.com/agents/model-context-protocol/",
+          "https://developers.cloudflare.com/agents/model-context-protocol/"
+        ),
+        evidence(
+          "summary",
+          "https://developers.cloudflare.com/agents/model-context-protocol/",
+          "MCP servers"
+        ),
+      ],
+      sourceUrls: [
+        "https://developers.cloudflare.com/agents/model-context-protocol/",
+      ],
+    }),
+    docsSpec,
+  );
+
+  assert.equal(
+    merged.row.docs_url,
+    "https://developers.cloudflare.com/agents/model-context-protocol/"
+  );
+  assert.equal(merged.row.docs_title, "Model Context Protocol");
+  assert.equal(merged.row.summary, "Official docs for Cloudflare MCP servers.");
+  assert.deepEqual(
+    merged.evidence.map((item) => item.field),
+    ["docs_title", "docs_url", "summary"]
+  );
+  assert.deepEqual(
+    merged.evidence.map((item) => item.url),
+    [
+      "https://developers.cloudflare.com/agents/model-context-protocol/",
+      "https://developers.cloudflare.com/agents/model-context-protocol/",
+      "https://developers.cloudflare.com/agents/model-context-protocol/",
+    ]
+  );
+  assert.deepEqual(merged.source_urls, [
+    "https://developers.cloudflare.com/agents/model-context-protocol/",
+  ]);
+});
+
+test("collection record merge drops docs URL evidence from unrelated source pages", () => {
+  const merged = mergePair(
+    record({
+      row: {
+        entity_name: "Cloudflare",
+        docs_title: "Docs for agents",
+        docs_url: null,
+        summary: null,
+      },
+      evidence: [],
+      sourceUrls: [],
+    }),
+    record({
+      row: {
+        entity_name: "Cloudflare",
+        docs_title: "Model Context Protocol",
+        docs_url: "https://developers.cloudflare.com/agents/model-context-protocol/",
+        summary: "Official docs for Cloudflare MCP servers.",
+      },
+      evidence: [
+        evidence(
+          "docs_url",
+          "https://developers.openai.com/api/docs",
+          "https://developers.cloudflare.com/agents/model-context-protocol/"
+        ),
+        evidence(
+          "summary",
+          "https://developers.cloudflare.com/agents/model-context-protocol/",
+          "MCP servers"
+        ),
+      ],
+      sourceUrls: [
+        "https://developers.openai.com/api/docs",
+        "https://developers.cloudflare.com/agents/model-context-protocol/",
+      ],
+    }),
+    docsSpec,
+  );
+
+  assert.equal(
+    merged.row.docs_url,
+    "https://developers.cloudflare.com/agents/model-context-protocol/"
+  );
+  assert.deepEqual(
+    merged.evidence.map((item) => item.field),
+    ["summary"]
+  );
+  assert.deepEqual(merged.source_urls, [
+    "https://developers.cloudflare.com/agents/model-context-protocol/",
+  ]);
+});
+
+test("collection record merge fixture reaches benchmark-equivalent domain coverage", () => {
+  const merged = mergeRecords(docsSpec, [
+    record({
+      row: {
+        entity_name: "OpenAI",
+        docs_title: "MCP and Connectors",
+        docs_url: "https://developers.openai.com/api/docs/guides/tools-connectors-mcp",
+        summary: "OpenAI MCP docs.",
+      },
+      evidence: [
+        evidence(
+          "summary",
+          "https://developers.openai.com/api/docs/guides/tools-connectors-mcp",
+          "remote MCP servers and connectors"
+        ),
+      ],
+      sourceUrls: [
+        "https://developers.openai.com/api/docs/guides/tools-connectors-mcp",
+      ],
+    }),
+    record({
+      row: {
+        entity_name: "Anthropic",
+        docs_title: "Introduction to Model Context Protocol",
+        docs_url: "https://anthropic.skilljar.com/introduction-to-model-context-protocol",
+        summary: "Anthropic MCP course.",
+      },
+      evidence: [
+        evidence(
+          "summary",
+          "https://anthropic.skilljar.com/introduction-to-model-context-protocol",
+          "course provides comprehensive coverage"
+        ),
+      ],
+      sourceUrls: [
+        "https://anthropic.skilljar.com/introduction-to-model-context-protocol",
+      ],
+    }),
+    record({
+      row: {
+        entity_name: "Anthropic",
+        docs_title: "MCP connector",
+        docs_url: "https://docs.anthropic.com/en/docs/agents-and-tools/mcp-connector",
+        summary: "Anthropic MCP connector docs.",
+      },
+      evidence: [
+        evidence(
+          "docs_url",
+          "https://docs.anthropic.com/en/docs/agents-and-tools/mcp-connector",
+          "https://docs.anthropic.com/en/docs/agents-and-tools/mcp-connector"
+        ),
+      ],
+      sourceUrls: [
+        "https://docs.anthropic.com/en/docs/agents-and-tools/mcp-connector",
+      ],
+    }),
+    record({
+      row: {
+        entity_name: "Cloudflare",
+        docs_title: "Code Mode",
+        docs_url: "https://blog.cloudflare.com/code-mode/",
+        summary: "Cloudflare MCP blog post.",
+      },
+      evidence: [
+        evidence(
+          "summary",
+          "https://blog.cloudflare.com/code-mode/",
+          "Cloudflare Agents SDK"
+        ),
+      ],
+      sourceUrls: ["https://blog.cloudflare.com/code-mode/"],
+    }),
+    record({
+      row: {
+        entity_name: "Cloudflare",
+        docs_title: "Model Context Protocol",
+        docs_url: "https://developers.cloudflare.com/agents/model-context-protocol/",
+        summary: "Cloudflare MCP docs.",
+      },
+      evidence: [
+        evidence(
+          "docs_url",
+          "https://developers.cloudflare.com/agents/model-context-protocol/",
+          "https://developers.cloudflare.com/agents/model-context-protocol/"
+        ),
+      ],
+      sourceUrls: [
+        "https://developers.cloudflare.com/agents/model-context-protocol/",
+      ],
+    }),
+  ]).records;
+
+  assert.equal(merged.length, 3);
+  assert.equal(
+    merged.find((item) => item.row.entity_name === "Anthropic")?.row.docs_url,
+    "https://docs.anthropic.com/en/docs/agents-and-tools/mcp-connector"
+  );
+  assert.equal(
+    merged.find((item) => item.row.entity_name === "Cloudflare")?.row.docs_url,
+    "https://developers.cloudflare.com/agents/model-context-protocol/"
+  );
+  assert.equal(
+    domainCoverage(merged, {
+      OpenAI: ["developers.openai.com", "platform.openai.com", "openai.com"],
+      Anthropic: ["docs.anthropic.com"],
+      Cloudflare: ["developers.cloudflare.com"],
+    }),
+    1,
+  );
+});
+
+function evidence(field: string, url: string, quote: string) {
+  return { field, url, quote };
+}
+
+function record(input: {
+  row: ExtractedRecord["row"];
+  evidence: ExtractedRecord["evidence"];
+  sourceUrls: string[];
+}): ExtractedRecord {
+  return {
+    row: input.row,
+    evidence: input.evidence,
+    source_urls: input.sourceUrls,
+    extraction_confidence: 0.9,
+  };
+}
+
+function domainCoverage(
+  records: ExtractedRecord[],
+  allowedDomainsByEntity: Record<string, string[]>,
+): number {
+  const matched = records.filter((record) => {
+    const entity = String(record.row.entity_name ?? "");
+    const allowedDomains = allowedDomainsByEntity[entity] ?? [];
+    return record.source_urls.some((url) =>
+      allowedDomains.some((domain) => hostname(url).endsWith(domain)),
+    );
+  });
+  return matched.length / records.length;
+}
+
+function hostname(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return "";
+  }
+}

--- a/backend/test/collection-record-merge.test.ts
+++ b/backend/test/collection-record-merge.test.ts
@@ -45,6 +45,41 @@ const docsSpec: DatasetSpec = {
   extraction_hints: "Prefer official docs pages.",
 };
 
+const earningsSpec: DatasetSpec = {
+  intent_summary: "Latest earnings releases.",
+  target_row_count: 3,
+  row_grain: "one row per company",
+  columns: [
+    {
+      name: "entity_name",
+      type: "string",
+      description: "Company name.",
+      required: true,
+    },
+    {
+      name: "release_date",
+      type: "date",
+      description: "Release date.",
+      required: true,
+    },
+    {
+      name: "fiscal_quarter",
+      type: "string",
+      description: "Fiscal quarter.",
+      required: true,
+    },
+    {
+      name: "source_url",
+      type: "string",
+      description: "Official earnings release source URL.",
+      required: true,
+    },
+  ],
+  dedupe_keys: ["entity_name"],
+  search_queries: ["latest earnings releases"],
+  extraction_hints: "Prefer official dated earnings release pages.",
+};
+
 test("collection record merge does not attach evidence from conflicting duplicate rows", () => {
   const officialRecord = record({
     row: {
@@ -322,6 +357,78 @@ test("collection record merge drops docs URL evidence from unrelated source page
   );
   assert.deepEqual(merged.source_urls, [
     "https://developers.cloudflare.com/agents/model-context-protocol/",
+  ]);
+});
+
+test("collection record merge folds corporate suffix variants and prefers stronger source pages", () => {
+  const merged = mergeRecords(earningsSpec, [
+    record({
+      row: {
+        entity_name: "Nvidia",
+        release_date: "2026-02-25",
+        fiscal_quarter: "Q4 Fiscal 2026",
+        source_url: "https://nvidianews.nvidia.com/news/nvidia-announces-financial-results-for-fourth-quarter-and-fiscal-2026",
+      },
+      evidence: [
+        evidence(
+          "release_date",
+          "https://nvidianews.nvidia.com/news/nvidia-announces-financial-results-for-fourth-quarter-and-fiscal-2026",
+          "February 25, 2026",
+        ),
+        evidence(
+          "fiscal_quarter",
+          "https://nvidianews.nvidia.com/news/nvidia-announces-financial-results-for-fourth-quarter-and-fiscal-2026",
+          "fourth quarter fiscal 2026",
+        ),
+        evidence(
+          "source_url",
+          "https://nvidianews.nvidia.com/news/nvidia-announces-financial-results-for-fourth-quarter-and-fiscal-2026",
+          "https://nvidianews.nvidia.com/news/nvidia-announces-financial-results-for-fourth-quarter-and-fiscal-2026",
+        ),
+      ],
+      sourceUrls: [
+        "https://nvidianews.nvidia.com/news/nvidia-announces-financial-results-for-fourth-quarter-and-fiscal-2026",
+      ],
+    }),
+    record({
+      row: {
+        entity_name: "NVIDIA Corporation",
+        release_date: "2026-05-20",
+        fiscal_quarter: "FY27 Q1",
+        source_url: "https://nvidianews.nvidia.com/news/nvidia-announces-financial-results-for-first-quarter-fiscal-2027",
+      },
+      evidence: [
+        evidence(
+          "release_date",
+          "https://nvidianews.nvidia.com/news/nvidia-announces-financial-results-for-first-quarter-fiscal-2027",
+          "May 20, 2026",
+        ),
+        evidence(
+          "fiscal_quarter",
+          "https://nvidianews.nvidia.com/news/nvidia-announces-financial-results-for-first-quarter-fiscal-2027",
+          "first quarter fiscal 2027",
+        ),
+        evidence(
+          "source_url",
+          "https://nvidianews.nvidia.com/news/nvidia-announces-financial-results-for-first-quarter-fiscal-2027",
+          "https://nvidianews.nvidia.com/news/nvidia-announces-financial-results-for-first-quarter-fiscal-2027",
+        ),
+      ],
+      sourceUrls: [
+        "https://nvidianews.nvidia.com/news/nvidia-announces-financial-results-for-first-quarter-fiscal-2027",
+      ],
+    }),
+  ]).records;
+
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0]?.row.entity_name, "Nvidia");
+  assert.equal(merged[0]?.row.fiscal_quarter, "FY27 Q1");
+  assert.equal(
+    merged[0]?.row.source_url,
+    "https://nvidianews.nvidia.com/news/nvidia-announces-financial-results-for-first-quarter-fiscal-2027",
+  );
+  assert.deepEqual(merged[0]?.source_urls, [
+    "https://nvidianews.nvidia.com/news/nvidia-announces-financial-results-for-first-quarter-fiscal-2027",
   ]);
 });
 

--- a/backend/test/collection-source-policy.test.ts
+++ b/backend/test/collection-source-policy.test.ts
@@ -6,11 +6,13 @@ import {
   applyPromptSourcePolicyToTriageResult,
   derivePromptSourcePolicy,
   promptSourceSearchQueries,
+  recordMatchesPromptSourcePolicy,
   sourceCandidatePolicyBoost,
   urlMatchesPromptSourcePolicy,
 } from "../BigSet_Data_Collection_Agent/src/agents/source-policy.js";
 import type {
   DatasetSpec,
+  ExtractedRecord,
   SourceCandidate,
   SourceTriageResult,
 } from "../BigSet_Data_Collection_Agent/src/models/schemas.js";
@@ -157,10 +159,10 @@ test("prompt source policy boosts official candidates", () => {
     ["Anthropic", "OpenAI", "Cloudflare"],
   );
   assert.deepEqual(promptSourceSearchQueries(policy).slice(0, 4), [
+    "Anthropic MCP connector docs site:platform.claude.com",
+    "OpenAI MCP connector docs site:developers.openai.com",
+    "Cloudflare MCP connector docs site:developers.cloudflare.com",
     "Anthropic MCP connector docs",
-    "Anthropic model context protocol docs",
-    "OpenAI MCP connector docs",
-    "OpenAI model context protocol docs",
   ]);
   const official: SourceCandidate = {
     url: "https://developers.cloudflare.com/agents/model-context-protocol/",
@@ -180,3 +182,131 @@ test("prompt source policy boosts official candidates", () => {
       sourceCandidatePolicyBoost(thirdParty, policy),
   );
 });
+
+test("prompt source policy prefers docs surfaces over blogs, courses, and directories", () => {
+  const policy = derivePromptSourcePolicy(
+    "I need official docs pages for setting up MCP servers from Anthropic, OpenAI, and Cloudflare.",
+  );
+  const docs: SourceCandidate = {
+    url: "https://platform.claude.com/docs/en/agents-and-tools/mcp-connector",
+    title: "Model Context Protocol connector",
+    snippet: "Official Anthropic documentation for MCP connector setup.",
+    query: "Anthropic MCP connector docs",
+  };
+  const course: SourceCandidate = {
+    url: "https://anthropic.skilljar.com/introduction-to-model-context-protocol",
+    title: "Introduction to Model Context Protocol",
+    snippet: "Anthropic course for learning MCP.",
+    query: "Anthropic MCP connector docs",
+  };
+  const blog: SourceCandidate = {
+    url: "https://blog.cloudflare.com/code-mode/",
+    title: "Code Mode: the better way to use MCP",
+    snippet: "Cloudflare blog post about MCP.",
+    query: "Cloudflare MCP connector docs",
+  };
+  const cloudflareDocs: SourceCandidate = {
+    url: "https://developers.cloudflare.com/agents/model-context-protocol/",
+    title: "Model Context Protocol",
+    snippet: "Official Cloudflare docs for MCP servers.",
+    query: "Cloudflare MCP connector docs",
+  };
+
+  assert.ok(
+    sourceCandidatePolicyBoost(docs, policy) >
+      sourceCandidatePolicyBoost(course, policy),
+  );
+  assert.equal(
+    urlMatchesPromptSourcePolicy(
+      "https://platform.claude.com/docs/en/agents-and-tools/mcp-connector",
+      policy,
+    ),
+    true,
+  );
+  assert.ok(
+    sourceCandidatePolicyBoost(cloudflareDocs, policy) >
+      sourceCandidatePolicyBoost(blog, policy),
+  );
+});
+
+test("prompt source policy rejects records sourced from another entity's docs", () => {
+  const policy = derivePromptSourcePolicy(
+    "I need official docs pages for setting up MCP servers from Anthropic, OpenAI, and Cloudflare.",
+  );
+  const spec: DatasetSpec = {
+    intent_summary: "Official MCP docs pages.",
+    target_row_count: 3,
+    row_grain: "one row per vendor",
+    columns: [
+      {
+        name: "entity_name",
+        type: "string",
+        description: "Vendor name.",
+        required: true,
+      },
+      {
+        name: "docs_url",
+        type: "string",
+        description: "Official docs page URL.",
+        required: true,
+      },
+    ],
+    dedupe_keys: ["entity_name"],
+    search_queries: [],
+    extraction_hints: "",
+  };
+
+  assert.equal(
+    recordMatchesPromptSourcePolicy(
+      record("Anthropic", "https://modelcontextprotocol.io/docs/develop/build-server"),
+      spec,
+      policy,
+    ),
+    false,
+  );
+  assert.equal(
+    recordMatchesPromptSourcePolicy(
+      record(
+        "Anthropic",
+        "https://platform.claude.com/docs/en/agents-and-tools/remote-mcp-servers",
+      ),
+      spec,
+      policy,
+    ),
+    true,
+  );
+  assert.equal(
+    recordMatchesPromptSourcePolicy(
+      record("OpenAI", "https://developers.openai.com/blog"),
+      spec,
+      policy,
+    ),
+    false,
+  );
+  assert.equal(
+    recordMatchesPromptSourcePolicy(
+      record("OpenAI", "https://developers.openai.com/api/docs/guides/tools-connectors-mcp"),
+      spec,
+      policy,
+    ),
+    true,
+  );
+});
+
+function record(entityName: string, docsUrl: string): ExtractedRecord {
+  return {
+    row: {
+      entity_name: entityName,
+      docs_url: docsUrl,
+    },
+    evidence: [
+      {
+        field: "docs_url",
+        url: docsUrl,
+        quote: docsUrl,
+      },
+    ],
+    source_urls: [docsUrl],
+    extraction_confidence: 0.8,
+  };
+}

--- a/backend/test/collection-source-policy.test.ts
+++ b/backend/test/collection-source-policy.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  applyPromptSourcePolicyToSpec,
+  applyPromptSourcePolicyToTriageResult,
+  derivePromptSourcePolicy,
+  promptSourceSearchQueries,
+  sourceCandidatePolicyBoost,
+  urlMatchesPromptSourcePolicy,
+} from "../BigSet_Data_Collection_Agent/src/agents/source-policy.js";
+import type {
+  DatasetSpec,
+  SourceCandidate,
+  SourceTriageResult,
+} from "../BigSet_Data_Collection_Agent/src/models/schemas.js";
+
+test("prompt source policy derives official queries from the user's prompt", () => {
+  const policy = derivePromptSourcePolicy(
+    "For Stripe, Paddle, and Chargebee, collect the official pricing page URL and the plan names or starting prices shown on the page.",
+  );
+
+  assert.equal(policy.requiresOfficialSource, true);
+  assert.deepEqual(
+    policy.entities.map((entity) => entity.name),
+    ["Stripe", "Paddle", "Chargebee"],
+  );
+  assert.deepEqual(promptSourceSearchQueries(policy).slice(0, 3), [
+    "Stripe official pricing page",
+    "Stripe billing pricing",
+    "Paddle official pricing page",
+  ]);
+});
+
+test("prompt source policy ignores generic durable recipe source wording", () => {
+  const policy = derivePromptSourcePolicy(
+    [
+      "Dataset: benchmark_latest-ai-blog-posts",
+      "Task: Can you make me a table of the latest blog posts from OpenAI, Anthropic, and Google DeepMind? I need title, publish date, and URL.",
+      "",
+      "Durable recipe instructions:",
+      "Prefer official docs, pricing, blog, product, or company pages over third-party summaries.",
+    ].join("\n"),
+  );
+
+  const queries = promptSourceSearchQueries(policy);
+
+  assert.deepEqual(queries, [
+    "OpenAI official blog latest post",
+    "Anthropic official blog latest post",
+    "Google DeepMind official blog latest post",
+  ]);
+});
+
+test("prompt source policy adds official-source guidance without benchmark answer keys", () => {
+  const spec: DatasetSpec = {
+    intent_summary: "Collect pricing pages.",
+    target_row_count: 3,
+    row_grain: "one row per company",
+    columns: [
+      {
+        name: "entity_name",
+        type: "string",
+        description: "Company.",
+        required: true,
+      },
+      {
+        name: "pricing_page_url",
+        type: "string",
+        description: "Official pricing URL.",
+        required: true,
+      },
+    ],
+    dedupe_keys: ["entity_name"],
+    search_queries: ["SaaS pricing pages"],
+    extraction_hints: "Extract plan names.",
+  };
+
+  const updated = applyPromptSourcePolicyToSpec(
+    spec,
+    "For Stripe and Paddle, collect the official pricing page URL.",
+  );
+
+  assert.equal(updated.search_queries[0], "Stripe official pricing page");
+  assert.equal(updated.search_queries[1], "Stripe billing pricing");
+  assert.equal(updated.search_queries[2], "Paddle official pricing page");
+  assert.match(updated.extraction_hints, /Prompt source policy/);
+  assert.match(updated.extraction_hints, /Stripe, Paddle/);
+});
+
+test("prompt source policy prefers entity-owned domains over third-party proof", () => {
+  const policy = derivePromptSourcePolicy(
+    "Find the latest investor relations earnings release page for Apple, Microsoft, and Nvidia.",
+  );
+
+  assert.equal(
+    urlMatchesPromptSourcePolicy("https://investor.apple.com/newsroom/", policy),
+    true,
+  );
+  assert.equal(
+    urlMatchesPromptSourcePolicy("https://finance.yahoo.com/quote/AAPL", policy),
+    false,
+  );
+  assert.equal(
+    urlMatchesPromptSourcePolicy("https://cloud.google.com/blog/topics/threat-intelligence", {
+      ...derivePromptSourcePolicy(
+        "Can you make me a table of the latest blog posts from OpenAI, Anthropic, and Google DeepMind?",
+      ),
+    }),
+    false,
+  );
+  assert.equal(
+    urlMatchesPromptSourcePolicy(
+      "https://openai.github.io/openai-agents-python/mcp/",
+      derivePromptSourcePolicy(
+        "I need official docs pages for setting up MCP servers from Anthropic, OpenAI, and Cloudflare.",
+      ),
+    ),
+    false,
+  );
+});
+
+test("prompt source policy downgrades third-party extraction triage", () => {
+  const policy = derivePromptSourcePolicy(
+    "For Stripe, Paddle, and Chargebee, collect the official pricing page URL and plan names.",
+  );
+  const triage: SourceTriageResult = {
+    url: "https://www.trustradius.com/products/paddle/pricing",
+    final_url: "https://www.trustradius.com/products/paddle/pricing",
+    title: "Paddle Pricing",
+    status: "extract_now",
+    confidence: 0.9,
+    source_data_confidence: 0.8,
+    expected_yield: "complete",
+    reasoning: "Page lists pricing information.",
+  };
+
+  const updated = applyPromptSourcePolicyToTriageResult(triage, policy);
+
+  assert.equal(updated.status, "low_value");
+  assert.equal(updated.expected_yield, "none");
+  assert.match(updated.reasoning, /official\/canonical sources/);
+});
+
+test("prompt source policy boosts official candidates", () => {
+  const policy = derivePromptSourcePolicy(
+    [
+      "Dataset: benchmark_mcp-docs-pages",
+      "Task: I need official docs pages for setting up MCP servers from Anthropic, OpenAI, and Cloudflare. Give me title, URL, and what each page covers.",
+      "",
+      "Durable recipe instructions:",
+      "Prefer official docs, pricing, blog, product, or company pages over third-party summaries.",
+    ].join("\n"),
+  );
+  assert.deepEqual(
+    policy.entities.map((entity) => entity.name),
+    ["Anthropic", "OpenAI", "Cloudflare"],
+  );
+  assert.deepEqual(promptSourceSearchQueries(policy).slice(0, 4), [
+    "Anthropic MCP connector docs",
+    "Anthropic model context protocol docs",
+    "OpenAI MCP connector docs",
+    "OpenAI model context protocol docs",
+  ]);
+  const official: SourceCandidate = {
+    url: "https://developers.cloudflare.com/agents/model-context-protocol/",
+    title: "MCP servers",
+    snippet: "Official Cloudflare docs for MCP server setup.",
+    query: "Cloudflare official docs MCP server setup",
+  };
+  const thirdParty: SourceCandidate = {
+    url: "https://example.com/cloudflare-mcp-guide",
+    title: "Cloudflare MCP guide",
+    snippet: "A blog guide to Cloudflare MCP.",
+    query: "Cloudflare official docs MCP server setup",
+  };
+
+  assert.ok(
+    sourceCandidatePolicyBoost(official, policy) >
+      sourceCandidatePolicyBoost(thirdParty, policy),
+  );
+});

--- a/backend/test/llm-usage.test.ts
+++ b/backend/test/llm-usage.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  emptyLlmUsage,
+  getCurrentLlmUsage,
+  recordLanguageModelUsage,
+  runWithLlmUsageScope,
+  toPopulateRuntimeUsage,
+} from "../src/pipeline/llm-usage.js";
+
+test("runWithLlmUsageScope accumulates token usage across calls", async () => {
+  const { usage } = await runWithLlmUsageScope(async () => {
+    recordLanguageModelUsage({
+      inputTokens: 100,
+      outputTokens: 40,
+      totalTokens: 140,
+    });
+    recordLanguageModelUsage({
+      inputTokens: 50,
+      outputTokens: 10,
+      totalTokens: 60,
+    });
+    return getCurrentLlmUsage();
+  });
+
+  assert.equal(usage.promptTokens, 150);
+  assert.equal(usage.completionTokens, 50);
+  assert.equal(usage.totalTokens, 200);
+  assert.equal(usage.callCount, 2);
+  assert.deepEqual(toPopulateRuntimeUsage(usage), {
+    promptTokens: 150,
+    completionTokens: 50,
+    totalTokens: 200,
+  });
+});
+
+test("recordLanguageModelUsage ignores calls outside an active scope", () => {
+  recordLanguageModelUsage({
+    inputTokens: 999,
+    outputTokens: 999,
+    totalTokens: 1998,
+  });
+  assert.deepEqual(getCurrentLlmUsage(), emptyLlmUsage());
+});

--- a/backend/test/populate-acquisition-prompt.test.ts
+++ b/backend/test/populate-acquisition-prompt.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  formatDataSpecBlock,
+  formatUserPromptBlock,
+  isLowTrustSourceUrl,
+} from "../src/pipeline/populate-acquisition-prompt.js";
+
+const context = {
+  datasetId: "dataset-1",
+  datasetName: "ny_ai_startup_careers",
+  description: "AI startups in New York with careers pages and hiring signals.",
+  columns: [
+    { name: "entity_name", type: "text" as const, description: "Company name." },
+    { name: "careers_page_url", type: "url" as const, description: "Careers page URL." },
+  ],
+};
+
+test("formatUserPromptBlock leads with user description", () => {
+  const block = formatUserPromptBlock(context);
+  assert.match(block, /User prompt \(primary/);
+  assert.match(block, /AI startups in New York/);
+});
+
+test("formatDataSpecBlock uses infer-schema column descriptions when provided", () => {
+  const block = formatDataSpecBlock(context, {
+    dataset_name: "ny_ai_startup_careers",
+    description: "Careers dataset for NYC AI startups.",
+    primary_key: "entity_name",
+    search_queries: [
+      "NYC AI startup careers site:greenhouse.io",
+      "New York AI company jobs hiring",
+    ],
+    columns: [
+      {
+        name: "entity_name",
+        display_name: "Company",
+        type: "string",
+        is_primary_key: true,
+        is_enumerable: true,
+        description: "Official company name.",
+        nullable: false,
+      },
+      {
+        name: "careers_page_url",
+        display_name: "Careers URL",
+        type: "url",
+        is_primary_key: false,
+        is_enumerable: false,
+        description: "URL of the official careers or jobs page.",
+        nullable: true,
+      },
+    ],
+  });
+
+  assert.match(block, /Initial search queries/);
+  assert.match(block, /NYC AI startup careers/);
+  assert.match(block, /Description: Official company name/);
+  assert.match(block, /Description: URL of the official careers/);
+  assert.match(block, /Primary key column: entity_name/);
+  assert.doesNotMatch(block, /Retrieval strategy/);
+  assert.doesNotMatch(block, /Source hint/);
+});
+
+test("isLowTrustSourceUrl flags major social hosts", () => {
+  assert.equal(isLowTrustSourceUrl("https://www.instagram.com/p/abc/"), true);
+  assert.equal(isLowTrustSourceUrl("https://x.com/user/status/1"), true);
+  assert.equal(isLowTrustSourceUrl("https://anthropic.com/careers"), false);
+});

--- a/backend/test/populate-acquisition.test.ts
+++ b/backend/test/populate-acquisition.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  captureScoredUrlsAsSources,
+  finalizeAcquisitionResult,
+  runSearchAcquisitionPhase,
+} from "../src/pipeline/populate-acquisition.js";
+import { normalizeSearchResultUrl } from "../src/pipeline/populate-search-prioritization.js";
+import type { DatasetSchema } from "../src/pipeline/types.js";
+
+function mockAcquisitionDataSpec(queryCount: number): DatasetSchema {
+  return {
+    dataset_name: "acquisition_test",
+    description: "Find one official page.",
+    primary_key: "source_url",
+    search_queries: Array.from(
+      { length: queryCount },
+      (_, index) => `seed query ${index + 1}`
+    ),
+    columns: [
+      {
+        name: "source_url",
+        display_name: "Source URL",
+        type: "url",
+        is_primary_key: true,
+        is_enumerable: true,
+        description: "Official page URL.",
+        nullable: false,
+      },
+    ],
+  };
+}
+
+test("finalize acquisition applies fetch limit to scored URLs", async () => {
+  const metrics = {
+    searchCalls: 0,
+    fetchCalls: 0,
+    browserCalls: 0,
+    agentRuns: 0,
+    agentSteps: 0,
+  };
+
+  const phase = await runSearchAcquisitionPhase({
+    context: {
+      datasetId: "acquisition-test",
+      datasetName: "acquisition_test",
+      description: "Find one official page.",
+      columns: [{ name: "source_url", type: "url" }],
+    },
+    maxSearchCalls: 10,
+    dataSpec: mockAcquisitionDataSpec(5),
+    webTools: {
+      search: async () => [
+        { title: "High", url: "https://example.com/high", snippet: "high" },
+        { title: "Low", url: "https://example.com/low", snippet: "low" },
+      ],
+      fetch: async () => ({}),
+    },
+    metrics,
+    validationIssues: [],
+    debugNotes: [],
+    searchAcquisitionRunner: async ({ tools }) => {
+      const searchWeb = tools.search_web as {
+        execute(input: { query: string }): Promise<unknown>;
+      };
+      await searchWeb.execute({ query: "test" });
+      return {
+        object: {
+          scored_urls: [
+            { url: "https://example.com/high", expectation_score: 5 },
+            { url: "https://example.com/low", expectation_score: 1 },
+          ],
+        },
+      };
+    },
+  });
+
+  const acquisition = finalizeAcquisitionResult(phase, 1);
+  const capturedSources = captureScoredUrlsAsSources(
+    acquisition.scoredUrls.filter((entry) =>
+      acquisition.prioritizedUrls.includes(normalizeSearchResultUrl(entry.url))
+    )
+  );
+
+  assert.equal(acquisition.prioritizedUrls.length, 1);
+  assert.equal(
+    normalizeSearchResultUrl(acquisition.prioritizedUrls[0] ?? ""),
+    "https://example.com/high"
+  );
+  assert.equal(capturedSources.length, 1);
+  assert.match(capturedSources[0]?.text ?? "", /search_query: test/);
+  assert.equal(acquisition.scoredUrls.length, 2);
+  assert.equal(acquisition.scoredUrls[0]?.url, "https://example.com/high");
+  assert.equal(acquisition.scoredUrls[0]?.search_query, "test");
+});

--- a/backend/test/populate-benchmark-debug.test.ts
+++ b/backend/test/populate-benchmark-debug.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import {
+  isPopulateBenchmarkDebugEnabled,
+  writePopulateBenchmarkDebugArtifacts,
+} from "../src/pipeline/populate-benchmark-debug.js";
+
+test("isPopulateBenchmarkDebugEnabled reads POPULATE_BENCHMARK_DEBUG", () => {
+  assert.equal(isPopulateBenchmarkDebugEnabled({}), false);
+  assert.equal(
+    isPopulateBenchmarkDebugEnabled({ POPULATE_BENCHMARK_DEBUG: "true" }),
+    true
+  );
+  assert.equal(
+    isPopulateBenchmarkDebugEnabled({ POPULATE_BENCHMARK_DEBUG: "0" }),
+    false
+  );
+});
+
+test("writePopulateBenchmarkDebugArtifacts writes debug json and csv files", async () => {
+  const artifactDirectory = await mkdtemp(join(tmpdir(), "populate-debug-"));
+  await writePopulateBenchmarkDebugArtifacts(artifactDirectory, {
+    runAt: "2026-05-23T00:00:00.000Z",
+    context: {
+      datasetId: "benchmark-test",
+      datasetName: "benchmark_test",
+      description: "Test dataset.",
+      columns: [{ name: "entity_name", type: "text" }],
+    },
+    limits: { maxRows: 10, maxSearchCalls: 5, maxFetchCalls: 20 },
+    searchPool: [
+      {
+        search_query: "yc companies",
+        title: "YC",
+        url: "https://example.com/yc",
+      },
+    ],
+    acquisition: {
+      initialQueries: ["yc companies"],
+      validationIssues: [],
+      scoredUrls: [
+        {
+          url: "https://example.com/yc",
+          expectation_score: 5,
+          search_query: "yc companies",
+        },
+      ],
+      prioritizedUrls: ["https://example.com/yc"],
+    },
+    populatePromptUrlCount: 1,
+    capturedSources: [{ url: "https://example.com/yc", text: "YC batch" }],
+    capturedRows: [],
+    validationIssues: [],
+    metrics: {
+      searchCalls: 1,
+      fetchCalls: 1,
+      browserCalls: 0,
+      agentRuns: 2,
+      agentSteps: 0,
+    },
+    notes: ["test note"],
+  });
+
+  const report = JSON.parse(
+    await readFile(join(artifactDirectory, "debug", "run_report.json"), "utf8")
+  );
+  assert.equal(report.counts.searchPool, 1);
+  assert.equal(report.counts.prioritizedUrls, 1);
+
+  const prioritizedCsv = await readFile(
+    join(artifactDirectory, "debug", "prioritized_urls.csv"),
+    "utf8"
+  );
+  assert.match(prioritizedCsv, /https:\/\/example.com\/yc/);
+});

--- a/backend/test/populate-collection-runtime.test.ts
+++ b/backend/test/populate-collection-runtime.test.ts
@@ -44,6 +44,12 @@ test("collection runtime threads recipe instructions into the collection prompt"
   let capturedInput: CollectionPopulatePipelineInput | undefined;
   const runtime = new CollectionPopulateRecipeRuntime({
     targetRows: 3,
+    benchmarkMetadata: {
+      promptId: "latest-ai-blog-posts",
+      promptQuality: "easy",
+      persona: "technical operator",
+      expectedStress: "Latest dated source pages; date precision matters.",
+    },
     runPipeline: async (input) => {
       capturedInput = input;
       return {
@@ -89,6 +95,13 @@ test("collection runtime threads recipe instructions into the collection prompt"
   assert.equal(capturedInput.datasetId, context.datasetId);
   assert.equal(capturedInput.datasetName, context.datasetName);
   assert.equal(capturedInput.targetRows, 3);
+  assert.equal(capturedInput.promptId, "latest-ai-blog-posts");
+  assert.equal(capturedInput.promptQuality, "easy");
+  assert.equal(capturedInput.persona, "technical operator");
+  assert.equal(
+    capturedInput.expectedStress,
+    "Latest dated source pages; date precision matters."
+  );
   assert.deepEqual(capturedInput.requiredColumns, [
     "entity_name",
     "latest_post_title",
@@ -117,6 +130,25 @@ test("collection pipeline input builder trims empty recipe instructions", () => 
 
   assert.equal(input.recipeInstructions, "");
   assert.doesNotMatch(input.prompt, /Durable recipe instructions/);
+});
+
+test("collection pipeline input builder carries benchmark metadata", () => {
+  const input = collectionPipelineInputFromRecipe({
+    recipe: collectionRecipe(),
+    context,
+    targetRows: 5,
+    benchmarkMetadata: {
+      promptId: "saas-pricing-pages",
+      promptQuality: "medium",
+      persona: "startup founder",
+      expectedStress: "Official pricing evidence.",
+    },
+  });
+
+  assert.equal(input.promptId, "saas-pricing-pages");
+  assert.equal(input.promptQuality, "medium");
+  assert.equal(input.persona, "startup founder");
+  assert.equal(input.expectedStress, "Official pricing evidence.");
 });
 
 function collectionRecipe(input: {

--- a/backend/test/populate-collection-runtime.test.ts
+++ b/backend/test/populate-collection-runtime.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  CollectionPopulateRecipeRuntime,
+  collectionPipelineInputFromRecipe,
+  type CollectionPopulatePipelineInput,
+} from "../src/pipeline/populate-collection-runtime.js";
+import {
+  createPopulateRecipe,
+  type PopulateRecipe,
+} from "../src/pipeline/populate-self-healing.js";
+import type { DatasetContext } from "../src/pipeline/populate.js";
+
+const context: DatasetContext = {
+  datasetId: "dataset-ai-posts",
+  datasetName: "AI posts",
+  description: "Find latest blog posts from OpenAI.",
+  columns: [
+    {
+      name: "entity_name",
+      type: "text",
+      description: "Company name.",
+    },
+    {
+      name: "latest_post_title",
+      type: "text",
+      description: "Post title.",
+    },
+    {
+      name: "source_url",
+      type: "url",
+      description: "Source URL.",
+    },
+    {
+      name: "evidence_quote",
+      type: "text",
+      description: "Evidence quote.",
+    },
+  ],
+};
+
+test("collection runtime threads recipe instructions into the collection prompt", async () => {
+  let capturedInput: CollectionPopulatePipelineInput | undefined;
+  const runtime = new CollectionPopulateRecipeRuntime({
+    targetRows: 3,
+    runPipeline: async (input) => {
+      capturedInput = input;
+      return {
+        rows: [{
+          cells: {
+            entity_name: "OpenAI",
+            latest_post_title: "Release notes from OpenAI",
+            source_url: "https://openai.com/news",
+            evidence_quote: "Release notes from OpenAI",
+          },
+          sourceUrls: ["https://openai.com/news"],
+          evidence: [{
+            columnName: "latest_post_title",
+            sourceUrl: "https://openai.com/news",
+            quote: "Release notes from OpenAI",
+          }],
+          needsReview: false,
+        }],
+        validationIssues: [],
+        usage: {
+          promptTokens: 11,
+          completionTokens: 7,
+          totalTokens: 18,
+        },
+        metrics: {
+          searchCalls: 1,
+          fetchCalls: 1,
+          browserCalls: 0,
+          agentRuns: 1,
+          agentSteps: 0,
+        },
+      };
+    },
+  });
+  const recipe = collectionRecipe({
+    runtimeInstructions:
+      "Prefer official news pages already known to work. Do not use aggregator pages.",
+  });
+
+  const run = await runtime.runRecipe({ recipe, context });
+
+  assert.ok(capturedInput);
+  assert.equal(capturedInput.datasetId, context.datasetId);
+  assert.equal(capturedInput.datasetName, context.datasetName);
+  assert.equal(capturedInput.targetRows, 3);
+  assert.deepEqual(capturedInput.requiredColumns, [
+    "entity_name",
+    "latest_post_title",
+    "source_url",
+    "evidence_quote",
+  ]);
+  assert.match(capturedInput.prompt, /Find latest blog posts from OpenAI/);
+  assert.match(capturedInput.prompt, /Durable recipe instructions/);
+  assert.match(capturedInput.prompt, /Do not use aggregator pages/);
+  assert.equal(
+    capturedInput.recipeInstructions,
+    "Prefer official news pages already known to work. Do not use aggregator pages."
+  );
+  assert.equal(run.runStatus, "succeeded");
+  assert.equal(run.productionValidation.isValid, true);
+  assert.equal(run.productionValidation.score, 1);
+  assert.equal(run.rows[0]?.cells.entity_name, "OpenAI");
+});
+
+test("collection pipeline input builder trims empty recipe instructions", () => {
+  const input = collectionPipelineInputFromRecipe({
+    recipe: collectionRecipe({ runtimeInstructions: "   " }),
+    context,
+    targetRows: 5,
+  });
+
+  assert.equal(input.recipeInstructions, "");
+  assert.doesNotMatch(input.prompt, /Durable recipe instructions/);
+});
+
+function collectionRecipe(input: {
+  runtimeInstructions?: string;
+} = {}): PopulateRecipe {
+  return createPopulateRecipe({
+    recipeId: "collection-v1",
+    datasetId: context.datasetId,
+    version: 1,
+    status: "active",
+    runtimeInstructions: input.runtimeInstructions ?? "",
+    sourceDescription: context.description,
+    requestedColumns: context.columns.map((column) => column.name),
+    createdBy: "system",
+  });
+}

--- a/backend/test/populate-collection-runtime.test.ts
+++ b/backend/test/populate-collection-runtime.test.ts
@@ -121,6 +121,57 @@ test("collection runtime threads recipe instructions into the collection prompt"
   assert.equal(run.rows[0]?.cells.entity_name, "OpenAI");
 });
 
+test("collection runtime treats capability diagnostics as non-fatal warnings for healthy rows", async () => {
+  const runtime = new CollectionPopulateRecipeRuntime({
+    targetRows: 3,
+    runPipeline: async () => ({
+      rows: [{
+        cells: {
+          entity_name: "OpenAI",
+          latest_post_title: "Release notes from OpenAI",
+          source_url: "https://openai.com/news",
+          evidence_quote: "Release notes from OpenAI",
+        },
+        sourceUrls: ["https://openai.com/news"],
+        evidence: [{
+          columnName: "latest_post_title",
+          sourceUrl: "https://openai.com/news",
+          quote: "Release notes from OpenAI",
+        }],
+        needsReview: false,
+      }],
+      validationIssues: [
+        "Capability diagnostic: TinyFish Agent disabled; triage requested browser/form/detail follow-up for 2 page(s) (requires_navigation=1, requires_form_submission=1). Enable COLLECTION_AGENT_ENABLE_AGENT=true for live navigation.",
+      ],
+      usage: {
+        promptTokens: 11,
+        completionTokens: 7,
+        totalTokens: 18,
+      },
+      metrics: {
+        searchCalls: 1,
+        fetchCalls: 1,
+        browserCalls: 0,
+        agentRuns: 0,
+        agentSteps: 0,
+      },
+    }),
+  });
+
+  const run = await runtime.runRecipe({
+    recipe: collectionRecipe(),
+    context,
+  });
+
+  assert.equal(run.runStatus, "succeeded");
+  assert.equal(run.productionValidation.isValid, true);
+  assert.deepEqual(run.productionValidation.criticalIssues, []);
+  assert.match(
+    run.productionValidation.warnings.join("\n"),
+    /Capability diagnostic: TinyFish Agent disabled/
+  );
+});
+
 test("collection pipeline input builder trims empty recipe instructions", () => {
   const input = collectionPipelineInputFromRecipe({
     recipe: collectionRecipe({ runtimeInstructions: "   " }),

--- a/backend/test/populate-convex-writer.test.ts
+++ b/backend/test/populate-convex-writer.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+test("Convex populate row writer uses one atomic replace mutation", async () => {
+  process.env.CONVEX_URL = process.env.CONVEX_URL ?? "https://example.convex.cloud";
+  process.env.CONVEX_SELF_HOSTED_ADMIN_KEY =
+    process.env.CONVEX_SELF_HOSTED_ADMIN_KEY ?? "test-admin-key";
+  const { ConvexPopulateDatasetRowWriter } = await import(
+    "../src/pipeline/populate-convex-writer.js"
+  );
+  const calls: Array<{ functionReference: unknown; args: unknown }> = [];
+  const replaceByDataset = Symbol("replaceByDataset");
+  const writer = new ConvexPopulateDatasetRowWriter({
+    internalApi: {
+      datasetRows: {
+        replaceByDataset,
+      },
+    },
+    convexClient: {
+      async mutation(functionReference, args) {
+        calls.push({ functionReference, args });
+        return {
+          clearedRowCount: 2,
+          insertedRowCount: 1,
+        };
+      },
+    },
+  });
+
+  const result = await writer.replaceRows({
+    datasetId: "dataset-ai-posts",
+    rows: [{
+      cells: {
+        entity_name: "OpenAI",
+        source_url: "https://openai.com/news",
+      },
+      sourceUrls: ["https://openai.com/news"],
+      evidence: [{
+        columnName: "entity_name",
+        sourceUrl: "https://openai.com/news",
+        quote: "OpenAI",
+      }],
+      needsReview: true,
+    }],
+  });
+
+  assert.deepEqual(result, {
+    clearedRowCount: 2,
+    insertedRowCount: 1,
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.functionReference, replaceByDataset);
+  assert.deepEqual(calls[0]?.args, {
+    datasetId: "dataset-ai-posts",
+    rows: [{
+      data: {
+        entity_name: "OpenAI",
+        source_url: "https://openai.com/news",
+      },
+      sources: ["https://openai.com/news"],
+    }],
+  });
+});

--- a/backend/test/populate-dataset-context-loader.test.ts
+++ b/backend/test/populate-dataset-context-loader.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { ConvexPopulateDatasetContextLoader } from "../src/pipeline/populate-dataset-context-loader.js";
+
+test("Convex dataset context loader maps system dataset to populate context", async () => {
+  const getForSystemPopulate = Symbol("getForSystemPopulate");
+  const calls: Array<{ functionReference: unknown; args: unknown }> = [];
+  const loader = new ConvexPopulateDatasetContextLoader({
+    internalApi: {
+      datasets: {
+        getForSystemPopulate,
+      },
+    },
+    convexClient: {
+      async query(functionReference, args) {
+        calls.push({ functionReference, args });
+        return {
+          name: "AI posts",
+          description: "Find latest blog posts from OpenAI.",
+          columns: [{
+            name: "entity_name",
+            type: "text",
+            description: "Company name.",
+          }],
+        };
+      },
+    },
+  });
+
+  const context = await loader.loadContext("dataset-ai-posts");
+
+  assert.deepEqual(calls, [{
+    functionReference: getForSystemPopulate,
+    args: { id: "dataset-ai-posts" },
+  }]);
+  assert.deepEqual(context, {
+    datasetId: "dataset-ai-posts",
+    datasetName: "AI posts",
+    description: "Find latest blog posts from OpenAI.",
+    columns: [{
+      name: "entity_name",
+      type: "text",
+      description: "Company name.",
+    }],
+  });
+});
+
+test("Convex dataset context loader rejects missing dataset", async () => {
+  const loader = new ConvexPopulateDatasetContextLoader({
+    internalApi: {
+      datasets: {
+        getForSystemPopulate: Symbol("getForSystemPopulate"),
+      },
+    },
+    convexClient: {
+      async query() {
+        return null;
+      },
+    },
+  });
+
+  await assert.rejects(
+    loader.loadContext("missing-dataset"),
+    /Dataset missing-dataset not found/
+  );
+});

--- a/backend/test/populate-extract-records.test.ts
+++ b/backend/test/populate-extract-records.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { finalizePopulateLlmRecords } from "../src/pipeline/populate-extract-records.js";
+import type { PopulateExtractionSpec } from "../src/pipeline/populate-extraction-spec.js";
+import { coerceHttpUrl, uniqueHttpUrls } from "../src/pipeline/populate-url-utils.js";
+
+const spec: PopulateExtractionSpec = {
+  dataset_name: "yc",
+  description: "YC companies",
+  primary_key: "company_name",
+  dedupe_keys: ["company_name"],
+  columns: [
+    {
+      name: "company_name",
+      display_name: "Company",
+      type: "string",
+      description: "Name",
+      nullable: false,
+    },
+    {
+      name: "source_url",
+      display_name: "Source",
+      type: "url",
+      description: "Source page URL",
+      nullable: true,
+    },
+  ],
+};
+
+test("coerceHttpUrl accepts strings and nested LLM shapes", () => {
+  assert.equal(coerceHttpUrl(" https://example.com "), "https://example.com");
+  assert.equal(coerceHttpUrl({ url: "https://nested.com" }), "https://nested.com");
+  assert.equal(
+    coerceHttpUrl(["https://first.com", "https://second.com"]),
+    "https://first.com"
+  );
+  assert.equal(coerceHttpUrl(42), null);
+});
+
+test("uniqueHttpUrls ignores non-string url values", () => {
+  assert.deepEqual(
+    uniqueHttpUrls([
+      "https://page.com",
+      { href: "https://obj.com" },
+      null,
+      undefined,
+      99,
+    ]),
+    ["https://page.com", "https://obj.com"]
+  );
+});
+
+test("finalizePopulateLlmRecords tolerates non-string evidence urls", () => {
+  const rows = finalizePopulateLlmRecords({
+    pageUrl: "https://techcrunch.com/article",
+    spec,
+    records: [
+      {
+        row: {
+          company_name: "Acme",
+          source_url: "https://acme.com",
+        },
+        evidence: [
+          {
+            field: "company_name",
+            quote: "Acme",
+            url: { href: "https://acme.com/about" },
+          },
+        ],
+        extraction_confidence: 0.9,
+      },
+    ],
+  });
+
+  assert.equal(rows.length, 1);
+  assert.ok(rows[0]?.sourceUrls.includes("https://techcrunch.com/article"));
+  assert.ok(rows[0]?.sourceUrls.includes("https://acme.com"));
+  assert.equal(rows[0]?.evidence[0]?.sourceUrl, "https://acme.com/about");
+});

--- a/backend/test/populate-normalize-dataset-keys.test.ts
+++ b/backend/test/populate-normalize-dataset-keys.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { DatasetContext } from "../src/pipeline/populate.js";
+import type { DatasetSchema } from "../src/pipeline/types.js";
+import {
+  buildPopulateColumnKeyAliases,
+  normalizePopulateRowCellsForDataset,
+} from "../src/pipeline/populate-normalize-dataset-keys.js";
+
+const context: DatasetContext = {
+  datasetId: "ds_test",
+  datasetName: "AI Companies",
+  description: "Top AI companies",
+  columns: [
+    { name: "Company Name", type: "text", description: "Legal or brand name" },
+    { name: "Official Website", type: "url", description: "Homepage" },
+    { name: "Description", type: "text", description: "What they do" },
+    { name: "Source URL", type: "url", description: "Evidence URL" },
+  ],
+};
+
+const dataSpec: DatasetSchema = {
+  dataset_name: "ai_companies",
+  description: "One row per AI company",
+  primary_key: "company_name",
+  search_queries: ["top AI companies 2025"],
+  columns: [
+    {
+      name: "company_name",
+      display_name: "Company Name",
+      type: "string",
+      is_primary_key: true,
+      is_enumerable: true,
+      description: "Legal or brand name",
+      nullable: false,
+    },
+    {
+      name: "official_website",
+      display_name: "Official Website",
+      type: "url",
+      is_primary_key: false,
+      is_enumerable: false,
+      description: "Homepage",
+      nullable: true,
+    },
+    {
+      name: "description",
+      display_name: "Description",
+      type: "string",
+      is_primary_key: false,
+      is_enumerable: false,
+      description: "What they do",
+      nullable: true,
+    },
+    {
+      name: "source_url",
+      display_name: "Source URL",
+      type: "url",
+      is_primary_key: false,
+      is_enumerable: false,
+      description: "Evidence URL",
+      nullable: true,
+    },
+  ],
+};
+
+test("buildPopulateColumnKeyAliases maps snake_case extraction keys to dataset column names", () => {
+  const aliases = buildPopulateColumnKeyAliases(dataSpec, context);
+
+  assert.equal(aliases.get("company_name"), "Company Name");
+  assert.equal(aliases.get("official_website"), "Official Website");
+  assert.equal(aliases.get("source_url"), "Source URL");
+  assert.equal(aliases.get("Company Name"), "Company Name");
+});
+
+test("normalizePopulateRowCellsForDataset rewrites row.cells before Convex write", () => {
+  const aliases = buildPopulateColumnKeyAliases(dataSpec, context);
+  const normalized = normalizePopulateRowCellsForDataset(
+    {
+      company_name: "OpenAI",
+      official_website: "https://openai.com",
+      description: "AI research lab",
+      source_url: "https://openai.com/about",
+    },
+    aliases
+  );
+
+  assert.deepEqual(normalized, {
+    "Company Name": "OpenAI",
+    "Official Website": "https://openai.com",
+    Description: "AI research lab",
+    "Source URL": "https://openai.com/about",
+  });
+});
+
+test("normalizePopulateRowCellsForDataset keeps already-correct keys", () => {
+  const aliases = buildPopulateColumnKeyAliases(dataSpec, context);
+  const normalized = normalizePopulateRowCellsForDataset(
+    {
+      "Company Name": "Anthropic",
+      "Official Website": "https://anthropic.com",
+    },
+    aliases
+  );
+
+  assert.deepEqual(normalized, {
+    "Company Name": "Anthropic",
+    "Official Website": "https://anthropic.com",
+  });
+});

--- a/backend/test/populate-parallel.test.ts
+++ b/backend/test/populate-parallel.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { shardPrioritizedUrlsEvenly } from "../src/pipeline/populate-parallel.js";
+
+test("shardPrioritizedUrlsEvenly spreads high and low priority across workers", () => {
+  const urls = Array.from({ length: 50 }, (_, index) => `https://example.com/${index}`);
+  const shards = shardPrioritizedUrlsEvenly(urls, 5);
+
+  assert.equal(shards.length, 10);
+  assert.equal(shards.reduce((sum, shard) => sum + shard.length, 0), 50);
+  assert.equal(shards[0]![0], "https://example.com/0");
+  assert.equal(shards[0]![1], "https://example.com/10");
+  assert.equal(shards[1]![0], "https://example.com/1");
+  assert.equal(shards[9]![4], "https://example.com/49");
+});

--- a/backend/test/populate-runtime-limits.test.ts
+++ b/backend/test/populate-runtime-limits.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { resolvePopulateRuntimeLimits } from "../src/pipeline/populate-runtime-limits.js";
+
+test("resolvePopulateRuntimeLimits uses POPULATE_MAX_FETCH_CALLS without search scaling", () => {
+  const limits = resolvePopulateRuntimeLimits({
+    maxRows: 5,
+    maxSearchCalls: 4,
+    maxFetchCalls: 100,
+    env: {},
+  });
+
+  assert.equal(limits.maxRows, 5);
+  assert.equal(limits.maxSearchCalls, 4);
+  assert.equal(limits.maxFetchCalls, 100);
+});
+
+test("resolvePopulateRuntimeLimits reads env overrides", () => {
+  const limits = resolvePopulateRuntimeLimits({
+    env: {
+      POPULATE_MAX_ROWS: "3",
+      POPULATE_MAX_SEARCH_CALLS: "2",
+      POPULATE_MAX_FETCH_CALLS: "5",
+    },
+  });
+
+  assert.deepEqual(limits, {
+    maxRows: 3,
+    maxSearchCalls: 2,
+    maxFetchCalls: 5,
+  });
+});
+
+test("resolvePopulateRuntimeLimits defaults maxFetchCalls to 50", () => {
+  const limits = resolvePopulateRuntimeLimits({ env: {} });
+  assert.equal(limits.maxFetchCalls, 50);
+});

--- a/backend/test/populate-runtime-prerequisites.test.ts
+++ b/backend/test/populate-runtime-prerequisites.test.ts
@@ -8,6 +8,7 @@ import {
 
 test("populate runtime prerequisite check reports every missing key", () => {
   assert.deepEqual(missingPopulateRuntimePrerequisites({}), [
+    "CONVEX_URL",
     "CONVEX_SELF_HOSTED_ADMIN_KEY",
     "OPENROUTER_API_KEY",
     "TINYFISH_API_KEY",
@@ -27,6 +28,7 @@ test("populate runtime prerequisite check skips Convex admin key for dry runs", 
 
 test("populate runtime prerequisite check passes when all keys are configured", () => {
   const input = {
+    convexUrl: "http://convex:3210",
     convexAdminKey: "convex",
     openRouterApiKey: "openrouter",
     tinyFishApiKey: "tinyfish",
@@ -34,4 +36,16 @@ test("populate runtime prerequisite check passes when all keys are configured", 
 
   assert.deepEqual(missingPopulateRuntimePrerequisites(input), []);
   assert.equal(populateRuntimePrerequisiteError(input), undefined);
+});
+
+test("populate runtime prerequisite check requires Convex keys for dataset-id dry runs", () => {
+  assert.deepEqual(
+    missingPopulateRuntimePrerequisites({
+      openRouterApiKey: "openrouter",
+      tinyFishApiKey: "tinyfish",
+      shouldCommitRows: false,
+      shouldLoadDatasetContext: true,
+    }),
+    ["CONVEX_URL", "CONVEX_SELF_HOSTED_ADMIN_KEY"]
+  );
 });

--- a/backend/test/populate-runtime-prerequisites.test.ts
+++ b/backend/test/populate-runtime-prerequisites.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  missingPopulateRuntimePrerequisites,
+  populateRuntimePrerequisiteError,
+} from "../src/pipeline/populate-runtime-prerequisites.js";
+
+test("populate runtime prerequisite check reports every missing key", () => {
+  assert.deepEqual(missingPopulateRuntimePrerequisites({}), [
+    "CONVEX_SELF_HOSTED_ADMIN_KEY",
+    "OPENROUTER_API_KEY",
+    "TINYFISH_API_KEY",
+  ]);
+});
+
+test("populate runtime prerequisite check passes when all keys are configured", () => {
+  const input = {
+    convexAdminKey: "convex",
+    openRouterApiKey: "openrouter",
+    tinyFishApiKey: "tinyfish",
+  };
+
+  assert.deepEqual(missingPopulateRuntimePrerequisites(input), []);
+  assert.equal(populateRuntimePrerequisiteError(input), undefined);
+});

--- a/backend/test/populate-runtime-prerequisites.test.ts
+++ b/backend/test/populate-runtime-prerequisites.test.ts
@@ -14,6 +14,17 @@ test("populate runtime prerequisite check reports every missing key", () => {
   ]);
 });
 
+test("populate runtime prerequisite check skips Convex admin key for dry runs", () => {
+  assert.deepEqual(
+    missingPopulateRuntimePrerequisites({
+      openRouterApiKey: "openrouter",
+      tinyFishApiKey: "tinyfish",
+      shouldCommitRows: false,
+    }),
+    []
+  );
+});
+
 test("populate runtime prerequisite check passes when all keys are configured", () => {
   const input = {
     convexAdminKey: "convex",

--- a/backend/test/populate-runtime-selection.test.ts
+++ b/backend/test/populate-runtime-selection.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  createPopulateRecipeRuntime,
+  selectedPopulateRuntimeName,
+} from "../src/pipeline/populate-runtime-selection.js";
+import { CollectionPopulateRecipeRuntime } from "../src/pipeline/populate-collection-runtime.js";
+import { MastraPopulateRecipeRuntime } from "../src/pipeline/populate-self-healing.js";
+
+test("populate runtime selection defaults to Mastra", async () => {
+  assert.equal(selectedPopulateRuntimeName({}), "mastra");
+  assert.ok(
+    await createPopulateRecipeRuntime({ env: {} }) instanceof
+      MastraPopulateRecipeRuntime
+  );
+});
+
+test("populate runtime selection supports collection when a runner is provided", async () => {
+  assert.equal(
+    selectedPopulateRuntimeName({ POPULATE_AGENT_RUNTIME: "collection" }),
+    "collection"
+  );
+  const runtime = await createPopulateRecipeRuntime({
+    env: { POPULATE_AGENT_RUNTIME: "collection" },
+    collectionRunner: async () => ({
+      rows: [],
+      validationIssues: ["not used"],
+      usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+      metrics: {
+        searchCalls: 0,
+        fetchCalls: 0,
+        browserCalls: 0,
+        agentRuns: 0,
+        agentSteps: 0,
+      },
+    }),
+  });
+
+  assert.ok(runtime instanceof CollectionPopulateRecipeRuntime);
+});
+
+test("populate runtime selection rejects collection without a runner", async () => {
+  await assert.rejects(
+    () => createPopulateRecipeRuntime({
+      env: { POPULATE_AGENT_RUNTIME: "collection" },
+    }),
+    /requires a collection pipeline runner/
+  );
+});

--- a/backend/test/populate-runtime-selection.test.ts
+++ b/backend/test/populate-runtime-selection.test.ts
@@ -6,7 +6,11 @@ import {
   selectedPopulateRuntimeName,
 } from "../src/pipeline/populate-runtime-selection.js";
 import { CollectionPopulateRecipeRuntime } from "../src/pipeline/populate-collection-runtime.js";
-import { MastraPopulateRecipeRuntime } from "../src/pipeline/populate-self-healing.js";
+import {
+  createPopulateRecipe,
+  MastraPopulateRecipeRuntime,
+} from "../src/pipeline/populate-self-healing.js";
+import type { DatasetContext } from "../src/pipeline/populate.js";
 
 test("populate runtime selection defaults to Mastra", async () => {
   assert.equal(selectedPopulateRuntimeName({}), "mastra");
@@ -48,3 +52,77 @@ test("populate runtime selection rejects collection without a runner", async () 
     /requires a collection pipeline runner/
   );
 });
+
+test("populate runtime selection loads collection runner from env module", async () => {
+  const runtime = await createPopulateRecipeRuntime({
+    env: {
+      POPULATE_AGENT_RUNTIME: "collection",
+      POPULATE_COLLECTION_RUNNER_MODULE: runnerModuleUrl(),
+      BIGSET_BENCHMARK_PROMPT_ID: "latest-ai-blog-posts",
+      BIGSET_BENCHMARK_PROMPT_QUALITY: "easy",
+      BIGSET_BENCHMARK_PERSONA: "technical operator",
+      BIGSET_BENCHMARK_EXPECTED_STRESS: "Latest dated source pages.",
+    },
+  });
+  const context: DatasetContext = {
+    datasetId: "dataset-ai-posts",
+    datasetName: "AI posts",
+    description: "Find latest blog posts from OpenAI.",
+    columns: [
+      { name: "entity_name", type: "text" },
+      { name: "source_url", type: "url" },
+      { name: "evidence_quote", type: "text" },
+    ],
+  };
+  const run = await runtime.runRecipe({
+    context,
+    recipe: createPopulateRecipe({
+      recipeId: "collection-v1",
+      datasetId: context.datasetId,
+      version: 1,
+      status: "active",
+      runtimeInstructions: "Prefer official sources.",
+      sourceDescription: context.description,
+      requestedColumns: context.columns.map((column) => column.name),
+      createdBy: "system",
+    }),
+  });
+
+  assert.equal(run.runStatus, "succeeded");
+  assert.equal(run.rows[0]?.cells.entity_name, "latest-ai-blog-posts");
+  assert.equal(run.rows[0]?.cells.evidence_quote, "technical operator");
+});
+
+function runnerModuleUrl(): string {
+  const source = `
+    export async function runCollectionPopulatePipeline(input) {
+      const quote = input.expectedStress || "Loaded runner module.";
+      return {
+        rows: [{
+          cells: {
+            entity_name: input.promptId,
+            source_url: "https://example.com/source",
+            evidence_quote: input.persona,
+          },
+          sourceUrls: ["https://example.com/source"],
+          evidence: [
+            { columnName: "entity_name", sourceUrl: "https://example.com/source", quote },
+            { columnName: "source_url", sourceUrl: "https://example.com/source", quote },
+            { columnName: "evidence_quote", sourceUrl: "https://example.com/source", quote },
+          ],
+          needsReview: false,
+        }],
+        validationIssues: [],
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        metrics: {
+          searchCalls: 0,
+          fetchCalls: 0,
+          browserCalls: 0,
+          agentRuns: 1,
+          agentSteps: 0,
+        },
+      };
+    }
+  `;
+  return `data:text/javascript,${encodeURIComponent(source)}`;
+}

--- a/backend/test/populate-runtime.test.ts
+++ b/backend/test/populate-runtime.test.ts
@@ -320,9 +320,10 @@ test("populate runtime uses structured recovery when insert_row rows lack eviden
   assert.equal(result.rows.length, 1);
   assert.equal(result.rows[0]?.evidence[0]?.quote, "Release notes from OpenAI");
   assert.match(
-    result.validationIssues.join("\n"),
+    result.debug?.notes.join("\n") ?? "",
     /Structured row recovery replaced insert_row rows/
   );
+  assert.deepEqual(result.validationIssues, []);
 });
 
 test("populate runtime enforces per-run row cap before inserting", async () => {

--- a/backend/test/populate-runtime.test.ts
+++ b/backend/test/populate-runtime.test.ts
@@ -1,7 +1,16 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import {
+  runSearchAcquisitionPhase,
+  type PopulateAcquisitionResult,
+} from "../src/pipeline/populate-acquisition.js";
+import { buildPopulateExtractionSpec } from "../src/pipeline/populate-extraction-spec.js";
+import { resolveInitialSearchQueryCap } from "../src/pipeline/schema-inference.js";
 import { runPopulateRuntime } from "../src/pipeline/populate-runtime.js";
+import { normalizeSearchResultUrl } from "../src/pipeline/populate-search-prioritization.js";
+import type { DatasetSchema } from "../src/pipeline/types.js";
+import { buildMockRow, mockTriageExtractHooks } from "./populate-test-hooks.js";
 
 interface ToolLike<TInput, TOutput> {
   execute(input: TInput): Promise<TOutput>;
@@ -35,421 +44,393 @@ const context = {
   ],
 };
 
-test("populate runtime captures rows through injected tools without Convex writes", async () => {
+function mockPopulateDataSpec(maxSearchCalls: number): DatasetSchema {
+  const queryCount = resolveInitialSearchQueryCap(maxSearchCalls);
+  return {
+    dataset_name: "benchmark_dataset",
+    description: context.description,
+    primary_key: "entity_name",
+    search_queries: Array.from(
+      { length: queryCount },
+      (_, index) => `seed query ${index + 1}`
+    ),
+    columns: [
+      {
+        name: "entity_name",
+        display_name: "Company",
+        type: "string",
+        is_primary_key: true,
+        is_enumerable: true,
+        description: "Company name on the official blog or news page.",
+        nullable: false,
+      },
+      {
+        name: "latest_post_title",
+        display_name: "Latest post",
+        type: "string",
+        is_primary_key: false,
+        is_enumerable: false,
+        description: "Title of the latest blog post.",
+        nullable: true,
+      },
+      {
+        name: "source_url",
+        display_name: "Source URL",
+        type: "url",
+        is_primary_key: false,
+        is_enumerable: false,
+        description: "Canonical URL of the latest post.",
+        nullable: true,
+      },
+    ],
+  };
+}
+
+function mockAcquisition(input: {
+  results: Array<{
+    url: string;
+    expectation_score?: number;
+    search_query?: string;
+  }>;
+  fetchLimit?: number;
+}): PopulateAcquisitionResult {
+  const scoredUrls = [...input.results]
+    .map((result) => ({
+      url: normalizeSearchResultUrl(result.url),
+      expectation_score: result.expectation_score ?? 5,
+      search_query: result.search_query ?? "Find latest blog posts from OpenAI.",
+    }))
+    .sort((a, b) => b.expectation_score - a.expectation_score);
+
+  const limitedResults =
+    input.fetchLimit === undefined
+      ? scoredUrls
+      : scoredUrls.slice(0, input.fetchLimit);
+
+  return {
+    prioritizedUrls: limitedResults.map((result) => result.url),
+    scoredUrls,
+    initialQueries: ["Find latest blog posts from OpenAI."],
+    validationIssues: [],
+  };
+}
+
+const openAiNewsUrl = "https://openai.com/news";
+const openAiNewsAcquisition = mockAcquisition({
+  results: [{ url: openAiNewsUrl }],
+});
+const testDataSpec = mockPopulateDataSpec(10);
+const testExtractionSpec = buildPopulateExtractionSpec({
+  context,
+  dataSpec: testDataSpec,
+});
+
+const emptyMetrics = () => ({
+  searchCalls: 0,
+  fetchCalls: 0,
+  browserCalls: 0,
+  agentRuns: 0,
+  agentSteps: 0,
+});
+
+test("populate runtime captures rows through parallel triage extract workers", async () => {
   const result = await runPopulateRuntime({
     context,
+    dataSpec: testDataSpec,
+    acquisition: openAiNewsAcquisition,
     webTools: {
-      search: async () => [
-        {
-          title: "OpenAI news",
-          snippet: "Release notes",
-          url: "https://openai.com/news",
-        },
-      ],
+      search: async () => [],
       fetch: async () => ({
         title: "OpenAI news",
         text: "Release notes",
       }),
     },
-    agentRunner: async ({ tools }) => {
-      const searchWeb = tools.search_web as ToolLike<
-        { query: string },
-        { results?: unknown[] }
-      >;
-      const fetchPage = tools.fetch_page as ToolLike<
-        { url: string },
-        { text?: string }
-      >;
-      const insertRow = tools.insert_row as ToolLike<
-        { datasetId: string; data: Record<string, unknown> },
-        { success: boolean }
-      >;
-
-      const search = await searchWeb.execute({ query: "OpenAI latest blog" });
-      assert.equal(search.results?.length, 1);
-      const page = await fetchPage.execute({ url: "https://openai.com/news" });
-      assert.match(page.text ?? "", /Release notes/);
-      const inserted = await insertRow.execute({
-        datasetId: "benchmark-dataset",
-        data: {
-          entity_name: "OpenAI",
-          latest_post_title: "Release notes",
-          source_url: "https://openai.com/news",
-          evidence_quote: "Release notes",
-        },
-      });
-      assert.equal(inserted.success, true);
-    },
+    populateHooks: mockTriageExtractHooks({
+      recordsByUrl: {
+        [openAiNewsUrl]: [
+          buildMockRow({
+            spec: testExtractionSpec,
+            entityName: "OpenAI",
+            sourceUrl: openAiNewsUrl,
+            extraCells: { latest_post_title: "Release notes", evidence_quote: "Release notes" },
+            quote: "Release notes",
+          }),
+        ],
+      },
+    }),
   });
 
   assert.equal(result.rows.length, 1);
   assert.equal(result.rows[0]?.cells.entity_name, "OpenAI");
-  assert.deepEqual(result.rows[0]?.sourceUrls, ["https://openai.com/news"]);
+  assert.deepEqual(result.rows[0]?.sourceUrls, [openAiNewsUrl]);
   assert.equal(result.rows[0]?.evidence[0]?.quote, "Release notes");
-  assert.equal(result.metrics.searchCalls, 1);
+  assert.equal(result.metrics.searchCalls, 0);
   assert.equal(result.metrics.fetchCalls, 1);
-  assert.equal(result.metrics.agentRuns, 1);
+  assert.ok(result.metrics.agentRuns >= 1);
   assert.deepEqual(result.validationIssues, []);
 });
 
-test("populate runtime accepts structured fallback rows backed by captured sources", async () => {
+test("populate runtime synthesizes evidence when row lacks explicit evidence_quote cell", async () => {
   const result = await runPopulateRuntime({
     context,
-    webTools: {
-      search: async () => [
-        {
-          title: "OpenAI news",
-          snippet: "Release notes from OpenAI",
-          url: "https://openai.com/news",
-        },
-      ],
-      fetch: async () => ({
-        title: "OpenAI news",
-        text: "Release notes from OpenAI",
-      }),
-    },
-    agentRunner: async ({ tools }) => {
-      const searchWeb = tools.search_web as ToolLike<
-        { query: string },
-        { results?: unknown[] }
-      >;
-      const fetchPage = tools.fetch_page as ToolLike<
-        { url: string },
-        { text?: string }
-      >;
-
-      await searchWeb.execute({ query: "OpenAI latest blog" });
-      await fetchPage.execute({ url: "https://openai.com/news" });
-
-      return {
-        rows: [{
-          cells: {
-            entity_name: "OpenAI",
-            latest_post_title: "Release notes",
-            source_url: "https://openai.com/news",
-            evidence_quote: "Release notes from OpenAI",
-          },
-          sourceUrls: ["https://openai.com/news"],
-          evidence: [{
-            columnName: "latest_post_title",
-            sourceUrl: "https://openai.com/news",
-            quote: "Release notes from OpenAI",
-          }],
-        }],
-      };
-    },
-  });
-
-  assert.equal(result.rows.length, 1);
-  assert.equal(result.rows[0]?.cells.entity_name, "OpenAI");
-  assert.equal(result.rows[0]?.needsReview, true);
-  assert.deepEqual(result.rows[0]?.sourceUrls, ["https://openai.com/news"]);
-  assert.deepEqual(result.validationIssues, []);
-});
-
-test("populate runtime rejects structured fallback rows without source-backed evidence", async () => {
-  const result = await runPopulateRuntime({
-    context,
-    webTools: {
-      search: async () => [
-        {
-          title: "OpenAI news",
-          snippet: "Release notes from OpenAI",
-          url: "https://openai.com/news",
-        },
-      ],
-      fetch: async () => ({
-        title: "OpenAI news",
-        text: "Release notes from OpenAI",
-      }),
-    },
-    agentRunner: async ({ tools }) => {
-      const searchWeb = tools.search_web as ToolLike<
-        { query: string },
-        { results?: unknown[] }
-      >;
-
-      await searchWeb.execute({ query: "OpenAI latest blog" });
-
-      return {
-        rows: [{
-          cells: {
-            entity_name: "OpenAI",
-            latest_post_title: "Invented post",
-            source_url: "https://openai.com/news",
-            evidence_quote: "Invented quote",
-          },
-          sourceUrls: ["https://openai.com/news"],
-          evidence: [{
-            columnName: "latest_post_title",
-            sourceUrl: "https://openai.com/news",
-            quote: "Invented quote",
-          }],
-        }],
-      };
-    },
-  });
-
-  assert.equal(result.rows.length, 0);
-  assert.match(result.validationIssues.join("\n"), /evidence quote not found/);
-  assert.match(result.validationIssues.join("\n"), /returned no rows/);
-});
-
-test("populate runtime prefers insert_row captures over contradictory structured rows", async () => {
-  const result = await runPopulateRuntime({
-    context,
-    webTools: {
-      search: async () => [
-        {
-          title: "OpenAI news",
-          snippet: "Release notes from OpenAI",
-          url: "https://openai.com/news",
-        },
-      ],
-      fetch: async () => ({
-        title: "OpenAI news",
-        text: "Release notes from OpenAI",
-      }),
-    },
-    agentRunner: async ({ tools }) => {
-      const searchWeb = tools.search_web as ToolLike<
-        { query: string },
-        { results?: unknown[] }
-      >;
-      const insertRow = tools.insert_row as ToolLike<
-        { datasetId: string; data: Record<string, unknown> },
-        { success: boolean }
-      >;
-
-      await searchWeb.execute({ query: "OpenAI latest blog" });
-      await insertRow.execute({
-        datasetId: "benchmark-dataset",
-        data: {
-          entity_name: "OpenAI",
-          latest_post_title: "Release notes",
-          source_url: "https://openai.com/news",
-          evidence_quote: "Release notes from OpenAI",
-        },
-      });
-
-      return {
-        rows: [{
-          cells: {
-            entity_name: "Different",
-            latest_post_title: "Release notes",
-            source_url: "https://openai.com/news",
-            evidence_quote: "Release notes from OpenAI",
-          },
-          sourceUrls: ["https://openai.com/news"],
-          evidence: [{
-            columnName: "latest_post_title",
-            sourceUrl: "https://openai.com/news",
-            quote: "Release notes from OpenAI",
-          }],
-        }],
-      };
-    },
-  });
-
-  assert.equal(result.rows.length, 1);
-  assert.equal(result.rows[0]?.cells.entity_name, "OpenAI");
-  assert.match(result.validationIssues.join("\n"), /Structured populate rows differed/);
-});
-
-test("populate runtime uses structured recovery when insert_row rows lack evidence", async () => {
-  const result = await runPopulateRuntime({
-    context,
-    webTools: {
-      search: async () => [
-        {
-          title: "OpenAI news",
-          snippet: "Release notes from OpenAI",
-          url: "https://openai.com/news",
-        },
-      ],
-      fetch: async () => ({
-        title: "OpenAI news",
-        text: "Release notes from OpenAI",
-      }),
-    },
-    agentRunner: async ({ tools }) => {
-      const searchWeb = tools.search_web as ToolLike<
-        { query: string },
-        { results?: unknown[] }
-      >;
-      const fetchPage = tools.fetch_page as ToolLike<
-        { url: string },
-        { text?: string }
-      >;
-      const insertRow = tools.insert_row as ToolLike<
-        { datasetId: string; data: Record<string, unknown> },
-        { success: boolean }
-      >;
-
-      await searchWeb.execute({ query: "OpenAI latest blog" });
-      await fetchPage.execute({ url: "https://openai.com/news" });
-      await insertRow.execute({
-        datasetId: "benchmark-dataset",
-        data: {
-          entity_name: "OpenAI",
-          latest_post_title: "Release notes",
-          source_url: "https://openai.com/news",
-          evidence_quote: "",
-        },
-      });
-
-      return {
-        rows: [{
-          cells: {
-            entity_name: "OpenAI",
-            latest_post_title: "Release notes",
-            source_url: "https://openai.com/news",
-            evidence_quote: "Release notes from OpenAI",
-          },
-          sourceUrls: ["https://openai.com/news"],
-          evidence: [{
-            columnName: "latest_post_title",
-            sourceUrl: "https://openai.com/news",
-            quote: "Release notes from OpenAI",
-          }],
-        }],
-      };
-    },
-  });
-
-  assert.equal(result.rows.length, 1);
-  assert.equal(result.rows[0]?.evidence[0]?.quote, "Release notes from OpenAI");
-  assert.match(
-    result.debug?.notes.join("\n") ?? "",
-    /Structured row recovery replaced insert_row rows/
-  );
-  assert.deepEqual(result.validationIssues, []);
-});
-
-test("populate runtime enforces per-run row cap before inserting", async () => {
-  const result = await runPopulateRuntime({
-    context,
-    maxRows: 1,
+    dataSpec: testDataSpec,
+    acquisition: openAiNewsAcquisition,
     webTools: {
       search: async () => [],
-      fetch: async () => ({}),
+      fetch: async () => ({
+        text: "Release notes from OpenAI about the latest model.",
+      }),
     },
-    agentRunner: async ({ tools }) => {
-      const insertRow = tools.insert_row as ToolLike<
-        { datasetId: string; data: Record<string, unknown> },
-        { success: boolean; error?: string }
-      >;
-
-      const first = await insertRow.execute({
-        datasetId: "benchmark-dataset",
-        data: {
-          entity_name: "OpenAI",
-          source_url: "https://openai.com/news",
-          evidence_quote: "Release notes",
-        },
-      });
-      const second = await insertRow.execute({
-        datasetId: "benchmark-dataset",
-        data: {
-          entity_name: "Anthropic",
-          source_url: "https://anthropic.com/news",
-          evidence_quote: "News",
-        },
-      });
-
-      assert.equal(first.success, true);
-      assert.equal(second.success, false);
-      assert.match(second.error ?? "", /Row cap/);
-    },
+    populateHooks: mockTriageExtractHooks({
+      recordsByUrl: {
+        [openAiNewsUrl]: [
+          buildMockRow({
+            spec: testExtractionSpec,
+            entityName: "OpenAI",
+            sourceUrl: openAiNewsUrl,
+            extraCells: {
+              latest_post_title: "Release notes from OpenAI",
+              evidence_quote: "",
+            },
+            quote: "Release notes from OpenAI about the latest model.",
+          }),
+        ],
+      },
+    }),
   });
 
   assert.equal(result.rows.length, 1);
-  assert.equal(result.rows[0]?.cells.entity_name, "OpenAI");
+  assert.equal(result.rows[0]?.sourceUrls[0], openAiNewsUrl);
+  assert.ok((result.rows[0]?.evidence.length ?? 0) > 0);
 });
 
-test("populate runtime asks for insurance quote inputs without running the agent", async () => {
-  let wasAgentRunnerCalled = false;
+test("populate runtime enforces per-run row cap during merge", async () => {
+  const secondUrl = "https://anthropic.com/news";
+  const result = await runPopulateRuntime({
+    context,
+    dataSpec: testDataSpec,
+    maxRows: 1,
+    acquisition: mockAcquisition({
+      results: [{ url: openAiNewsUrl }, { url: secondUrl }],
+    }),
+    webTools: {
+      search: async () => [],
+      fetch: async () => ({ text: "content" }),
+    },
+    populateHooks: mockTriageExtractHooks({
+      recordsByUrl: {
+        [openAiNewsUrl]: [
+          buildMockRow({
+            spec: testExtractionSpec,
+            entityName: "OpenAI",
+            sourceUrl: openAiNewsUrl,
+            quote: "OpenAI evidence",
+          }),
+        ],
+        [secondUrl]: [
+          buildMockRow({
+            spec: testExtractionSpec,
+            entityName: "Anthropic",
+            sourceUrl: secondUrl,
+            quote: "Anthropic evidence",
+          }),
+        ],
+      },
+    }),
+  });
+
+  assert.equal(result.rows.length, 1);
+});
+
+test("populate runtime asks for insurance quote inputs without running populate", async () => {
   const result = await runPopulateRuntime({
     context: {
       ...context,
       description:
         "find me the best car insurance prices in California so I can pick the best bang for my buck",
     },
-    webTools: {
-      search: async () => {
-        throw new Error("search should not run");
-      },
-      fetch: async () => {
-        throw new Error("fetch should not run");
-      },
-    },
-    agentRunner: async () => {
-      wasAgentRunnerCalled = true;
-    },
   });
 
-  assert.equal(wasAgentRunnerCalled, false);
   assert.deepEqual(result.rows, []);
-  assert.equal(result.metrics.agentRuns, 0);
-  assert.equal(result.metrics.searchCalls, 0);
   assert.equal(result.metrics.fetchCalls, 0);
   assert.match(result.validationIssues.join(" "), /driver/);
-  assert.match(result.validationIssues.join(" "), /vehicle/);
-  assert.match(result.validationIssues.join(" "), /zip/);
-  assert.match(result.validationIssues.join(" "), /coverage/);
-  assert.match(result.validationIssues.join(" "), /deductible/);
 });
 
-test("populate runtime asks for AI company scope without running the agent", async () => {
-  let wasAgentRunnerCalled = false;
+test("populate runtime asks for AI company scope without running populate", async () => {
   const result = await runPopulateRuntime({
     context: {
       ...context,
       description: "get me the latest stuff from the big AI companies",
     },
+  });
+
+  assert.deepEqual(result.rows, []);
+  assert.equal(result.metrics.fetchCalls, 0);
+});
+
+test("search acquisition enforces search call budget", async () => {
+  const metrics = emptyMetrics();
+  await runSearchAcquisitionPhase({
+    context,
+    dataSpec: mockPopulateDataSpec(1),
+    maxSearchCalls: 1,
     webTools: {
-      search: async () => {
-        throw new Error("search should not run");
-      },
-      fetch: async () => {
-        throw new Error("fetch should not run");
-      },
+      search: async () => [
+        { title: "A", url: "https://example.com/a" },
+      ],
+      fetch: async () => ({}),
     },
-    agentRunner: async () => {
-      wasAgentRunnerCalled = true;
+    metrics,
+    validationIssues: [],
+    debugNotes: [],
+    searchAcquisitionRunner: async ({ tools }) => {
+      const searchWeb = tools.search_web as ToolLike<
+        { query: string },
+        { error?: string }
+      >;
+      await searchWeb.execute({ query: "first" });
+      const blocked = await searchWeb.execute({ query: "second" });
+      assert.match(blocked.error ?? "", /Search budget/);
+      return {
+        object: {
+          scored_urls: [
+            { url: "https://example.com/a", expectation_score: 5 },
+          ],
+        },
+      };
     },
   });
 
-  assert.equal(wasAgentRunnerCalled, false);
-  assert.deepEqual(result.rows, []);
-  assert.equal(result.metrics.agentRuns, 0);
-  assert.equal(result.metrics.searchCalls, 0);
-  assert.equal(result.metrics.fetchCalls, 0);
-  assert.match(result.validationIssues.join(" "), /which companies/);
-  assert.match(result.validationIssues.join(" "), /source type/);
-  assert.match(result.validationIssues.join(" "), /news/);
-  assert.match(result.validationIssues.join(" "), /blog/);
-  assert.match(result.validationIssues.join(" "), /release/);
-  assert.match(result.validationIssues.join(" "), /columns/);
+  assert.equal(metrics.searchCalls, 1);
+  assert.equal(metrics.agentRuns, 1);
 });
 
-test("populate runtime does not preflight explicit latest blog post requests", async () => {
-  let wasAgentRunnerCalled = false;
+test("search acquisition scores every pooled search result", async () => {
+  const metrics = emptyMetrics();
+  const phase = await runSearchAcquisitionPhase({
+    context,
+    dataSpec: mockPopulateDataSpec(10),
+    maxSearchCalls: 10,
+    webTools: {
+      search: async () => [
+        { title: "A", url: "https://example.com/a" },
+        { title: "B", url: "https://example.com/b" },
+      ],
+      fetch: async () => ({}),
+    },
+    metrics,
+    validationIssues: [],
+    debugNotes: [],
+    searchAcquisitionRunner: async ({ tools }) => {
+      const searchWeb = tools.search_web as ToolLike<{ query: string }, unknown>;
+      await searchWeb.execute({ query: "first" });
+      return {
+        object: {
+          scored_urls: [
+            { url: "https://example.com/a", expectation_score: 5 },
+            { url: "https://example.com/b", expectation_score: 2 },
+          ],
+        },
+      };
+    },
+  });
+
+  assert.equal(metrics.searchCalls, 1);
+  assert.equal(metrics.agentRuns, 1);
+  assert.equal(phase.scoredUrls.length, 2);
+});
+
+test("populate runtime fetches each prioritized URL in worker shards", async () => {
+  const urls = {
+    high: "https://example.com/high",
+    low: "https://example.com/low",
+  };
+
+  const result = await runPopulateRuntime({
+    context,
+    dataSpec: testDataSpec,
+    maxFetchCalls: 1,
+    acquisition: mockAcquisition({
+      fetchLimit: 1,
+      results: [
+        { url: urls.high, expectation_score: 5 },
+        { url: urls.low, expectation_score: 1 },
+      ],
+    }),
+    webTools: {
+      search: async () => [],
+      fetch: async ({ url }) => ({
+        title: url,
+        text: `content for ${url}`,
+      }),
+    },
+    populateHooks: mockTriageExtractHooks({
+      recordsByUrl: {
+        [urls.high]: [
+          buildMockRow({
+            spec: testExtractionSpec,
+            entityName: "High",
+            sourceUrl: urls.high,
+            quote: "content for high",
+          }),
+        ],
+      },
+    }),
+  });
+
+  assert.equal(result.metrics.fetchCalls, 1);
+  assert.equal(result.rows.length, 1);
+});
+
+test("populate runtime normalizes URLs when fetching prioritized pages", async () => {
+  const normalized = normalizeSearchResultUrl("https://openai.com/news");
+  const result = await runPopulateRuntime({
+    context,
+    dataSpec: testDataSpec,
+    acquisition: mockAcquisition({
+      results: [{ url: "https://openai.com/news/" }],
+    }),
+    webTools: {
+      search: async () => [],
+      fetch: async () => ({
+        title: "OpenAI news",
+        text: "Release notes",
+      }),
+    },
+    populateHooks: mockTriageExtractHooks({
+      recordsByUrl: {
+        [normalized]: [
+          buildMockRow({
+            spec: testExtractionSpec,
+            entityName: "OpenAI",
+            sourceUrl: normalized,
+            quote: "Release notes",
+          }),
+        ],
+      },
+    }),
+  });
+
+  assert.equal(result.rows.length, 1);
+  assert.equal(result.metrics.fetchCalls, 1);
+});
+
+test("populate runtime runs parallel populate for explicit blog post requests", async () => {
   const result = await runPopulateRuntime({
     context: {
       ...context,
       description:
         "Can you make me a table of the latest blog posts from OpenAI, Anthropic, and Google DeepMind?",
     },
+    dataSpec: testDataSpec,
+    acquisition: mockAcquisition({ results: [] }),
     webTools: {
       search: async () => [],
       fetch: async () => ({}),
     },
-    agentRunner: async () => {
-      wasAgentRunnerCalled = true;
-    },
+    populateHooks: mockTriageExtractHooks({ recordsByUrl: {} }),
   });
 
-  assert.equal(wasAgentRunnerCalled, true);
-  assert.equal(result.metrics.agentRuns, 1);
+  assert.equal(result.metrics.fetchCalls, 0);
+  assert.deepEqual(result.rows, []);
 });

--- a/backend/test/populate-runtime.test.ts
+++ b/backend/test/populate-runtime.test.ts
@@ -92,6 +92,239 @@ test("populate runtime captures rows through injected tools without Convex write
   assert.deepEqual(result.validationIssues, []);
 });
 
+test("populate runtime accepts structured fallback rows backed by captured sources", async () => {
+  const result = await runPopulateRuntime({
+    context,
+    webTools: {
+      search: async () => [
+        {
+          title: "OpenAI news",
+          snippet: "Release notes from OpenAI",
+          url: "https://openai.com/news",
+        },
+      ],
+      fetch: async () => ({
+        title: "OpenAI news",
+        text: "Release notes from OpenAI",
+      }),
+    },
+    agentRunner: async ({ tools }) => {
+      const searchWeb = tools.search_web as ToolLike<
+        { query: string },
+        { results?: unknown[] }
+      >;
+      const fetchPage = tools.fetch_page as ToolLike<
+        { url: string },
+        { text?: string }
+      >;
+
+      await searchWeb.execute({ query: "OpenAI latest blog" });
+      await fetchPage.execute({ url: "https://openai.com/news" });
+
+      return {
+        rows: [{
+          cells: {
+            entity_name: "OpenAI",
+            latest_post_title: "Release notes",
+            source_url: "https://openai.com/news",
+            evidence_quote: "Release notes from OpenAI",
+          },
+          sourceUrls: ["https://openai.com/news"],
+          evidence: [{
+            columnName: "latest_post_title",
+            sourceUrl: "https://openai.com/news",
+            quote: "Release notes from OpenAI",
+          }],
+        }],
+      };
+    },
+  });
+
+  assert.equal(result.rows.length, 1);
+  assert.equal(result.rows[0]?.cells.entity_name, "OpenAI");
+  assert.equal(result.rows[0]?.needsReview, true);
+  assert.deepEqual(result.rows[0]?.sourceUrls, ["https://openai.com/news"]);
+  assert.deepEqual(result.validationIssues, []);
+});
+
+test("populate runtime rejects structured fallback rows without source-backed evidence", async () => {
+  const result = await runPopulateRuntime({
+    context,
+    webTools: {
+      search: async () => [
+        {
+          title: "OpenAI news",
+          snippet: "Release notes from OpenAI",
+          url: "https://openai.com/news",
+        },
+      ],
+      fetch: async () => ({
+        title: "OpenAI news",
+        text: "Release notes from OpenAI",
+      }),
+    },
+    agentRunner: async ({ tools }) => {
+      const searchWeb = tools.search_web as ToolLike<
+        { query: string },
+        { results?: unknown[] }
+      >;
+
+      await searchWeb.execute({ query: "OpenAI latest blog" });
+
+      return {
+        rows: [{
+          cells: {
+            entity_name: "OpenAI",
+            latest_post_title: "Invented post",
+            source_url: "https://openai.com/news",
+            evidence_quote: "Invented quote",
+          },
+          sourceUrls: ["https://openai.com/news"],
+          evidence: [{
+            columnName: "latest_post_title",
+            sourceUrl: "https://openai.com/news",
+            quote: "Invented quote",
+          }],
+        }],
+      };
+    },
+  });
+
+  assert.equal(result.rows.length, 0);
+  assert.match(result.validationIssues.join("\n"), /evidence quote not found/);
+  assert.match(result.validationIssues.join("\n"), /returned no rows/);
+});
+
+test("populate runtime prefers insert_row captures over contradictory structured rows", async () => {
+  const result = await runPopulateRuntime({
+    context,
+    webTools: {
+      search: async () => [
+        {
+          title: "OpenAI news",
+          snippet: "Release notes from OpenAI",
+          url: "https://openai.com/news",
+        },
+      ],
+      fetch: async () => ({
+        title: "OpenAI news",
+        text: "Release notes from OpenAI",
+      }),
+    },
+    agentRunner: async ({ tools }) => {
+      const searchWeb = tools.search_web as ToolLike<
+        { query: string },
+        { results?: unknown[] }
+      >;
+      const insertRow = tools.insert_row as ToolLike<
+        { datasetId: string; data: Record<string, unknown> },
+        { success: boolean }
+      >;
+
+      await searchWeb.execute({ query: "OpenAI latest blog" });
+      await insertRow.execute({
+        datasetId: "benchmark-dataset",
+        data: {
+          entity_name: "OpenAI",
+          latest_post_title: "Release notes",
+          source_url: "https://openai.com/news",
+          evidence_quote: "Release notes from OpenAI",
+        },
+      });
+
+      return {
+        rows: [{
+          cells: {
+            entity_name: "Different",
+            latest_post_title: "Release notes",
+            source_url: "https://openai.com/news",
+            evidence_quote: "Release notes from OpenAI",
+          },
+          sourceUrls: ["https://openai.com/news"],
+          evidence: [{
+            columnName: "latest_post_title",
+            sourceUrl: "https://openai.com/news",
+            quote: "Release notes from OpenAI",
+          }],
+        }],
+      };
+    },
+  });
+
+  assert.equal(result.rows.length, 1);
+  assert.equal(result.rows[0]?.cells.entity_name, "OpenAI");
+  assert.match(result.validationIssues.join("\n"), /Structured populate rows differed/);
+});
+
+test("populate runtime uses structured recovery when insert_row rows lack evidence", async () => {
+  const result = await runPopulateRuntime({
+    context,
+    webTools: {
+      search: async () => [
+        {
+          title: "OpenAI news",
+          snippet: "Release notes from OpenAI",
+          url: "https://openai.com/news",
+        },
+      ],
+      fetch: async () => ({
+        title: "OpenAI news",
+        text: "Release notes from OpenAI",
+      }),
+    },
+    agentRunner: async ({ tools }) => {
+      const searchWeb = tools.search_web as ToolLike<
+        { query: string },
+        { results?: unknown[] }
+      >;
+      const fetchPage = tools.fetch_page as ToolLike<
+        { url: string },
+        { text?: string }
+      >;
+      const insertRow = tools.insert_row as ToolLike<
+        { datasetId: string; data: Record<string, unknown> },
+        { success: boolean }
+      >;
+
+      await searchWeb.execute({ query: "OpenAI latest blog" });
+      await fetchPage.execute({ url: "https://openai.com/news" });
+      await insertRow.execute({
+        datasetId: "benchmark-dataset",
+        data: {
+          entity_name: "OpenAI",
+          latest_post_title: "Release notes",
+          source_url: "https://openai.com/news",
+          evidence_quote: "",
+        },
+      });
+
+      return {
+        rows: [{
+          cells: {
+            entity_name: "OpenAI",
+            latest_post_title: "Release notes",
+            source_url: "https://openai.com/news",
+            evidence_quote: "Release notes from OpenAI",
+          },
+          sourceUrls: ["https://openai.com/news"],
+          evidence: [{
+            columnName: "latest_post_title",
+            sourceUrl: "https://openai.com/news",
+            quote: "Release notes from OpenAI",
+          }],
+        }],
+      };
+    },
+  });
+
+  assert.equal(result.rows.length, 1);
+  assert.equal(result.rows[0]?.evidence[0]?.quote, "Release notes from OpenAI");
+  assert.match(
+    result.validationIssues.join("\n"),
+    /Structured row recovery replaced insert_row rows/
+  );
+});
+
 test("populate runtime enforces per-run row cap before inserting", async () => {
   const result = await runPopulateRuntime({
     context,
@@ -131,4 +364,91 @@ test("populate runtime enforces per-run row cap before inserting", async () => {
 
   assert.equal(result.rows.length, 1);
   assert.equal(result.rows[0]?.cells.entity_name, "OpenAI");
+});
+
+test("populate runtime asks for insurance quote inputs without running the agent", async () => {
+  let wasAgentRunnerCalled = false;
+  const result = await runPopulateRuntime({
+    context: {
+      ...context,
+      description:
+        "find me the best car insurance prices in California so I can pick the best bang for my buck",
+    },
+    webTools: {
+      search: async () => {
+        throw new Error("search should not run");
+      },
+      fetch: async () => {
+        throw new Error("fetch should not run");
+      },
+    },
+    agentRunner: async () => {
+      wasAgentRunnerCalled = true;
+    },
+  });
+
+  assert.equal(wasAgentRunnerCalled, false);
+  assert.deepEqual(result.rows, []);
+  assert.equal(result.metrics.agentRuns, 0);
+  assert.equal(result.metrics.searchCalls, 0);
+  assert.equal(result.metrics.fetchCalls, 0);
+  assert.match(result.validationIssues.join(" "), /driver/);
+  assert.match(result.validationIssues.join(" "), /vehicle/);
+  assert.match(result.validationIssues.join(" "), /zip/);
+  assert.match(result.validationIssues.join(" "), /coverage/);
+  assert.match(result.validationIssues.join(" "), /deductible/);
+});
+
+test("populate runtime asks for AI company scope without running the agent", async () => {
+  let wasAgentRunnerCalled = false;
+  const result = await runPopulateRuntime({
+    context: {
+      ...context,
+      description: "get me the latest stuff from the big AI companies",
+    },
+    webTools: {
+      search: async () => {
+        throw new Error("search should not run");
+      },
+      fetch: async () => {
+        throw new Error("fetch should not run");
+      },
+    },
+    agentRunner: async () => {
+      wasAgentRunnerCalled = true;
+    },
+  });
+
+  assert.equal(wasAgentRunnerCalled, false);
+  assert.deepEqual(result.rows, []);
+  assert.equal(result.metrics.agentRuns, 0);
+  assert.equal(result.metrics.searchCalls, 0);
+  assert.equal(result.metrics.fetchCalls, 0);
+  assert.match(result.validationIssues.join(" "), /which companies/);
+  assert.match(result.validationIssues.join(" "), /source type/);
+  assert.match(result.validationIssues.join(" "), /news/);
+  assert.match(result.validationIssues.join(" "), /blog/);
+  assert.match(result.validationIssues.join(" "), /release/);
+  assert.match(result.validationIssues.join(" "), /columns/);
+});
+
+test("populate runtime does not preflight explicit latest blog post requests", async () => {
+  let wasAgentRunnerCalled = false;
+  const result = await runPopulateRuntime({
+    context: {
+      ...context,
+      description:
+        "Can you make me a table of the latest blog posts from OpenAI, Anthropic, and Google DeepMind?",
+    },
+    webTools: {
+      search: async () => [],
+      fetch: async () => ({}),
+    },
+    agentRunner: async () => {
+      wasAgentRunnerCalled = true;
+    },
+  });
+
+  assert.equal(wasAgentRunnerCalled, true);
+  assert.equal(result.metrics.agentRuns, 1);
 });

--- a/backend/test/populate-runtime.test.ts
+++ b/backend/test/populate-runtime.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { runPopulateRuntime } from "../src/pipeline/populate-runtime.js";
+
+interface ToolLike<TInput, TOutput> {
+  execute(input: TInput): Promise<TOutput>;
+}
+
+const context = {
+  datasetId: "benchmark-dataset",
+  datasetName: "benchmark_dataset",
+  description: "Find latest blog posts from OpenAI.",
+  columns: [
+    {
+      name: "entity_name",
+      type: "text" as const,
+      description: "Company name.",
+    },
+    {
+      name: "latest_post_title",
+      type: "text" as const,
+      description: "Latest post title.",
+    },
+    {
+      name: "source_url",
+      type: "url" as const,
+      description: "Source URL.",
+    },
+    {
+      name: "evidence_quote",
+      type: "text" as const,
+      description: "Evidence quote.",
+    },
+  ],
+};
+
+test("populate runtime captures rows through injected tools without Convex writes", async () => {
+  const result = await runPopulateRuntime({
+    context,
+    webTools: {
+      search: async () => [
+        {
+          title: "OpenAI news",
+          snippet: "Release notes",
+          url: "https://openai.com/news",
+        },
+      ],
+      fetch: async () => ({
+        title: "OpenAI news",
+        text: "Release notes",
+      }),
+    },
+    agentRunner: async ({ tools }) => {
+      const searchWeb = tools.search_web as ToolLike<
+        { query: string },
+        { results?: unknown[] }
+      >;
+      const fetchPage = tools.fetch_page as ToolLike<
+        { url: string },
+        { text?: string }
+      >;
+      const insertRow = tools.insert_row as ToolLike<
+        { datasetId: string; data: Record<string, unknown> },
+        { success: boolean }
+      >;
+
+      const search = await searchWeb.execute({ query: "OpenAI latest blog" });
+      assert.equal(search.results?.length, 1);
+      const page = await fetchPage.execute({ url: "https://openai.com/news" });
+      assert.match(page.text ?? "", /Release notes/);
+      const inserted = await insertRow.execute({
+        datasetId: "benchmark-dataset",
+        data: {
+          entity_name: "OpenAI",
+          latest_post_title: "Release notes",
+          source_url: "https://openai.com/news",
+          evidence_quote: "Release notes",
+        },
+      });
+      assert.equal(inserted.success, true);
+    },
+  });
+
+  assert.equal(result.rows.length, 1);
+  assert.equal(result.rows[0]?.cells.entity_name, "OpenAI");
+  assert.deepEqual(result.rows[0]?.sourceUrls, ["https://openai.com/news"]);
+  assert.equal(result.rows[0]?.evidence[0]?.quote, "Release notes");
+  assert.equal(result.metrics.searchCalls, 1);
+  assert.equal(result.metrics.fetchCalls, 1);
+  assert.equal(result.metrics.agentRuns, 1);
+  assert.deepEqual(result.validationIssues, []);
+});
+
+test("populate runtime enforces per-run row cap before inserting", async () => {
+  const result = await runPopulateRuntime({
+    context,
+    maxRows: 1,
+    webTools: {
+      search: async () => [],
+      fetch: async () => ({}),
+    },
+    agentRunner: async ({ tools }) => {
+      const insertRow = tools.insert_row as ToolLike<
+        { datasetId: string; data: Record<string, unknown> },
+        { success: boolean; error?: string }
+      >;
+
+      const first = await insertRow.execute({
+        datasetId: "benchmark-dataset",
+        data: {
+          entity_name: "OpenAI",
+          source_url: "https://openai.com/news",
+          evidence_quote: "Release notes",
+        },
+      });
+      const second = await insertRow.execute({
+        datasetId: "benchmark-dataset",
+        data: {
+          entity_name: "Anthropic",
+          source_url: "https://anthropic.com/news",
+          evidence_quote: "News",
+        },
+      });
+
+      assert.equal(first.success, true);
+      assert.equal(second.success, false);
+      assert.match(second.error ?? "", /Row cap/);
+    },
+  });
+
+  assert.equal(result.rows.length, 1);
+  assert.equal(result.rows[0]?.cells.entity_name, "OpenAI");
+});

--- a/backend/test/populate-self-healing-command.test.ts
+++ b/backend/test/populate-self-healing-command.test.ts
@@ -33,6 +33,74 @@ test("self-healing CLI parses context and dry-run mode", () => {
   });
 });
 
+test("self-healing CLI parses dataset-id mode", () => {
+  assert.deepEqual(parsePopulateSelfHealingCliArgs([
+    "--dataset-id",
+    "dataset-ai-posts",
+    "--commit",
+  ]), {
+    datasetId: "dataset-ai-posts",
+    shouldReadStdin: false,
+    shouldCommitRows: true,
+  });
+});
+
+test("self-healing CLI rejects dataset-id mixed with context input", () => {
+  assert.throws(
+    () => parsePopulateSelfHealingCliArgs([
+      "--dataset-id",
+      "dataset-ai-posts",
+      "--context",
+      "context.json",
+    ]),
+    /Choose exactly one context source/
+  );
+  assert.throws(
+    () => parsePopulateSelfHealingCliArgs([
+      "--context",
+      "context.json",
+      "--dataset-id",
+      "dataset-ai-posts",
+    ]),
+    /Choose exactly one context source/
+  );
+  assert.throws(
+    () => parsePopulateSelfHealingCliArgs([
+      "--dataset-id",
+      "dataset-ai-posts",
+      "--stdin",
+    ]),
+    /Choose exactly one context source/
+  );
+  assert.throws(
+    () => parsePopulateSelfHealingCliArgs([
+      "--stdin",
+      "--dataset-id",
+      "dataset-ai-posts",
+    ]),
+    /Choose exactly one context source/
+  );
+});
+
+test("self-healing CLI rejects context and stdin mixed in any order", () => {
+  assert.throws(
+    () => parsePopulateSelfHealingCliArgs([
+      "--context",
+      "context.json",
+      "--stdin",
+    ]),
+    /Choose exactly one context source/
+  );
+  assert.throws(
+    () => parsePopulateSelfHealingCliArgs([
+      "--stdin",
+      "--context",
+      "context.json",
+    ]),
+    /Choose exactly one context source/
+  );
+});
+
 test("self-healing CLI dry run does not require Convex admin key or create writer", async () => {
   const stdout: string[] = [];
   let runCalls = 0;
@@ -68,6 +136,144 @@ test("self-healing CLI dry run does not require Convex admin key or create write
   assert.equal(output.success, true);
   assert.equal(output.dryRun, true);
   assert.equal(output.rowCount, 1);
+});
+
+test("self-healing CLI dataset-id dry run loads context before running", async () => {
+  const stdout: string[] = [];
+  let loadedDatasetId = "";
+  let didReadFile = false;
+  const exitCode = await runPopulateSelfHealingCli({
+    argv: ["--dataset-id", "dataset-ai-posts"],
+    env: {
+      CONVEX_URL: "http://convex:3210",
+      CONVEX_SELF_HOSTED_ADMIN_KEY: "convex-admin",
+      OPENROUTER_API_KEY: "openrouter",
+      TINYFISH_API_KEY: "tinyfish",
+    },
+    readFileText: async () => {
+      didReadFile = true;
+      return JSON.stringify(context);
+    },
+    loadDatasetContextById: async (datasetId) => {
+      loadedDatasetId = datasetId;
+      return context;
+    },
+    writeStdout: (text) => stdout.push(text),
+    writeStderr: () => undefined,
+    runSelfHealing: async (input) => {
+      assert.equal(input.context.datasetId, context.datasetId);
+      assert.equal(input.shouldCommitRows, false);
+      assert.ok(input.store);
+      assert.equal(input.rowWriter, undefined);
+      return successfulResult(input.context.datasetId);
+    },
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(loadedDatasetId, "dataset-ai-posts");
+  assert.equal(didReadFile, false);
+  assert.equal(JSON.parse(stdout[0]!).success, true);
+});
+
+test("self-healing CLI dataset-id commit loads context and creates writer", async () => {
+  const stdout: string[] = [];
+  let writerCalls = 0;
+  const exitCode = await runPopulateSelfHealingCli({
+    argv: ["--dataset-id", "dataset-ai-posts", "--commit"],
+    env: {
+      CONVEX_URL: "http://convex:3210",
+      CONVEX_SELF_HOSTED_ADMIN_KEY: "convex-admin",
+      OPENROUTER_API_KEY: "openrouter",
+      TINYFISH_API_KEY: "tinyfish",
+      POPULATE_RECIPE_STORE_DIR: ".bigset/populate-recipes",
+    },
+    loadDatasetContextById: async (datasetId) => ({
+      ...context,
+      datasetId,
+    }),
+    createRowWriter: async () => {
+      writerCalls += 1;
+      return {
+        async replaceRows() {
+          return { insertedRowCount: 1 };
+        },
+      };
+    },
+    writeStdout: (text) => stdout.push(text),
+    writeStderr: () => undefined,
+    runSelfHealing: async (input) => {
+      assert.equal(input.context.datasetId, "dataset-ai-posts");
+      assert.equal(input.shouldCommitRows, true);
+      assert.equal(input.store, undefined);
+      assert.equal(input.recipeStoreDirectory, ".bigset/populate-recipes");
+      assert.ok(input.rowWriter);
+      return successfulResult(input.context.datasetId);
+    },
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(writerCalls, 1);
+  assert.equal(JSON.parse(stdout[0]!).success, true);
+});
+
+test("self-healing CLI dataset-id mode preflights Convex keys before loading context", async () => {
+  const stdout: string[] = [];
+  let loadCalls = 0;
+  const exitCode = await runPopulateSelfHealingCli({
+    argv: ["--dataset-id", "dataset-ai-posts"],
+    env: {
+      OPENROUTER_API_KEY: "openrouter",
+      TINYFISH_API_KEY: "tinyfish",
+    },
+    loadDatasetContextById: async () => {
+      loadCalls += 1;
+      return context;
+    },
+    writeStdout: (text) => stdout.push(text),
+    writeStderr: () => undefined,
+  });
+
+  assert.equal(exitCode, 1);
+  assert.equal(loadCalls, 0);
+  assert.match(stdout[0]!, /CONVEX_URL/);
+  assert.match(stdout[0]!, /CONVEX_SELF_HOSTED_ADMIN_KEY/);
+});
+
+test("self-healing CLI dataset-id loader failures skip runtime and writer", async () => {
+  const stdout: string[] = [];
+  let runCalls = 0;
+  let writerCalls = 0;
+  const exitCode = await runPopulateSelfHealingCli({
+    argv: ["--dataset-id", "not-a-convex-id", "--commit"],
+    env: {
+      CONVEX_URL: "http://convex:3210",
+      CONVEX_SELF_HOSTED_ADMIN_KEY: "convex-admin",
+      OPENROUTER_API_KEY: "openrouter",
+      TINYFISH_API_KEY: "tinyfish",
+    },
+    loadDatasetContextById: async () => {
+      throw new Error("Invalid dataset id: not-a-convex-id.");
+    },
+    createRowWriter: async () => {
+      writerCalls += 1;
+      return {
+        async replaceRows() {
+          return { insertedRowCount: 0 };
+        },
+      };
+    },
+    writeStdout: (text) => stdout.push(text),
+    writeStderr: () => undefined,
+    runSelfHealing: async () => {
+      runCalls += 1;
+      throw new Error("runtime should not run");
+    },
+  });
+
+  assert.equal(exitCode, 1);
+  assert.equal(runCalls, 0);
+  assert.equal(writerCalls, 0);
+  assert.match(stdout[0]!, /Invalid dataset id/);
 });
 
 test("self-healing CLI rejects durable recipe store on dry run", async () => {

--- a/backend/test/populate-self-healing-command.test.ts
+++ b/backend/test/populate-self-healing-command.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import type { DatasetContext } from "../src/pipeline/populate.js";
+import type { PopulateRecipeRuntime } from "../src/pipeline/populate-self-healing.js";
 import type { RunSelfHealingPopulateResult } from "../src/pipeline/populate-self-healing-runner.js";
 import {
   parsePopulateSelfHealingCliArgs,
@@ -136,6 +137,38 @@ test("self-healing CLI dry run does not require Convex admin key or create write
   assert.equal(output.success, true);
   assert.equal(output.dryRun, true);
   assert.equal(output.rowCount, 1);
+});
+
+test("self-healing CLI passes selected runtime into the runner", async () => {
+  const stdout: string[] = [];
+  const selectedRuntime = fakeRuntime();
+  let createRuntimeCalls = 0;
+  let didUseSelectedRuntime = false;
+  const exitCode = await runPopulateSelfHealingCli({
+    argv: ["--context", "context.json"],
+    env: {
+      OPENROUTER_API_KEY: "openrouter",
+      TINYFISH_API_KEY: "tinyfish",
+      POPULATE_AGENT_RUNTIME: "collection",
+    },
+    readFileText: async () => JSON.stringify(context),
+    writeStdout: (text) => stdout.push(text),
+    writeStderr: () => undefined,
+    createRuntime: async (input) => {
+      createRuntimeCalls += 1;
+      assert.equal(input.env.POPULATE_AGENT_RUNTIME, "collection");
+      return selectedRuntime;
+    },
+    runSelfHealing: async (input) => {
+      didUseSelectedRuntime = input.runtime === selectedRuntime;
+      return successfulResult(input.context.datasetId);
+    },
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(createRuntimeCalls, 1);
+  assert.equal(didUseSelectedRuntime, true);
+  assert.equal(JSON.parse(stdout[0]!).success, true);
 });
 
 test("self-healing CLI dataset-id dry run loads context before running", async () => {
@@ -460,5 +493,13 @@ function baseRun(datasetId: string): RunSelfHealingPopulateResult["selectedRun"]
       warnings: [],
     },
     artifacts: [],
+  };
+}
+
+function fakeRuntime(): PopulateRecipeRuntime {
+  return {
+    async runRecipe() {
+      throw new Error("fake runtime should not execute in CLI unit tests");
+    },
   };
 }

--- a/backend/test/populate-self-healing-command.test.ts
+++ b/backend/test/populate-self-healing-command.test.ts
@@ -1,0 +1,258 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { DatasetContext } from "../src/pipeline/populate.js";
+import type { RunSelfHealingPopulateResult } from "../src/pipeline/populate-self-healing-runner.js";
+import {
+  parsePopulateSelfHealingCliArgs,
+  runPopulateSelfHealingCli,
+} from "../src/pipeline/populate-self-healing-command.js";
+
+const context: DatasetContext = {
+  datasetId: "dataset-ai-posts",
+  datasetName: "AI posts",
+  description: "Find latest blog posts from OpenAI.",
+  columns: [{
+    name: "entity_name",
+    type: "text",
+    description: "Company name.",
+  }],
+};
+
+test("self-healing CLI parses context and dry-run mode", () => {
+  assert.deepEqual(parsePopulateSelfHealingCliArgs([
+    "--context",
+    "context.json",
+    "--max-rows",
+    "3",
+  ]), {
+    contextPath: "context.json",
+    shouldReadStdin: false,
+    shouldCommitRows: false,
+    maxRows: 3,
+  });
+});
+
+test("self-healing CLI dry run does not require Convex admin key or create writer", async () => {
+  const stdout: string[] = [];
+  let runCalls = 0;
+  let writerCalls = 0;
+  const exitCode = await runPopulateSelfHealingCli({
+    argv: ["--context", "context.json"],
+    env: {
+      OPENROUTER_API_KEY: "openrouter",
+      TINYFISH_API_KEY: "tinyfish",
+    },
+    readFileText: async () => JSON.stringify(context),
+    writeStdout: (text) => stdout.push(text),
+    writeStderr: () => undefined,
+    createRowWriter: async () => {
+      writerCalls += 1;
+      throw new Error("writer should not be created");
+    },
+    runSelfHealing: async (input) => {
+      runCalls += 1;
+      assert.equal(input.shouldCommitRows, false);
+      assert.equal(input.rowWriter, undefined);
+      assert.equal(input.recipeStoreDirectory, undefined);
+      assert.ok(input.store);
+      return successfulResult(input.context.datasetId);
+    },
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(runCalls, 1);
+  assert.equal(writerCalls, 0);
+  assert.equal(stdout.length, 1);
+  const output = JSON.parse(stdout[0]!);
+  assert.equal(output.success, true);
+  assert.equal(output.dryRun, true);
+  assert.equal(output.rowCount, 1);
+});
+
+test("self-healing CLI rejects durable recipe store on dry run", async () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  let didReadContext = false;
+  const exitCode = await runPopulateSelfHealingCli({
+    argv: [
+      "--stdin",
+      "--recipe-store-dir",
+      ".bigset/test-recipes",
+    ],
+    env: {
+      OPENROUTER_API_KEY: "openrouter",
+      TINYFISH_API_KEY: "tinyfish",
+    },
+    readStdinText: async () => {
+      didReadContext = true;
+      return JSON.stringify(context);
+    },
+    writeStdout: (text) => stdout.push(text),
+    writeStderr: (text) => stderr.push(text),
+    runSelfHealing: async () => {
+      throw new Error("runtime should not run");
+    },
+  });
+
+  assert.equal(exitCode, 1);
+  assert.equal(didReadContext, false);
+  assert.equal(stdout.length, 1);
+  assert.match(stdout[0]!, /--recipe-store-dir requires --commit/);
+  assert.match(stderr.join("\n"), /--recipe-store-dir requires --commit/);
+});
+
+test("self-healing CLI commit mode preflights missing Convex key before runtime", async () => {
+  const stdout: string[] = [];
+  let runCalls = 0;
+  const exitCode = await runPopulateSelfHealingCli({
+    argv: ["--context", "context.json", "--commit"],
+    env: {
+      OPENROUTER_API_KEY: "openrouter",
+      TINYFISH_API_KEY: "tinyfish",
+    },
+    readFileText: async () => JSON.stringify(context),
+    writeStdout: (text) => stdout.push(text),
+    writeStderr: () => undefined,
+    runSelfHealing: async () => {
+      runCalls += 1;
+      throw new Error("runtime should not run");
+    },
+  });
+
+  assert.equal(exitCode, 1);
+  assert.equal(runCalls, 0);
+  assert.equal(stdout.length, 1);
+  assert.match(stdout[0]!, /CONVEX_SELF_HOSTED_ADMIN_KEY/);
+});
+
+test("self-healing CLI exits 2 when tick rejects candidate", async () => {
+  const stdout: string[] = [];
+  const exitCode = await runPopulateSelfHealingCli({
+    argv: ["--stdin"],
+    env: {
+      OPENROUTER_API_KEY: "openrouter",
+      TINYFISH_API_KEY: "tinyfish",
+    },
+    readStdinText: async () => JSON.stringify(context),
+    writeStdout: (text) => stdout.push(text),
+    writeStderr: () => undefined,
+    runSelfHealing: async (input) => rejectedResult(input.context.datasetId),
+  });
+
+  assert.equal(exitCode, 2);
+  assert.equal(stdout.length, 1);
+  const output = JSON.parse(stdout[0]!);
+  assert.equal(output.success, false);
+  assert.equal(output.action, "candidate_rejected");
+  assert.match(output.validationIssues.join("\n"), /Still no evidence/);
+});
+
+test("self-healing CLI reports malformed context JSON as one stdout object", async () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const exitCode = await runPopulateSelfHealingCli({
+    argv: ["--context", "context.json"],
+    env: {
+      OPENROUTER_API_KEY: "openrouter",
+      TINYFISH_API_KEY: "tinyfish",
+    },
+    readFileText: async () => "{ nope",
+    writeStdout: (text) => stdout.push(text),
+    writeStderr: (text) => stderr.push(text),
+  });
+
+  assert.equal(exitCode, 1);
+  assert.equal(stdout.length, 1);
+  assert.equal(JSON.parse(stdout[0]!).success, false);
+  assert.match(stderr.join("\n"), /JSON/);
+});
+
+function successfulResult(datasetId: string): RunSelfHealingPopulateResult {
+  return {
+    success: true,
+    action: "generated_initial_recipe",
+    datasetId,
+    selectedRun: {
+      ...baseRun(datasetId),
+      rows: [{
+        cells: { entity_name: "OpenAI" },
+        sourceUrls: ["https://openai.com/news"],
+        evidence: [{
+          columnName: "entity_name",
+          sourceUrl: "https://openai.com/news",
+          quote: "OpenAI",
+        }],
+        needsReview: true,
+      }],
+    },
+    rejectionReasons: [],
+    validationIssues: [],
+    tick: {
+      datasetId,
+      action: "generated_initial_recipe",
+      rejectionReasons: [],
+    },
+  };
+}
+
+function rejectedResult(datasetId: string): RunSelfHealingPopulateResult {
+  return {
+    success: false,
+    action: "candidate_rejected",
+    datasetId,
+    diagnosticRun: {
+      ...baseRun(datasetId),
+      runStatus: "failed",
+      validationIssues: ["Still no evidence."],
+      productionValidation: {
+        ...baseRun(datasetId).productionValidation,
+        isValid: false,
+        score: 0,
+        criticalIssues: ["Still no evidence."],
+      },
+    },
+    rejectionReasons: ["Still no evidence."],
+    validationIssues: ["Still no evidence."],
+    tick: {
+      datasetId,
+      action: "candidate_rejected",
+      rejectionReasons: ["Still no evidence."],
+    },
+  };
+}
+
+function baseRun(datasetId: string): RunSelfHealingPopulateResult["selectedRun"] {
+  return {
+    rows: [],
+    validationIssues: [],
+    usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+    metrics: {
+      searchCalls: 0,
+      fetchCalls: 0,
+      browserCalls: 0,
+      agentRuns: 0,
+      agentSteps: 0,
+    },
+    recipeId: `${datasetId}-recipe-v1`,
+    recipeVersion: 1,
+    runStatus: "succeeded",
+    startedAt: "2026-05-22T00:00:00.000Z",
+    completedAt: "2026-05-22T00:00:01.000Z",
+    runtimeMs: 1_000,
+    productionValidation: {
+      isValid: true,
+      score: 1,
+      rowCount: 1,
+      requestedCellCompletenessRatio: 1,
+      sourceUrlCoverageRatio: 1,
+      evidenceCoverageRatio: 1,
+      expectedEntityCoverageRatio: 1,
+      expectedEntities: [],
+      missingExpectedEntities: [],
+      criticalIssues: [],
+      warnings: [],
+    },
+    artifacts: [],
+  };
+}

--- a/backend/test/populate-self-healing-runner.test.ts
+++ b/backend/test/populate-self-healing-runner.test.ts
@@ -1,0 +1,365 @@
+import assert from "node:assert/strict";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import type { DatasetContext } from "../src/pipeline/populate.js";
+import {
+  createPopulateRecipe,
+  FileSystemPopulateRecipeStore,
+  InMemoryPopulateRecipeStore,
+  type PopulateRecipe,
+  type PopulateRecipeAuthor,
+  type PopulateRecipeRunResult,
+  type PopulateRecipeRuntime,
+  type SelfHealingPopulateTickResult,
+} from "../src/pipeline/populate-self-healing.js";
+import {
+  diagnosticRunForTick,
+  runSelfHealingPopulate,
+  validationIssuesForSelfHealingTick,
+  type PopulateDatasetRowWriter,
+} from "../src/pipeline/populate-self-healing-runner.js";
+
+const context: DatasetContext = {
+  datasetId: "dataset-ai-posts",
+  datasetName: "AI posts",
+  description: "Find latest blog posts from OpenAI.",
+  columns: [
+    {
+      name: "entity_name",
+      type: "text",
+      description: "Company name.",
+    },
+    {
+      name: "latest_post_title",
+      type: "text",
+      description: "Post title.",
+    },
+    {
+      name: "source_url",
+      type: "url",
+      description: "Source URL.",
+    },
+    {
+      name: "evidence_quote",
+      type: "text",
+      description: "Evidence quote.",
+    },
+  ],
+};
+
+test("self-healing runner commits rows only after a successful tick", async () => {
+  const store = new InMemoryPopulateRecipeStore();
+  const generatedRecipe = recipe({ recipeId: "generated-v1" });
+  const writer = new FakePopulateDatasetRowWriter();
+
+  const result = await runSelfHealingPopulate({
+    context,
+    store,
+    runtime: new FakePopulateRecipeRuntime({
+      "generated-v1": validRun(generatedRecipe),
+    }),
+    author: new FakeRecipeAuthor({ generatedRecipe }),
+    rowWriter: writer,
+    shouldCommitRows: true,
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.action, "generated_initial_recipe");
+  assert.equal(result.committedRows?.insertedRowCount, 1);
+  assert.equal(writer.replaceCalls.length, 1);
+  assert.equal(writer.replaceCalls[0]?.datasetId, context.datasetId);
+  assert.equal(writer.replaceCalls[0]?.rows[0]?.cells.entity_name, "OpenAI");
+});
+
+test("self-healing runner requires a row writer before runtime work when committing", async () => {
+  let runtimeCalls = 0;
+
+  await assert.rejects(
+    runSelfHealingPopulate({
+      context,
+      runtime: {
+        async runRecipe(input) {
+          runtimeCalls += 1;
+          return validRun(input.recipe);
+        },
+      },
+      author: new FakeRecipeAuthor({
+        generatedRecipe: recipe({ recipeId: "generated-v1" }),
+      }),
+      shouldCommitRows: true,
+    }),
+    /rowWriter is required/
+  );
+
+  assert.equal(runtimeCalls, 0);
+});
+
+test("self-healing runner commits healthy active reruns", async () => {
+  const store = new InMemoryPopulateRecipeStore();
+  const activeRecipe = recipe({ recipeId: "active-v1", status: "active" });
+  const writer = new FakePopulateDatasetRowWriter();
+  await store.saveRecipe(activeRecipe);
+
+  const result = await runSelfHealingPopulate({
+    context,
+    store,
+    runtime: new FakePopulateRecipeRuntime({
+      "active-v1": validRun(activeRecipe),
+    }),
+    author: new FakeRecipeAuthor(),
+    rowWriter: writer,
+    shouldCommitRows: true,
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.action, "active_rerun_succeeded");
+  assert.equal(result.selectedRun?.recipeId, "active-v1");
+  assert.equal(writer.replaceCalls.length, 1);
+});
+
+test("self-healing runner commits promoted repair candidate rows", async () => {
+  const store = new InMemoryPopulateRecipeStore();
+  const activeRecipe = recipe({ recipeId: "active-broken", status: "active" });
+  const repairedRecipe = recipe({ recipeId: "repair-v2", version: 2 });
+  const writer = new FakePopulateDatasetRowWriter();
+  await store.saveRecipe(activeRecipe);
+
+  const result = await runSelfHealingPopulate({
+    context,
+    store,
+    runtime: new FakePopulateRecipeRuntime({
+      "active-broken": invalidRun(activeRecipe, "No source-backed rows."),
+      "repair-v2": validRun(repairedRecipe),
+    }),
+    author: new FakeRecipeAuthor({ repairedRecipe }),
+    rowWriter: writer,
+    shouldCommitRows: true,
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.action, "repaired_active_recipe");
+  assert.equal(result.selectedRun?.recipeId, "repair-v2");
+  assert.equal(writer.replaceCalls.length, 1);
+});
+
+test("self-healing runner does not clear or insert rows when candidate is rejected", async () => {
+  const store = new InMemoryPopulateRecipeStore();
+  const activeRecipe = recipe({ recipeId: "active-broken", status: "active" });
+  const rejectedRecipe = recipe({ recipeId: "repair-v2", version: 2 });
+  const writer = new FakePopulateDatasetRowWriter();
+  await store.saveRecipe(activeRecipe);
+
+  const result = await runSelfHealingPopulate({
+    context,
+    store,
+    runtime: new FakePopulateRecipeRuntime({
+      "active-broken": invalidRun(activeRecipe, "No source-backed rows."),
+      "repair-v2": invalidRun(rejectedRecipe, "Still no evidence."),
+    }),
+    author: new FakeRecipeAuthor({ repairedRecipe: rejectedRecipe }),
+    rowWriter: writer,
+    shouldCommitRows: true,
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.action, "candidate_rejected");
+  assert.equal(result.selectedRun, undefined);
+  assert.equal(result.diagnosticRun?.recipeId, "repair-v2");
+  assert.equal(result.committedRows, undefined);
+  assert.equal(writer.replaceCalls.length, 0);
+  assert.match(result.validationIssues.join("\n"), /Still no evidence/);
+});
+
+test("filesystem store lets the runner reuse an active recipe across calls", async () => {
+  const rootDirectory = await mkdtemp(join(tmpdir(), "bigset-populate-runner-"));
+  const store = new FileSystemPopulateRecipeStore(rootDirectory);
+  const generatedRecipe = recipe({ recipeId: "generated-v1" });
+  const writer = new FakePopulateDatasetRowWriter();
+  const runtime = new FakePopulateRecipeRuntime({
+    "generated-v1": validRun(generatedRecipe),
+  });
+  const author = new FakeRecipeAuthor({ generatedRecipe });
+
+  const first = await runSelfHealingPopulate({
+    context,
+    store,
+    runtime,
+    author,
+    rowWriter: writer,
+    shouldCommitRows: true,
+  });
+  const second = await runSelfHealingPopulate({
+    context,
+    store: new FileSystemPopulateRecipeStore(rootDirectory),
+    runtime,
+    author,
+    rowWriter: writer,
+    shouldCommitRows: true,
+  });
+
+  assert.equal(first.action, "generated_initial_recipe");
+  assert.equal(second.action, "active_rerun_succeeded");
+  assert.equal(author.generateCalls, 1);
+  assert.equal(writer.replaceCalls.length, 2);
+});
+
+test("self-healing tick diagnostics expose rejected candidate validation issues", () => {
+  const candidateRecipe = recipe({ recipeId: "repair-v2", version: 2 });
+  const candidateRun = invalidRun(candidateRecipe, "Missing expected entities: Anthropic.");
+  const tick: SelfHealingPopulateTickResult = {
+    datasetId: context.datasetId,
+    action: "candidate_rejected",
+    candidateRecipe,
+    candidateRun,
+    rejectionReasons: ["Candidate validation score is below the active recipe baseline."],
+  };
+
+  assert.equal(diagnosticRunForTick(tick)?.recipeId, "repair-v2");
+  assert.deepEqual(validationIssuesForSelfHealingTick(tick), [
+    "Missing expected entities: Anthropic.",
+    "Candidate validation score is below the active recipe baseline.",
+  ]);
+});
+
+function recipe(input: {
+  recipeId: string;
+  version?: number;
+  status?: PopulateRecipe["status"];
+}): PopulateRecipe {
+  return createPopulateRecipe({
+    recipeId: input.recipeId,
+    datasetId: context.datasetId,
+    version: input.version ?? 1,
+    status: input.status,
+    sourceDescription: context.description,
+    requestedColumns: context.columns.map((column) => column.name),
+    createdAt: "2026-05-22T00:00:00.000Z",
+  });
+}
+
+function validRun(recipe: PopulateRecipe): PopulateRecipeRunResult {
+  return runResult({
+    recipe,
+    rows: [{
+      cells: {
+        entity_name: "OpenAI",
+        latest_post_title: "Release notes from OpenAI",
+        source_url: "https://openai.com/news",
+        evidence_quote: "Release notes from OpenAI",
+      },
+      sourceUrls: ["https://openai.com/news"],
+      evidence: [{
+        columnName: "latest_post_title",
+        sourceUrl: "https://openai.com/news",
+        quote: "Release notes from OpenAI",
+      }],
+      needsReview: true,
+    }],
+    isValid: true,
+    score: 1,
+  });
+}
+
+function invalidRun(recipe: PopulateRecipe, issue: string): PopulateRecipeRunResult {
+  return runResult({
+    recipe,
+    rows: [],
+    validationIssues: [issue],
+    criticalIssues: [issue],
+    isValid: false,
+    score: 0,
+  });
+}
+
+function runResult(input: {
+  recipe: PopulateRecipe;
+  rows: PopulateRecipeRunResult["rows"];
+  validationIssues?: string[];
+  criticalIssues?: string[];
+  isValid: boolean;
+  score: number;
+}): PopulateRecipeRunResult {
+  return {
+    rows: input.rows,
+    validationIssues: input.validationIssues ?? [],
+    usage: {
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+    },
+    metrics: {
+      searchCalls: 0,
+      fetchCalls: 0,
+      browserCalls: 0,
+      agentRuns: 0,
+      agentSteps: 0,
+    },
+    recipeId: input.recipe.recipeId,
+    recipeVersion: input.recipe.version,
+    runStatus: input.isValid ? "succeeded" : "failed",
+    startedAt: "2026-05-22T00:00:00.000Z",
+    completedAt: "2026-05-22T00:00:01.000Z",
+    runtimeMs: 1_000,
+    productionValidation: {
+      isValid: input.isValid,
+      score: input.score,
+      rowCount: input.rows.length,
+      requestedCellCompletenessRatio: input.score,
+      sourceUrlCoverageRatio: input.score,
+      evidenceCoverageRatio: input.score,
+      expectedEntityCoverageRatio: input.score,
+      expectedEntities: [],
+      missingExpectedEntities: [],
+      criticalIssues: input.criticalIssues ?? [],
+      warnings: input.validationIssues ?? [],
+    },
+    artifacts: [],
+  };
+}
+
+class FakePopulateRecipeRuntime implements PopulateRecipeRuntime {
+  constructor(private readonly runsByRecipeId: Record<string, PopulateRecipeRunResult>) {}
+
+  async runRecipe(input: {
+    recipe: PopulateRecipe;
+    context: DatasetContext;
+  }): Promise<PopulateRecipeRunResult> {
+    return this.runsByRecipeId[input.recipe.recipeId] ??
+      invalidRun(input.recipe, `Missing fake run for ${input.recipe.recipeId}.`);
+  }
+}
+
+class FakeRecipeAuthor implements PopulateRecipeAuthor {
+  generateCalls = 0;
+
+  constructor(
+    private readonly recipes: {
+      generatedRecipe?: PopulateRecipe;
+      repairedRecipe?: PopulateRecipe;
+    } = {}
+  ) {}
+
+  async generateRecipe(): Promise<PopulateRecipe> {
+    this.generateCalls += 1;
+    return this.recipes.generatedRecipe ?? recipe({ recipeId: "generated-v1" });
+  }
+
+  async repairRecipe(): Promise<PopulateRecipe> {
+    return this.recipes.repairedRecipe ?? recipe({ recipeId: "repair-v2", version: 2 });
+  }
+}
+
+class FakePopulateDatasetRowWriter implements PopulateDatasetRowWriter {
+  readonly replaceCalls: Array<Parameters<PopulateDatasetRowWriter["replaceRows"]>[0]> = [];
+
+  async replaceRows(input: Parameters<PopulateDatasetRowWriter["replaceRows"]>[0]) {
+    this.replaceCalls.push(input);
+    return {
+      clearedRowCount: 7,
+      insertedRowCount: input.rows.length,
+    };
+  }
+}

--- a/backend/test/populate-self-healing.test.ts
+++ b/backend/test/populate-self-healing.test.ts
@@ -1,0 +1,556 @@
+import assert from "node:assert/strict";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import {
+  createPopulateRecipe,
+  FileSystemPopulateRecipeStore,
+  InMemoryPopulateRecipeStore,
+  MastraPopulateRecipeRuntime,
+  SelfHealingPopulateRecipeService,
+} from "../src/pipeline/populate-self-healing.js";
+import type {
+  PopulateRecipe,
+  PopulateRecipeAuthor,
+  PopulateRecipeRunResult,
+  PopulateRecipeRuntime,
+} from "../src/pipeline/populate-self-healing.js";
+import type { DatasetContext } from "../src/pipeline/populate.js";
+
+const context: DatasetContext = {
+  datasetId: "dataset-ai-posts",
+  datasetName: "AI posts",
+  description: "Find latest blog posts from OpenAI.",
+  columns: [
+    {
+      name: "entity_name",
+      type: "text",
+      description: "Company name.",
+    },
+    {
+      name: "latest_post_title",
+      type: "text",
+      description: "Post title.",
+    },
+    {
+      name: "source_url",
+      type: "url",
+      description: "Source URL.",
+    },
+    {
+      name: "evidence_quote",
+      type: "text",
+      description: "Evidence quote.",
+    },
+  ],
+};
+
+test("Mastra populate recipe runtime maps populate rows into a healthy recipe run", async () => {
+  let promptText = "";
+  const runtime = new MastraPopulateRecipeRuntime({
+    webTools: {
+      search: async () => [
+        {
+          title: "OpenAI news",
+          snippet: "Release notes from OpenAI",
+          url: "https://openai.com/news",
+        },
+      ],
+      fetch: async () => ({
+        title: "OpenAI news",
+        text: "Release notes from OpenAI",
+      }),
+    },
+    agentRunner: async ({ prompt, tools }) => {
+      promptText = prompt;
+      const searchWeb = tools.search_web as ToolLike<
+        { query: string },
+        { results?: unknown[] }
+      >;
+      const fetchPage = tools.fetch_page as ToolLike<
+        { url: string },
+        { text?: string }
+      >;
+      const insertRow = tools.insert_row as ToolLike<
+        { datasetId: string; data: Record<string, unknown> },
+        { success: boolean }
+      >;
+      await searchWeb.execute({ query: "OpenAI latest blog" });
+      await fetchPage.execute({ url: "https://openai.com/news" });
+      await insertRow.execute({
+        datasetId: context.datasetId,
+        data: {
+          entity_name: "OpenAI",
+          latest_post_title: "Release notes from OpenAI",
+          source_url: "https://openai.com/news",
+          evidence_quote: "Release notes from OpenAI",
+        },
+      });
+    },
+  });
+
+  const run = await runtime.runRecipe({
+    recipe: recipe({
+      recipeId: "recipe-v1",
+      runtimeInstructions: "Prefer official news pages already known to work.",
+    }),
+    context,
+  });
+
+  assert.match(promptText, /Durable recipe instructions/);
+  assert.equal(run.runStatus, "succeeded");
+  assert.equal(run.productionValidation.isValid, true);
+  assert.equal(run.productionValidation.score, 1);
+  assert.equal(run.recipeId, "recipe-v1");
+  assert.equal(run.rows[0]?.cells.entity_name, "OpenAI");
+  assert.equal(run.debug?.selectedRowSource, "insert_row");
+  assert.ok(run.artifacts.some((artifact) => artifact.kind === "source-transcript"));
+  assert.ok(run.artifacts.some((artifact) => artifact.kind === "captured-rows"));
+});
+
+test("Mastra populate recipe runtime keeps supplemental fetch misses non-blocking", async () => {
+  const runtime = new MastraPopulateRecipeRuntime({
+    runPopulate: async () => ({
+      rows: validRows(),
+      validationIssues: [
+        "Structured fallback fetch failed for https://example.com/noise: timeout",
+      ],
+      usage: emptyUsage(),
+      metrics: emptyMetrics(),
+    }),
+  });
+
+  const run = await runtime.runRecipe({
+    recipe: recipe({ recipeId: "recipe-v1" }),
+    context,
+  });
+
+  assert.equal(run.runStatus, "succeeded");
+  assert.equal(run.productionValidation.isValid, true);
+  assert.deepEqual(run.productionValidation.criticalIssues, []);
+  assert.match(run.productionValidation.warnings.join("\n"), /timeout/);
+});
+
+test("Mastra populate recipe runtime blocks missing expected entities", async () => {
+  const runtime = new MastraPopulateRecipeRuntime({
+    runPopulate: async () => ({
+      rows: [{
+        ...validRows()[0]!,
+        cells: {
+          ...validRows()[0]!.cells,
+          latest_post_title:
+            "OpenAI roundtable mentions Anthropic and Google DeepMind",
+          evidence_quote:
+            "OpenAI discussed Anthropic and Google DeepMind in passing.",
+        },
+        evidence: [{
+          columnName: "latest_post_title",
+          sourceUrl: "https://openai.com/news",
+          quote: "OpenAI discussed Anthropic and Google DeepMind in passing.",
+        }],
+      }],
+      validationIssues: [],
+      usage: emptyUsage(),
+      metrics: emptyMetrics(),
+    }),
+  });
+
+  const run = await runtime.runRecipe({
+    recipe: recipe({ recipeId: "recipe-v1" }),
+    context: {
+      ...context,
+      description:
+        "Find latest blog posts from OpenAI, Anthropic, and Google DeepMind.",
+    },
+  });
+
+  assert.equal(run.runStatus, "failed");
+  assert.equal(run.productionValidation.isValid, false);
+  assert.deepEqual(run.productionValidation.expectedEntities, [
+    "OpenAI",
+    "Anthropic",
+    "Google DeepMind",
+  ]);
+  assert.deepEqual(run.productionValidation.missingExpectedEntities, [
+    "Anthropic",
+    "Google DeepMind",
+  ]);
+  assert.match(
+    run.productionValidation.criticalIssues.join("\n"),
+    /Missing expected entities/
+  );
+});
+
+test("self-healing service reruns a healthy active recipe without author repair", async () => {
+  const store = new InMemoryPopulateRecipeStore();
+  const activeRecipe = recipe({ recipeId: "active-v1", status: "active" });
+  await store.saveRecipe(activeRecipe);
+  const author = new FakeRecipeAuthor();
+  const service = new SelfHealingPopulateRecipeService({
+    store,
+    runtime: new FakePopulateRecipeRuntime({
+      "active-v1": validRun(activeRecipe),
+    }),
+    author,
+  });
+
+  const result = await service.tick({ datasetId: context.datasetId, context });
+
+  assert.equal(result.action, "active_rerun_succeeded");
+  assert.equal(author.generateCalls, 0);
+  assert.equal(author.repairCalls, 0);
+  assert.equal(result.activeRecipe?.status, "active");
+  assert.equal(result.activeRecipe?.lastValidationScore, 1);
+});
+
+test("self-healing service generates and activates the first valid recipe", async () => {
+  const store = new InMemoryPopulateRecipeStore();
+  const generatedRecipe = recipe({ recipeId: "generated-v1" });
+  const service = new SelfHealingPopulateRecipeService({
+    store,
+    runtime: new FakePopulateRecipeRuntime({
+      "generated-v1": validRun(generatedRecipe),
+    }),
+    author: new FakeRecipeAuthor({ generatedRecipe }),
+  });
+
+  const result = await service.tick({ datasetId: context.datasetId, context });
+  const snapshot = await store.loadSnapshot(context.datasetId);
+
+  assert.equal(result.action, "generated_initial_recipe");
+  assert.equal(result.activeRecipe?.recipeId, "generated-v1");
+  assert.equal(snapshot.recipes[0]?.status, "active");
+  assert.equal(snapshot.runRecords.length, 1);
+});
+
+test("self-healing service normalizes author recipe metadata before storing", async () => {
+  const store = new InMemoryPopulateRecipeStore();
+  const generatedRecipe = createPopulateRecipe({
+    recipeId: "generated-v1",
+    datasetId: "wrong-dataset",
+    version: 99,
+    status: "active",
+    sourceDescription: "wrong prompt",
+    requestedColumns: ["wrong_column"],
+  });
+  const service = new SelfHealingPopulateRecipeService({
+    store,
+    runtime: new FakePopulateRecipeRuntime({
+      "generated-v1": validRun({
+        ...generatedRecipe,
+        datasetId: context.datasetId,
+        version: 1,
+        status: "candidate",
+      }),
+    }),
+    author: new FakeRecipeAuthor({ generatedRecipe }),
+  });
+
+  const result = await service.tick({ datasetId: context.datasetId, context });
+  const snapshot = await store.loadSnapshot(context.datasetId);
+
+  assert.equal(result.action, "generated_initial_recipe");
+  assert.equal(result.activeRecipe?.datasetId, context.datasetId);
+  assert.equal(result.activeRecipe?.version, 1);
+  assert.equal(result.activeRecipe?.status, "active");
+  assert.deepEqual(
+    result.activeRecipe?.requestedColumns,
+    context.columns.map((column) => column.name)
+  );
+  assert.equal(snapshot.recipes.length, 1);
+  assert.equal(snapshot.recipes[0]?.datasetId, context.datasetId);
+});
+
+test("self-healing service uses tick dataset id as the runtime context id", async () => {
+  const store = new InMemoryPopulateRecipeStore();
+  const generatedRecipe = recipe({ recipeId: "generated-v1" });
+  let runtimeContextDatasetId = "";
+  const service = new SelfHealingPopulateRecipeService({
+    store,
+    runtime: {
+      async runRecipe(input) {
+        runtimeContextDatasetId = input.context.datasetId;
+        return validRun(input.recipe);
+      },
+    },
+    author: new FakeRecipeAuthor({ generatedRecipe }),
+  });
+
+  await service.tick({
+    datasetId: context.datasetId,
+    context: {
+      ...context,
+      datasetId: "wrong-dataset",
+    },
+  });
+
+  assert.equal(runtimeContextDatasetId, context.datasetId);
+});
+
+test("self-healing service repairs a failed active recipe and promotes the candidate", async () => {
+  const store = new InMemoryPopulateRecipeStore();
+  const activeRecipe = recipe({ recipeId: "active-broken", status: "active" });
+  const repairedRecipe = recipe({ recipeId: "repair-v2", version: 2 });
+  await store.saveRecipe(activeRecipe);
+  const author = new FakeRecipeAuthor({ repairedRecipe });
+  const service = new SelfHealingPopulateRecipeService({
+    store,
+    runtime: new FakePopulateRecipeRuntime({
+      "active-broken": invalidRun(activeRecipe, "No source-backed rows."),
+      "repair-v2": validRun(repairedRecipe),
+    }),
+    author,
+  });
+
+  const result = await service.tick({ datasetId: context.datasetId, context });
+  const snapshot = await store.loadSnapshot(context.datasetId);
+
+  assert.equal(result.action, "repaired_active_recipe");
+  assert.equal(author.repairCalls, 1);
+  assert.equal(author.lastRepairInput?.failedRun.runStatus, "failed");
+  assert.equal(snapshot.recipes.find((item) => item.recipeId === "active-broken")?.status, "retired");
+  assert.equal(snapshot.recipes.find((item) => item.recipeId === "repair-v2")?.status, "active");
+});
+
+test("self-healing service rejects valid repairs below active recipe baseline", async () => {
+  const store = new InMemoryPopulateRecipeStore();
+  const activeRecipe = {
+    ...recipe({ recipeId: "active-broken", status: "active" }),
+    lastValidationScore: 1,
+  };
+  const weakerRepair = recipe({ recipeId: "repair-v2", version: 2 });
+  await store.saveRecipe(activeRecipe);
+  const service = new SelfHealingPopulateRecipeService({
+    store,
+    runtime: new FakePopulateRecipeRuntime({
+      "active-broken": invalidRun(activeRecipe, "Transient source outage."),
+      "repair-v2": validRun(weakerRepair, 0.75),
+    }),
+    author: new FakeRecipeAuthor({ repairedRecipe: weakerRepair }),
+  });
+
+  const result = await service.tick({ datasetId: context.datasetId, context });
+  const snapshot = await store.loadSnapshot(context.datasetId);
+
+  assert.equal(result.action, "candidate_rejected");
+  assert.match(result.rejectionReasons.join("\n"), /active recipe baseline/);
+  assert.equal(snapshot.recipes.find((item) => item.recipeId === "active-broken")?.status, "active");
+  assert.equal(snapshot.recipes.find((item) => item.recipeId === "repair-v2")?.status, "rejected");
+});
+
+test("self-healing service rejects a repaired candidate that still fails validation", async () => {
+  const store = new InMemoryPopulateRecipeStore();
+  const activeRecipe = recipe({ recipeId: "active-broken", status: "active" });
+  const rejectedRecipe = recipe({ recipeId: "bad-repair", version: 2 });
+  await store.saveRecipe(activeRecipe);
+  const service = new SelfHealingPopulateRecipeService({
+    store,
+    runtime: new FakePopulateRecipeRuntime({
+      "active-broken": invalidRun(activeRecipe, "No source-backed rows."),
+      "bad-repair": invalidRun(rejectedRecipe, "Still no evidence."),
+    }),
+    author: new FakeRecipeAuthor({ repairedRecipe: rejectedRecipe }),
+  });
+
+  const result = await service.tick({ datasetId: context.datasetId, context });
+  const snapshot = await store.loadSnapshot(context.datasetId);
+
+  assert.equal(result.action, "candidate_rejected");
+  assert.match(result.rejectionReasons.join("\n"), /Still no evidence/);
+  assert.equal(snapshot.recipes.find((item) => item.recipeId === "active-broken")?.status, "active");
+  assert.equal(snapshot.recipes.find((item) => item.recipeId === "bad-repair")?.status, "rejected");
+});
+
+test("file store reloads populate recipes and run records", async () => {
+  const rootDirectory = await mkdtemp(join(tmpdir(), "bigset-populate-recipes-"));
+  const store = new FileSystemPopulateRecipeStore(rootDirectory);
+  const generatedRecipe = recipe({ recipeId: "persisted-v1" });
+  const service = new SelfHealingPopulateRecipeService({
+    store,
+    runtime: new FakePopulateRecipeRuntime({
+      "persisted-v1": validRun(generatedRecipe),
+    }),
+    author: new FakeRecipeAuthor({ generatedRecipe }),
+  });
+
+  await service.tick({ datasetId: context.datasetId, context });
+
+  const reloadedStore = new FileSystemPopulateRecipeStore(rootDirectory);
+  const snapshot = await reloadedStore.loadSnapshot(context.datasetId);
+
+  assert.equal(snapshot.recipes.length, 1);
+  assert.equal(snapshot.recipes[0]?.status, "active");
+  assert.equal(snapshot.runRecords.length, 1);
+  assert.equal(snapshot.runRecords[0]?.runStatus, "succeeded");
+});
+
+interface ToolLike<TInput, TOutput> {
+  execute(input: TInput): Promise<TOutput>;
+}
+
+function recipe(input: {
+  recipeId: string;
+  version?: number;
+  status?: PopulateRecipe["status"];
+  runtimeInstructions?: string;
+}): PopulateRecipe {
+  return createPopulateRecipe({
+    recipeId: input.recipeId,
+    datasetId: context.datasetId,
+    version: input.version ?? 1,
+    status: input.status,
+    sourceDescription: context.description,
+    requestedColumns: context.columns.map((column) => column.name),
+    runtimeInstructions: input.runtimeInstructions,
+    createdAt: "2026-05-22T00:00:00.000Z",
+  });
+}
+
+function validRun(recipe: PopulateRecipe, score = 1): PopulateRecipeRunResult {
+  return runResult({
+    recipe,
+    rows: validRows(),
+    isValid: true,
+    score,
+  });
+}
+
+function invalidRun(recipe: PopulateRecipe, issue: string): PopulateRecipeRunResult {
+  return runResult({
+    recipe,
+    rows: [],
+    validationIssues: [issue],
+    criticalIssues: [issue],
+    isValid: false,
+    score: 0,
+  });
+}
+
+function runResult(input: {
+  recipe: PopulateRecipe;
+  rows: PopulateRecipeRunResult["rows"];
+  validationIssues?: string[];
+  criticalIssues?: string[];
+  isValid: boolean;
+  score: number;
+}): PopulateRecipeRunResult {
+  return {
+    rows: input.rows,
+    validationIssues: input.validationIssues ?? [],
+    usage: {
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+    },
+    metrics: {
+      searchCalls: 0,
+      fetchCalls: 0,
+      browserCalls: 0,
+      agentRuns: 0,
+      agentSteps: 0,
+    },
+    recipeId: input.recipe.recipeId,
+    recipeVersion: input.recipe.version,
+    runStatus: input.isValid ? "succeeded" : "failed",
+    startedAt: "2026-05-22T00:00:00.000Z",
+    completedAt: "2026-05-22T00:00:01.000Z",
+    runtimeMs: 1_000,
+    productionValidation: {
+      isValid: input.isValid,
+      score: input.score,
+      rowCount: input.rows.length,
+      requestedCellCompletenessRatio: input.score,
+      sourceUrlCoverageRatio: input.score,
+      evidenceCoverageRatio: input.score,
+      expectedEntityCoverageRatio: input.score,
+      expectedEntities: [],
+      missingExpectedEntities: [],
+      criticalIssues: input.criticalIssues ?? [],
+      warnings: input.validationIssues ?? [],
+    },
+    artifacts: [],
+  };
+}
+
+function validRows(): PopulateRecipeRunResult["rows"] {
+  return [
+    {
+      cells: {
+        entity_name: "OpenAI",
+        latest_post_title: "Release notes from OpenAI",
+        source_url: "https://openai.com/news",
+        evidence_quote: "Release notes from OpenAI",
+      },
+      sourceUrls: ["https://openai.com/news"],
+      evidence: [
+        {
+          columnName: "latest_post_title",
+          sourceUrl: "https://openai.com/news",
+          quote: "Release notes from OpenAI",
+        },
+      ],
+      needsReview: true,
+    },
+  ];
+}
+
+function emptyUsage(): PopulateRecipeRunResult["usage"] {
+  return {
+    promptTokens: 0,
+    completionTokens: 0,
+    totalTokens: 0,
+  };
+}
+
+function emptyMetrics(): PopulateRecipeRunResult["metrics"] {
+  return {
+    searchCalls: 0,
+    fetchCalls: 0,
+    browserCalls: 0,
+    agentRuns: 0,
+    agentSteps: 0,
+  };
+}
+
+class FakePopulateRecipeRuntime implements PopulateRecipeRuntime {
+  constructor(private readonly runsByRecipeId: Record<string, PopulateRecipeRunResult>) {}
+
+  async runRecipe(input: {
+    recipe: PopulateRecipe;
+    context: DatasetContext;
+  }): Promise<PopulateRecipeRunResult> {
+    const run = this.runsByRecipeId[input.recipe.recipeId];
+    if (!run) {
+      return invalidRun(input.recipe, `Missing fake run for ${input.recipe.recipeId}.`);
+    }
+    return run;
+  }
+}
+
+class FakeRecipeAuthor implements PopulateRecipeAuthor {
+  generateCalls = 0;
+  repairCalls = 0;
+  lastRepairInput?: Parameters<PopulateRecipeAuthor["repairRecipe"]>[0];
+
+  constructor(
+    private readonly recipes: {
+      generatedRecipe?: PopulateRecipe;
+      repairedRecipe?: PopulateRecipe;
+    } = {}
+  ) {}
+
+  async generateRecipe(): Promise<PopulateRecipe> {
+    this.generateCalls += 1;
+    return this.recipes.generatedRecipe ?? recipe({ recipeId: "generated-v1" });
+  }
+
+  async repairRecipe(
+    input: Parameters<PopulateRecipeAuthor["repairRecipe"]>[0]
+  ): Promise<PopulateRecipe> {
+    this.repairCalls += 1;
+    this.lastRepairInput = input;
+    return this.recipes.repairedRecipe ?? recipe({ recipeId: "repair-v2", version: 2 });
+  }
+}

--- a/backend/test/populate-self-healing.test.ts
+++ b/backend/test/populate-self-healing.test.ts
@@ -17,7 +17,11 @@ import type {
   PopulateRecipeRunResult,
   PopulateRecipeRuntime,
 } from "../src/pipeline/populate-self-healing.js";
+import type { PopulateAcquisitionResult } from "../src/pipeline/populate-acquisition.js";
+import { buildPopulateExtractionSpec } from "../src/pipeline/populate-extraction-spec.js";
 import type { DatasetContext } from "../src/pipeline/populate.js";
+import { normalizeSearchResultUrl } from "../src/pipeline/populate-search-prioritization.js";
+import { buildMockRow, mockTriageExtractHooks } from "./populate-test-hooks.js";
 
 const context: DatasetContext = {
   datasetId: "dataset-ai-posts",
@@ -48,47 +52,79 @@ const context: DatasetContext = {
 };
 
 test("Mastra populate recipe runtime maps populate rows into a healthy recipe run", async () => {
-  let promptText = "";
-  const runtime = new MastraPopulateRecipeRuntime({
-    webTools: {
-      search: async () => [
+  const newsUrl = "https://openai.com/news";
+  const extractionSpec = buildPopulateExtractionSpec({
+    context,
+    dataSpec: {
+      dataset_name: "ai_posts",
+      description: context.description,
+      primary_key: "entity_name",
+      search_queries: ["openai blog"],
+      columns: [
         {
-          title: "OpenAI news",
-          snippet: "Release notes from OpenAI",
-          url: "https://openai.com/news",
+          name: "entity_name",
+          display_name: "Company",
+          type: "string",
+          is_primary_key: true,
+          is_enumerable: true,
+          description: "Company name.",
+          nullable: false,
+        },
+        {
+          name: "latest_post_title",
+          display_name: "Post",
+          type: "string",
+          is_primary_key: false,
+          is_enumerable: false,
+          description: "Post title.",
+          nullable: true,
+        },
+        {
+          name: "source_url",
+          display_name: "Source",
+          type: "url",
+          is_primary_key: false,
+          is_enumerable: false,
+          description: "Source URL.",
+          nullable: true,
+        },
+        {
+          name: "evidence_quote",
+          display_name: "Evidence",
+          type: "string",
+          is_primary_key: false,
+          is_enumerable: false,
+          description: "Evidence quote.",
+          nullable: true,
         },
       ],
+    },
+  });
+  const runtime = new MastraPopulateRecipeRuntime({
+    acquisition: selfHealingAcquisition(),
+    webTools: {
+      search: async () => [],
       fetch: async () => ({
         title: "OpenAI news",
         text: "Release notes from OpenAI",
       }),
     },
-    agentRunner: async ({ prompt, tools }) => {
-      promptText = prompt;
-      const searchWeb = tools.search_web as ToolLike<
-        { query: string },
-        { results?: unknown[] }
-      >;
-      const fetchPage = tools.fetch_page as ToolLike<
-        { url: string },
-        { text?: string }
-      >;
-      const insertRow = tools.insert_row as ToolLike<
-        { datasetId: string; data: Record<string, unknown> },
-        { success: boolean }
-      >;
-      await searchWeb.execute({ query: "OpenAI latest blog" });
-      await fetchPage.execute({ url: "https://openai.com/news" });
-      await insertRow.execute({
-        datasetId: context.datasetId,
-        data: {
-          entity_name: "OpenAI",
-          latest_post_title: "Release notes from OpenAI",
-          source_url: "https://openai.com/news",
-          evidence_quote: "Release notes from OpenAI",
-        },
-      });
-    },
+    populateHooks: mockTriageExtractHooks({
+      recordsByUrl: {
+        [newsUrl]: [
+          buildMockRow({
+            spec: extractionSpec,
+            entityName: "OpenAI",
+            sourceUrl: newsUrl,
+            extraCells: {
+              latest_post_title: "Release notes from OpenAI",
+              evidence_quote: "Release notes from OpenAI",
+            },
+            quote: "Release notes from OpenAI",
+          }),
+        ],
+      },
+    }),
   });
 
   const run = await runtime.runRecipe({
@@ -99,13 +135,12 @@ test("Mastra populate recipe runtime maps populate rows into a healthy recipe ru
     context,
   });
 
-  assert.match(promptText, /Durable recipe instructions/);
   assert.equal(run.runStatus, "succeeded");
   assert.equal(run.productionValidation.isValid, true);
   assert.equal(run.productionValidation.score, 1);
   assert.equal(run.recipeId, "recipe-v1");
   assert.equal(run.rows[0]?.cells.entity_name, "OpenAI");
-  assert.equal(run.debug?.selectedRowSource, "insert_row");
+  assert.equal(run.debug?.selectedRowSource, "structured_recovery");
   assert.ok(run.artifacts.some((artifact) => artifact.kind === "source-transcript"));
   assert.ok(run.artifacts.some((artifact) => artifact.kind === "captured-rows"));
 });
@@ -511,6 +546,22 @@ function emptyMetrics(): PopulateRecipeRunResult["metrics"] {
     browserCalls: 0,
     agentRuns: 0,
     agentSteps: 0,
+  };
+}
+
+function selfHealingAcquisition(): PopulateAcquisitionResult {
+  const url = "https://openai.com/news";
+  return {
+    prioritizedUrls: [normalizeSearchResultUrl(url)],
+    scoredUrls: [
+      {
+        url,
+        expectation_score: 5,
+        search_query: "OpenAI official blog latest post",
+      },
+    ],
+    initialQueries: ["OpenAI official blog latest post"],
+    validationIssues: [],
   };
 }
 

--- a/backend/test/populate-server.test.ts
+++ b/backend/test/populate-server.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { createBigSetServer } from "../src/server.js";
+import type { DatasetContext } from "../src/pipeline/populate.js";
+import type { PopulateRecipeRuntime } from "../src/pipeline/populate-self-healing.js";
+import type { RunSelfHealingPopulateResult } from "../src/pipeline/populate-self-healing-runner.js";
+
+const context: DatasetContext = {
+  datasetId: "dataset-ai-posts",
+  datasetName: "AI posts",
+  description: "Find latest blog posts from OpenAI.",
+  columns: [{
+    name: "entity_name",
+    type: "text",
+    description: "Company name.",
+  }],
+};
+
+test("POST /populate passes selected runtime into self-healing runner", async () => {
+  const selectedRuntime = fakeRuntime();
+  let createRuntimeCalls = 0;
+  let didUseSelectedRuntime = false;
+  const app = await createBigSetServer({
+    env: {
+      CLIENT_ORIGIN: "http://localhost:3500",
+      CONVEX_URL: "http://convex:3210",
+      CONVEX_ADMIN_KEY: "convex-admin",
+      OPENROUTER_API_KEY: "openrouter",
+      TINYFISH_API_KEY: "tinyfish",
+      POPULATE_RECIPE_STORE_DIR: ".bigset/populate-recipes",
+    },
+    runtimeEnv: {
+      POPULATE_AGENT_RUNTIME: "collection",
+    },
+    authPreHandler: async (request) => {
+      request.auth = { userId: "user-1" };
+    },
+    getDatasetById: async (datasetId) => {
+      assert.equal(datasetId, context.datasetId);
+      return { ownerId: "user-1" };
+    },
+    populateRowWriter: {
+      async replaceRows() {
+        return { insertedRowCount: 1 };
+      },
+    },
+    createRuntime: async (input) => {
+      createRuntimeCalls += 1;
+      assert.equal(input.env.POPULATE_AGENT_RUNTIME, "collection");
+      return selectedRuntime;
+    },
+    runSelfHealing: async (input) => {
+      didUseSelectedRuntime = input.runtime === selectedRuntime;
+      assert.equal(input.shouldCommitRows, true);
+      assert.equal(input.recipeStoreDirectory, ".bigset/populate-recipes");
+      assert.ok(input.rowWriter);
+      return successfulResult(input.context.datasetId);
+    },
+  });
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/populate",
+    payload: context,
+  });
+
+  await app.close();
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(createRuntimeCalls, 1);
+  assert.equal(didUseSelectedRuntime, true);
+  assert.equal(response.json().success, true);
+});
+
+function successfulResult(datasetId: string): RunSelfHealingPopulateResult {
+  return {
+    success: true,
+    action: "generated_initial_recipe",
+    datasetId,
+    selectedRun: {
+      rows: [{
+        cells: { entity_name: "OpenAI" },
+        sourceUrls: ["https://openai.com/news"],
+        evidence: [{
+          columnName: "entity_name",
+          sourceUrl: "https://openai.com/news",
+          quote: "OpenAI",
+        }],
+        needsReview: true,
+      }],
+      validationIssues: [],
+      usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+      metrics: {
+        searchCalls: 0,
+        fetchCalls: 0,
+        browserCalls: 0,
+        agentRuns: 0,
+        agentSteps: 0,
+      },
+      recipeId: `${datasetId}-recipe-v1`,
+      recipeVersion: 1,
+      runStatus: "succeeded",
+      startedAt: "2026-05-22T00:00:00.000Z",
+      completedAt: "2026-05-22T00:00:01.000Z",
+      runtimeMs: 1_000,
+      productionValidation: {
+        isValid: true,
+        score: 1,
+        rowCount: 1,
+        requestedCellCompletenessRatio: 1,
+        sourceUrlCoverageRatio: 1,
+        evidenceCoverageRatio: 1,
+        expectedEntityCoverageRatio: 1,
+        expectedEntities: [],
+        missingExpectedEntities: [],
+        criticalIssues: [],
+        warnings: [],
+      },
+      artifacts: [],
+    },
+    rejectionReasons: [],
+    validationIssues: [],
+    tick: {
+      datasetId,
+      action: "generated_initial_recipe",
+      rejectionReasons: [],
+    },
+  };
+}
+
+function fakeRuntime(): PopulateRecipeRuntime {
+  return {
+    async runRecipe() {
+      throw new Error("fake runtime should not execute in route unit tests");
+    },
+  };
+}

--- a/backend/test/populate-test-hooks.ts
+++ b/backend/test/populate-test-hooks.ts
@@ -1,0 +1,67 @@
+import type { PopulateParallelHooks } from "../src/pipeline/populate-parallel.js";
+import type { PopulateExtractionSpec } from "../src/pipeline/populate-extraction-spec.js";
+import type { PopulateCandidateRow } from "../src/pipeline/populate-row.js";
+
+export function mockTriageExtractHooks(input: {
+  recordsByUrl: Record<string, PopulateCandidateRow[]>;
+}): PopulateParallelHooks {
+  return {
+    triageAndExtractPage: async ({ page, spec }) => {
+      const pageUrl = page.final_url || page.url;
+      const records = input.recordsByUrl[pageUrl] ?? [];
+      return {
+        triage: {
+          url: page.url,
+          final_url: pageUrl,
+          title: page.title ?? "",
+          status: "extract_now",
+          confidence: 1,
+          source_data_confidence: 1,
+          expected_yield: "complete",
+          reasoning: "mock",
+        },
+        records: records.map((row) => ({
+          ...row,
+          primaryKey:
+            row.primaryKey ||
+            String(row.cells[spec.primary_key] ?? "").trim().toLowerCase(),
+        })),
+      };
+    },
+    runTinyfishAgentsBatch: async () => [],
+  };
+}
+
+export function buildMockRow(input: {
+  spec: PopulateExtractionSpec;
+  entityName: string;
+  sourceUrl: string;
+  extraCells?: Record<string, string | number | boolean | null>;
+  quote?: string;
+}): PopulateCandidateRow {
+  const cells: Record<string, string | number | boolean | null> = {
+    [input.spec.primary_key]: input.entityName,
+    source_url: input.sourceUrl,
+    ...input.extraCells,
+  };
+  for (const column of input.spec.columns) {
+    if (cells[column.name] === undefined) {
+      cells[column.name] = null;
+    }
+  }
+  const quote = input.quote ?? `${input.entityName} evidence`;
+  return {
+    cells,
+    sourceUrls: [input.sourceUrl],
+    evidence: [
+      {
+        columnName: input.spec.primary_key,
+        sourceUrl: input.sourceUrl,
+        quote,
+      },
+    ],
+    needsReview: true,
+    extractionConfidence: 0.9,
+    primaryKey: input.entityName.trim().toLowerCase(),
+  };
+}

--- a/backend/test/schema-inference.test.ts
+++ b/backend/test/schema-inference.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  resolveInitialSearchQueryCap,
+  resolvePopulateDataSpec,
+} from "../src/pipeline/schema-inference.js";
+import type { DatasetSchema } from "../src/pipeline/types.js";
+
+function mockDataSpec(searchQueries: string[]): DatasetSchema {
+  return {
+    dataset_name: "earnings_releases",
+    description: "Latest earnings releases.",
+    primary_key: "entity_name",
+    search_queries: searchQueries,
+    columns: [
+      {
+        name: "entity_name",
+        display_name: "Company",
+        type: "string",
+        is_primary_key: true,
+        is_enumerable: true,
+        description: "Company name.",
+        nullable: false,
+      },
+    ],
+  };
+}
+
+test("resolveInitialSearchQueryCap uses half of max search calls", () => {
+  assert.equal(resolveInitialSearchQueryCap(20), 10);
+  assert.equal(resolveInitialSearchQueryCap(3), 1);
+});
+
+test("resolvePopulateDataSpec uses data spec queries when count matches", async () => {
+  const queries = Array.from({ length: 5 }, (_, index) => `seed query ${index + 1}`);
+  const dataSpec = mockDataSpec(queries);
+
+  const resolved = await resolvePopulateDataSpec({
+    prompt: "Earnings for Apple, Microsoft, and Nvidia.",
+    dataSpec,
+    maxSearchCalls: 10,
+  });
+
+  assert.deepEqual(resolved.initialQueries, queries);
+  assert.equal(resolved.dataSpec, dataSpec);
+});
+
+test("resolvePopulateDataSpec infers when search_queries count mismatches", async () => {
+  const inferred = mockDataSpec(["inferred a", "inferred b"]);
+  const resolved = await resolvePopulateDataSpec({
+    prompt: "Earnings releases.",
+    dataSpec: mockDataSpec(["only one"]),
+    maxSearchCalls: 4,
+    inferSchemaFn: async () => inferred,
+  });
+
+  assert.deepEqual(resolved.initialQueries, ["inferred a", "inferred b"]);
+  assert.equal(resolved.dataSpec, inferred);
+});

--- a/benchmarks/dataset-agent/README.md
+++ b/benchmarks/dataset-agent/README.md
@@ -21,6 +21,25 @@ Real Mastra benchmark runs require `OPENROUTER_API_KEY` and `TINYFISH_API_KEY`
 loaded execution-only. If either is missing, the adapter returns a blocked
 benchmark result instead of touching app data.
 
+## Run Collection Inside Self-Healing
+
+The collection adapter uses the same benchmark runner, but wraps
+`CollectionPopulateRecipeRuntime` inside `SelfHealingPopulateRecipeService`.
+That means collection results are scored after the same recipe generation,
+repair, validation, and promotion path as the app runtime.
+
+```bash
+node benchmarks/dataset-agent/run-benchmark.mjs \
+  --prompt-ids latest-ai-blog-posts,saas-pricing-pages \
+  --system collection-self-heal='node --import ./backend/node_modules/tsx/dist/esm/index.mjs benchmarks/dataset-agent/adapters/collection-self-healing-adapter.mjs'
+```
+
+Real collection benchmark runs require `OPENROUTER_API_KEY`,
+`TINYFISH_API_KEY`, and `BIGSET_COLLECTION_BENCHMARK_RUNNER_MODULE` loaded in
+the shell. The runner module must export `runCollectionPopulatePipeline(input)`
+or a default runner that accepts `CollectionPopulatePipelineInput` and returns a
+`PopulateRuntimeResult`.
+
 ## Verify Self-Healing Stack
 
 Use this before asking someone else to migrate a new collection agent into the
@@ -30,9 +49,9 @@ app path:
 make verify-self-healing
 ```
 
-That command runs backend tests, backend build, adapter syntax checks, and a
-no-key benchmark smoke that must produce a clean `blocked` result without
-spending OpenRouter or TinyFish credits.
+That command runs backend tests, backend build, adapter syntax checks, and
+Mastra + collection no-key benchmark smokes that must produce clean `blocked`
+results without spending OpenRouter or TinyFish credits.
 
 Live checks are explicit:
 

--- a/benchmarks/dataset-agent/README.md
+++ b/benchmarks/dataset-agent/README.md
@@ -73,12 +73,17 @@ For each prompt the runner sets:
 - `BIGSET_BENCHMARK_PROMPT`
 - `BIGSET_BENCHMARK_PROMPT_ID`
 - `BIGSET_BENCHMARK_PROMPT_QUALITY`
+- `BIGSET_BENCHMARK_PERSONA`
+- `BIGSET_BENCHMARK_EXPECTED_STRESS`
 - `BIGSET_BENCHMARK_REQUIRED_COLUMNS`
 - `BIGSET_BENCHMARK_MINIMUM_REQUIRED_COLUMNS`
 
 `BIGSET_BENCHMARK_REQUIRED_COLUMNS` is the requested table shape.
 `BIGSET_BENCHMARK_MINIMUM_REQUIRED_COLUMNS` is the hard row identity minimum.
-Rows still need at least one source URL and evidence quote.
+Rows still need at least one source URL and evidence quote. Collection benchmark
+runners receive prompt id, quality, persona, expected stress, and required
+columns through `CollectionPopulatePipelineInput` so they can build the same
+benchmark/spec context that the direct collection lane expects.
 
 ## Agent Output Contract
 

--- a/benchmarks/dataset-agent/README.md
+++ b/benchmarks/dataset-agent/README.md
@@ -1,0 +1,77 @@
+# Dataset Agent Benchmark
+
+Shared harness for scoring one dataset agent command against the same prompt pack.
+
+The runner is intentionally standalone. Each system is a command that reads the
+benchmark env vars, runs one prompt, and prints one JSON object to stdout.
+
+## Run Mastra Populate
+
+The Mastra adapter calls `runPopulateRuntime`, a direct callable runtime around
+the Mastra populate agent. It avoids the HTTP/auth route and uses an injected
+in-memory row sink so benchmark runs do not clear or insert Convex rows.
+
+```bash
+node benchmarks/dataset-agent/run-benchmark.mjs \
+  --prompt-ids latest-ai-blog-posts,saas-pricing-pages \
+  --system mastra='node --import ./backend/node_modules/tsx/dist/esm/index.mjs benchmarks/dataset-agent/adapters/mastra-populate-adapter.mjs'
+```
+
+Real Mastra benchmark runs require `OPENROUTER_API_KEY` and `TINYFISH_API_KEY`
+loaded execution-only. If either is missing, the adapter returns a blocked
+benchmark result instead of touching app data.
+
+## Benchmark Env
+
+For each prompt the runner sets:
+
+- `BIGSET_BENCHMARK_PROMPT`
+- `BIGSET_BENCHMARK_PROMPT_ID`
+- `BIGSET_BENCHMARK_PROMPT_QUALITY`
+- `BIGSET_BENCHMARK_REQUIRED_COLUMNS`
+- `BIGSET_BENCHMARK_MINIMUM_REQUIRED_COLUMNS`
+
+`BIGSET_BENCHMARK_REQUIRED_COLUMNS` is the requested table shape.
+`BIGSET_BENCHMARK_MINIMUM_REQUIRED_COLUMNS` is the hard row identity minimum.
+Rows still need at least one source URL and evidence quote.
+
+## Agent Output Contract
+
+The command must print JSON:
+
+```json
+{
+  "rows": [
+    {
+      "cells": {
+        "entity_name": "Example",
+        "source_url": "https://example.com"
+      },
+      "sourceUrls": ["https://example.com"],
+      "evidence": [
+        {
+          "columnName": "entity_name",
+          "sourceUrl": "https://example.com",
+          "quote": "Example source quote"
+        }
+      ],
+      "needsReview": false
+    }
+  ],
+  "validationIssues": [],
+  "usage": {
+    "promptTokens": 0,
+    "completionTokens": 0,
+    "totalTokens": 0
+  },
+  "metrics": {
+    "searchCalls": 0,
+    "fetchCalls": 0,
+    "browserCalls": 0,
+    "agentRuns": 1,
+    "agentSteps": 0
+  }
+}
+```
+
+Logs must go to stderr.

--- a/benchmarks/dataset-agent/README.md
+++ b/benchmarks/dataset-agent/README.md
@@ -5,6 +5,13 @@ Shared harness for scoring one dataset agent command against the same prompt pac
 The runner is intentionally standalone. Each system is a command that reads the
 benchmark env vars, runs one prompt, and prints one JSON object to stdout.
 
+On startup, `run-benchmark.mjs` loads env files from the repo (without
+overriding variables you already exported in the shell): `.env`,
+`backend/.env`, and `backend/.env.local`. It also sets default
+`COLLECTION_AGENT_PIPELINE_MODULE` and `BIGSET_COLLECTION_BENCHMARK_RUNNER_MODULE`
+when those are unset. Child adapter processes inherit everything through
+`process.env`.
+
 ## Run Mastra Populate
 
 The Mastra adapter calls the self-healing populate service around
@@ -13,9 +20,21 @@ recipe store per prompt run, and never clears or inserts Convex rows.
 
 ```bash
 node benchmarks/dataset-agent/run-benchmark.mjs \
-  --prompt-ids latest-ai-blog-posts,saas-pricing-pages \
   --system mastra='node --import ./backend/node_modules/tsx/dist/esm/index.mjs benchmarks/dataset-agent/adapters/mastra-populate-adapter.mjs'
 ```
+
+The default `prompts.json` has **5 open-ended** prompts (scoringMode `open_ended`, ~100-row target contract) followed by the **original 16** fixed-entity prompts (scoringMode `entity`, stricter gates with evidence required).
+
+| Pack | Scoring | Pass highlights |
+|------|---------|-----------------|
+| Open-ended (first 5) | `open_ended` | ≥50 rows, source URLs, 60% cell completeness; evidence optional |
+| Original 16 | `entity` | Entity/domain answer keys, 75% completeness, evidence required |
+
+Target contract defaults for open-ended: `targetRows=100`, `minRowCount=50`, `minEvidenceCoverage=0.95` (informational unless `--require-evidence`).
+
+**Search vs fetch:** acquisition only searches; populate fetches from the prioritized URL list (capped by `POPULATE_MAX_FETCH_CALLS`, default 50). The populate agent is not given a separate fetch budget — it should work through that list. Raise `POPULATE_MAX_SEARCH_CALLS` and `POPULATE_MAX_FETCH_CALLS` in `backend/.env.local` for large open-ended runs.
+
+**Populate debug artifacts:** set `POPULATE_BENCHMARK_DEBUG=true` in `backend/.env.local`. Each prompt run writes `debug/` under its artifact folder (`run_report.json`, `search_pool.json`, `source_candidates.json`, `prioritized_urls.json`, CSVs, etc.). Stdout/`parsed-output.json` stay unchanged when debug is off.
 
 Real Mastra benchmark runs require `OPENROUTER_API_KEY` and `TINYFISH_API_KEY`
 loaded execution-only. If either is missing, the adapter returns a blocked
@@ -29,16 +48,13 @@ That means collection results are scored after the same recipe generation,
 repair, validation, and promotion path as the app runtime.
 
 ```bash
-COLLECTION_AGENT_PIPELINE_MODULE=./backend/BigSet_Data_Collection_Agent/src/orchestrator/pipeline.ts \
-BIGSET_COLLECTION_BENCHMARK_RUNNER_MODULE=./backend/src/pipeline/collection-agent-runner.ts \
 node benchmarks/dataset-agent/run-benchmark.mjs \
   --prompt-ids latest-ai-blog-posts,saas-pricing-pages \
   --system collection-self-heal='node --import ./backend/node_modules/tsx/dist/esm/index.mjs benchmarks/dataset-agent/adapters/collection-self-healing-adapter.mjs'
 ```
 
-Real collection benchmark runs require `OPENROUTER_API_KEY`,
-`TINYFISH_API_KEY`, `BIGSET_COLLECTION_BENCHMARK_RUNNER_MODULE`, and
-`COLLECTION_AGENT_PIPELINE_MODULE` loaded in the shell. The benchmark runner
+Real collection benchmark runs require `OPENROUTER_API_KEY` and
+`TINYFISH_API_KEY` in the env files above or in the shell. The benchmark runner
 module must export `runCollectionPopulatePipeline(input)` or a default runner
 that accepts `CollectionPopulatePipelineInput` and returns a
 `PopulateRuntimeResult`. The pipeline module must export `runPipeline(options)`.

--- a/benchmarks/dataset-agent/README.md
+++ b/benchmarks/dataset-agent/README.md
@@ -7,9 +7,9 @@ benchmark env vars, runs one prompt, and prints one JSON object to stdout.
 
 ## Run Mastra Populate
 
-The Mastra adapter calls `runPopulateRuntime`, a direct callable runtime around
-the Mastra populate agent. It avoids the HTTP/auth route and uses an injected
-in-memory row sink so benchmark runs do not clear or insert Convex rows.
+The Mastra adapter calls the self-healing populate service around
+`runPopulateRuntime`. It avoids the HTTP/auth route, uses an isolated in-memory
+recipe store per prompt run, and never clears or inserts Convex rows.
 
 ```bash
 node benchmarks/dataset-agent/run-benchmark.mjs \

--- a/benchmarks/dataset-agent/README.md
+++ b/benchmarks/dataset-agent/README.md
@@ -47,6 +47,37 @@ benchmark stays cheap and bounded. Set `COLLECTION_AGENT_ENABLE_AGENT=true` to
 opt in; Agent polling is capped by `AGENT_POLL_TIMEOUT_MS`, or by
 `COLLECTION_AGENT_POLL_TIMEOUT_MS` when the generic timeout is unset.
 
+When Agent is off and triage finds browser/form/detail-page follow-up, the
+collection runner emits a non-fatal capability diagnostic. Healthy rows can
+still pass self-healing validation with this diagnostic as a warning. Benchmark
+failures show the same diagnostic as the failure message so the result says
+"turn Agent on for this prompt" instead of pretending the run hit auth,
+credits, or generic zero-row failure.
+
+Use this canary when checking whether Agent/browser follow-up fixes the current
+source-evidence misses:
+
+```bash
+COLLECTION_AGENT_ENABLE_AGENT=true \
+COLLECTION_AGENT_POLL_TIMEOUT_MS=480000 \
+COLLECTION_AGENT_PIPELINE_MODULE=./backend/BigSet_Data_Collection_Agent/src/orchestrator/pipeline.ts \
+BIGSET_COLLECTION_BENCHMARK_RUNNER_MODULE=./backend/src/pipeline/collection-agent-runner.ts \
+node benchmarks/dataset-agent/run-benchmark.mjs \
+  --prompt-ids mcp-docs-pages \
+  --timeout-ms 900000 \
+  --system collection-self-heal='node --import ./backend/node_modules/tsx/dist/esm/index.mjs benchmarks/dataset-agent/adapters/collection-self-healing-adapter.mjs'
+```
+
+Latest `mcp-docs-pages` Agent-enabled canary evidence:
+
+- artifact: `benchmark-results/collection-agent-canary-mcp-20260523-001`
+- status: failed, not blocked
+- rows/evidence: 3 rows, 12 evidence quotes, 10 source URLs
+- cost: about `$0.053552`
+- signal: Agent runs complete and claim support reaches `1.0`, but domain
+  accuracy stays `0.667`; next fix is source/domain coherence, not more Agent
+  plumbing.
+
 App and CLI collection-runtime runs use the same runner shape, but load it from
 `POPULATE_COLLECTION_RUNNER_MODULE` when `POPULATE_AGENT_RUNTIME=collection`.
 

--- a/benchmarks/dataset-agent/README.md
+++ b/benchmarks/dataset-agent/README.md
@@ -40,6 +40,9 @@ the shell. The runner module must export `runCollectionPopulatePipeline(input)`
 or a default runner that accepts `CollectionPopulatePipelineInput` and returns a
 `PopulateRuntimeResult`.
 
+App and CLI collection-runtime runs use the same runner shape, but load it from
+`POPULATE_COLLECTION_RUNNER_MODULE` when `POPULATE_AGENT_RUNTIME=collection`.
+
 ## Verify Self-Healing Stack
 
 Use this before asking someone else to migrate a new collection agent into the

--- a/benchmarks/dataset-agent/README.md
+++ b/benchmarks/dataset-agent/README.md
@@ -29,16 +29,19 @@ That means collection results are scored after the same recipe generation,
 repair, validation, and promotion path as the app runtime.
 
 ```bash
+COLLECTION_AGENT_PIPELINE_MODULE=./backend/BigSet_Data_Collection_Agent/src/orchestrator/pipeline.ts \
+BIGSET_COLLECTION_BENCHMARK_RUNNER_MODULE=./backend/src/pipeline/collection-agent-runner.ts \
 node benchmarks/dataset-agent/run-benchmark.mjs \
   --prompt-ids latest-ai-blog-posts,saas-pricing-pages \
   --system collection-self-heal='node --import ./backend/node_modules/tsx/dist/esm/index.mjs benchmarks/dataset-agent/adapters/collection-self-healing-adapter.mjs'
 ```
 
 Real collection benchmark runs require `OPENROUTER_API_KEY`,
-`TINYFISH_API_KEY`, and `BIGSET_COLLECTION_BENCHMARK_RUNNER_MODULE` loaded in
-the shell. The runner module must export `runCollectionPopulatePipeline(input)`
-or a default runner that accepts `CollectionPopulatePipelineInput` and returns a
-`PopulateRuntimeResult`.
+`TINYFISH_API_KEY`, `BIGSET_COLLECTION_BENCHMARK_RUNNER_MODULE`, and
+`COLLECTION_AGENT_PIPELINE_MODULE` loaded in the shell. The benchmark runner
+module must export `runCollectionPopulatePipeline(input)` or a default runner
+that accepts `CollectionPopulatePipelineInput` and returns a
+`PopulateRuntimeResult`. The pipeline module must export `runPipeline(options)`.
 
 App and CLI collection-runtime runs use the same runner shape, but load it from
 `POPULATE_COLLECTION_RUNNER_MODULE` when `POPULATE_AGENT_RUNTIME=collection`.

--- a/benchmarks/dataset-agent/README.md
+++ b/benchmarks/dataset-agent/README.md
@@ -21,6 +21,32 @@ Real Mastra benchmark runs require `OPENROUTER_API_KEY` and `TINYFISH_API_KEY`
 loaded execution-only. If either is missing, the adapter returns a blocked
 benchmark result instead of touching app data.
 
+## Verify Self-Healing Stack
+
+Use this before asking someone else to migrate a new collection agent into the
+app path:
+
+```bash
+make verify-self-healing
+```
+
+That command runs backend tests, backend build, adapter syntax checks, and a
+no-key benchmark smoke that must produce a clean `blocked` result without
+spending OpenRouter or TinyFish credits.
+
+Live checks are explicit:
+
+```bash
+bash scripts/verify-self-healing-stack.sh --real-benchmark
+bash scripts/verify-self-healing-stack.sh --convex-push --dataset-id <dataset-id>
+bash scripts/verify-self-healing-stack.sh --convex-push --dataset-id <dataset-id> --commit
+```
+
+The live benchmark and dataset smoke expect required env vars to already be
+exported in the shell. They print only missing key names and never print secret
+values. The `--convex-push` mode still uses the existing `make convex-push`
+target, which requires `frontend/.env.local`.
+
 ## Benchmark Env
 
 For each prompt the runner sets:

--- a/benchmarks/dataset-agent/README.md
+++ b/benchmarks/dataset-agent/README.md
@@ -42,6 +42,10 @@ Real collection benchmark runs require `OPENROUTER_API_KEY`,
 module must export `runCollectionPopulatePipeline(input)` or a default runner
 that accepts `CollectionPopulatePipelineInput` and returns a
 `PopulateRuntimeResult`. The pipeline module must export `runPipeline(options)`.
+The BigSet runner keeps TinyFish Agent/browser calls off by default so the
+benchmark stays cheap and bounded. Set `COLLECTION_AGENT_ENABLE_AGENT=true` to
+opt in; Agent polling is capped by `AGENT_POLL_TIMEOUT_MS`, or by
+`COLLECTION_AGENT_POLL_TIMEOUT_MS` when the generic timeout is unset.
 
 App and CLI collection-runtime runs use the same runner shape, but load it from
 `POPULATE_COLLECTION_RUNNER_MODULE` when `POPULATE_AGENT_RUNTIME=collection`.

--- a/benchmarks/dataset-agent/adapters/.gitignore
+++ b/benchmarks/dataset-agent/adapters/.gitignore
@@ -1,0 +1,1 @@
+local-*.mjs

--- a/benchmarks/dataset-agent/adapters/collection-self-healing-adapter.mjs
+++ b/benchmarks/dataset-agent/adapters/collection-self-healing-adapter.mjs
@@ -5,6 +5,8 @@ import { resolve } from "node:path";
 const prompt = requiredEnv("BIGSET_BENCHMARK_PROMPT");
 const promptId = process.env.BIGSET_BENCHMARK_PROMPT_ID ?? "benchmark-prompt";
 const promptQuality = process.env.BIGSET_BENCHMARK_PROMPT_QUALITY ?? "unknown";
+const persona = process.env.BIGSET_BENCHMARK_PERSONA;
+const expectedStress = process.env.BIGSET_BENCHMARK_EXPECTED_STRESS;
 const requiredColumns = columnList(
   requiredEnv("BIGSET_BENCHMARK_REQUIRED_COLUMNS")
 );
@@ -74,6 +76,12 @@ const service = new SelfHealingPopulateRecipeService({
   runtime: new CollectionPopulateRecipeRuntime({
     runPipeline: collectionRunner,
     targetRows: Number(process.env.BIGSET_COLLECTION_BENCHMARK_MAX_ROWS ?? "10"),
+    benchmarkMetadata: {
+      promptId,
+      promptQuality,
+      persona,
+      expectedStress,
+    },
   }),
   author: new DefaultPopulateRecipeAuthor(),
 });

--- a/benchmarks/dataset-agent/adapters/collection-self-healing-adapter.mjs
+++ b/benchmarks/dataset-agent/adapters/collection-self-healing-adapter.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+import { pathToFileURL } from "node:url";
+import { resolve } from "node:path";
+
+const prompt = requiredEnv("BIGSET_BENCHMARK_PROMPT");
+const promptId = process.env.BIGSET_BENCHMARK_PROMPT_ID ?? "benchmark-prompt";
+const promptQuality = process.env.BIGSET_BENCHMARK_PROMPT_QUALITY ?? "unknown";
+const requiredColumns = columnList(
+  requiredEnv("BIGSET_BENCHMARK_REQUIRED_COLUMNS")
+);
+const minimumRequiredColumns = columnList(
+  process.env.BIGSET_BENCHMARK_MINIMUM_REQUIRED_COLUMNS ?? ""
+);
+
+const missingRuntimeKeys = ["OPENROUTER_API_KEY", "TINYFISH_API_KEY"].filter(
+  (name) => !process.env[name]
+);
+if (missingRuntimeKeys.length > 0) {
+  console.log(JSON.stringify({
+    rows: [],
+    validationIssues: [
+      `Missing ${missingRuntimeKeys.join(", ")} for collection self-healing benchmark.`,
+    ],
+    usage: emptyUsage(),
+    metrics: emptyMetrics(),
+  }));
+  process.exit(0);
+}
+
+const collectionRunner = await loadCollectionRunner();
+if (!collectionRunner) {
+  console.log(JSON.stringify({
+    rows: [],
+    validationIssues: [
+      "Collection self-healing benchmark runner is not configured. Set BIGSET_COLLECTION_BENCHMARK_RUNNER_MODULE to a module exporting runCollectionPopulatePipeline(input).",
+    ],
+    usage: emptyUsage(),
+    metrics: emptyMetrics(),
+  }));
+  process.exit(0);
+}
+
+const {
+  diagnosticRunForTick,
+  validationIssuesForSelfHealingTick,
+} = await import(
+  "../../../backend/src/pipeline/populate-self-healing-runner.ts"
+);
+const {
+  DefaultPopulateRecipeAuthor,
+  InMemoryPopulateRecipeStore,
+  SelfHealingPopulateRecipeService,
+} = await import(
+  "../../../backend/src/pipeline/populate-self-healing.ts"
+);
+const {
+  CollectionPopulateRecipeRuntime,
+} = await import(
+  "../../../backend/src/pipeline/populate-collection-runtime.ts"
+);
+
+const context = {
+  datasetId: `benchmark-${safeIdSegment(promptId)}`,
+  datasetName: `benchmark_${safeIdSegment(promptId)}`,
+  description: prompt,
+  columns: requiredColumns.map((columnName) => ({
+    name: columnName,
+    type: inferPopulateColumnType(columnName),
+    description: `Benchmark requested column for ${promptQuality} prompt.`,
+  })),
+};
+const service = new SelfHealingPopulateRecipeService({
+  store: new InMemoryPopulateRecipeStore(),
+  runtime: new CollectionPopulateRecipeRuntime({
+    runPipeline: collectionRunner,
+    targetRows: Number(process.env.BIGSET_COLLECTION_BENCHMARK_MAX_ROWS ?? "10"),
+  }),
+  author: new DefaultPopulateRecipeAuthor(),
+});
+const tick = await service.tick({ datasetId: context.datasetId, context });
+const result = diagnosticRunForTick(tick);
+
+console.log(JSON.stringify({
+  rows: result?.rows ?? [],
+  validationIssues: [
+    ...validationIssuesForSelfHealingTick(tick),
+    ...minimumColumnIssues(result?.rows ?? []),
+  ],
+  usage: result?.usage ?? emptyUsage(),
+  metrics: result?.metrics ?? emptyMetrics(),
+}));
+
+async function loadCollectionRunner() {
+  const moduleSpecifier = process.env.BIGSET_COLLECTION_BENCHMARK_RUNNER_MODULE;
+  if (!moduleSpecifier) {
+    return undefined;
+  }
+  const moduleUrl = moduleSpecifier.startsWith(".") || moduleSpecifier.startsWith("/")
+    ? pathToFileURL(resolve(moduleSpecifier)).href
+    : moduleSpecifier;
+  const loaded = await import(moduleUrl);
+  const runner = loaded.runCollectionPopulatePipeline ?? loaded.default;
+  if (typeof runner !== "function") {
+    throw new Error(
+      `${moduleSpecifier} must export runCollectionPopulatePipeline(input) or a default runner.`
+    );
+  }
+  return runner;
+}
+
+function minimumColumnIssues(rows) {
+  const issues = [];
+  for (const [rowIndex, row] of rows.entries()) {
+    for (const columnName of minimumRequiredColumns) {
+      const value = row.cells?.[columnName];
+      if (value === undefined || value === null || value === "") {
+        issues.push(`Row ${rowIndex} missing minimum required column ${columnName}.`);
+      }
+    }
+  }
+  return issues;
+}
+
+function inferPopulateColumnType(columnName) {
+  if (/(url|website|link|page)$/i.test(columnName)) return "url";
+  if (/(date|_at)$/i.test(columnName)) return "date";
+  if (/^(is_|has_|can_)/i.test(columnName)) return "boolean";
+  if (/(count|price|amount|score|number|total)/i.test(columnName)) return "number";
+  return "text";
+}
+
+function safeIdSegment(value) {
+  return String(value).replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 80);
+}
+
+function columnList(value) {
+  return value
+    .split(",")
+    .map((columnName) => columnName.trim())
+    .filter(Boolean);
+}
+
+function emptyUsage() {
+  return { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+}
+
+function emptyMetrics() {
+  return {
+    searchCalls: 0,
+    fetchCalls: 0,
+    browserCalls: 0,
+    agentRuns: 0,
+    agentSteps: 0,
+  };
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing ${name}. Run through run-benchmark.mjs.`);
+  }
+  return value;
+}

--- a/benchmarks/dataset-agent/adapters/mastra-populate-adapter.mjs
+++ b/benchmarks/dataset-agent/adapters/mastra-populate-adapter.mjs
@@ -44,11 +44,13 @@ const result = await runPopulateRuntime({
 });
 
 console.log(JSON.stringify({
-  ...result,
+  rows: result.rows,
   validationIssues: [
     ...result.validationIssues,
     ...minimumColumnIssues(result.rows),
   ],
+  usage: result.usage,
+  metrics: result.metrics,
 }));
 
 function minimumColumnIssues(rows) {

--- a/benchmarks/dataset-agent/adapters/mastra-populate-adapter.mjs
+++ b/benchmarks/dataset-agent/adapters/mastra-populate-adapter.mjs
@@ -53,7 +53,7 @@ const context = {
 const service = new SelfHealingPopulateRecipeService({
   store: new InMemoryPopulateRecipeStore(),
   runtime: new MastraPopulateRecipeRuntime({
-    maxRows: Number(process.env.BIGSET_MASTRA_BENCHMARK_MAX_ROWS ?? "10"),
+    maxRows: Number(process.env.BIGSET_MASTRA_BENCHMARK_MAX_ROWS ?? "100"),
   }),
   author: new DefaultPopulateRecipeAuthor(),
 });

--- a/benchmarks/dataset-agent/adapters/mastra-populate-adapter.mjs
+++ b/benchmarks/dataset-agent/adapters/mastra-populate-adapter.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+const prompt = requiredEnv("BIGSET_BENCHMARK_PROMPT");
+const promptId = process.env.BIGSET_BENCHMARK_PROMPT_ID ?? "benchmark-prompt";
+const promptQuality = process.env.BIGSET_BENCHMARK_PROMPT_QUALITY ?? "unknown";
+const requiredColumns = columnList(
+  requiredEnv("BIGSET_BENCHMARK_REQUIRED_COLUMNS")
+);
+const minimumRequiredColumns = columnList(
+  process.env.BIGSET_BENCHMARK_MINIMUM_REQUIRED_COLUMNS ?? ""
+);
+
+const missingRuntimeKeys = ["OPENROUTER_API_KEY", "TINYFISH_API_KEY"].filter(
+  (name) => !process.env[name]
+);
+if (missingRuntimeKeys.length > 0) {
+  console.log(JSON.stringify({
+    rows: [],
+    validationIssues: [
+      `Missing ${missingRuntimeKeys.join(", ")} for Mastra populate benchmark.`,
+    ],
+    usage: emptyUsage(),
+    metrics: emptyMetrics(),
+  }));
+  process.exit(0);
+}
+
+const { runPopulateRuntime } = await import(
+  "../../../backend/src/pipeline/populate-runtime.ts"
+);
+
+const result = await runPopulateRuntime({
+  context: {
+    datasetId: `benchmark-${safeIdSegment(promptId)}`,
+    datasetName: `benchmark_${safeIdSegment(promptId)}`,
+    description: prompt,
+    columns: requiredColumns.map((columnName) => ({
+      name: columnName,
+      type: inferPopulateColumnType(columnName),
+      description: `Benchmark requested column for ${promptQuality} prompt.`,
+    })),
+  },
+  maxRows: Number(process.env.BIGSET_MASTRA_BENCHMARK_MAX_ROWS ?? "10"),
+});
+
+console.log(JSON.stringify({
+  ...result,
+  validationIssues: [
+    ...result.validationIssues,
+    ...minimumColumnIssues(result.rows),
+  ],
+}));
+
+function minimumColumnIssues(rows) {
+  const issues = [];
+  for (const [rowIndex, row] of rows.entries()) {
+    for (const columnName of minimumRequiredColumns) {
+      const value = row.cells?.[columnName];
+      if (value === undefined || value === null || value === "") {
+        issues.push(`Row ${rowIndex} missing minimum required column ${columnName}.`);
+      }
+    }
+  }
+  return issues;
+}
+
+function inferPopulateColumnType(columnName) {
+  if (/(url|website|link|page)$/i.test(columnName)) return "url";
+  if (/(date|_at)$/i.test(columnName)) return "date";
+  if (/^(is_|has_|can_)/i.test(columnName)) return "boolean";
+  if (/(count|price|amount|score|number|total)/i.test(columnName)) return "number";
+  return "text";
+}
+
+function safeIdSegment(value) {
+  return String(value).replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 80);
+}
+
+function columnList(value) {
+  return value
+    .split(",")
+    .map((columnName) => columnName.trim())
+    .filter(Boolean);
+}
+
+function emptyUsage() {
+  return { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+}
+
+function emptyMetrics() {
+  return {
+    searchCalls: 0,
+    fetchCalls: 0,
+    browserCalls: 0,
+    agentRuns: 0,
+    agentSteps: 0,
+  };
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing ${name}. Run through run-benchmark.mjs.`);
+  }
+  return value;
+}

--- a/benchmarks/dataset-agent/adapters/mastra-populate-adapter.mjs
+++ b/benchmarks/dataset-agent/adapters/mastra-populate-adapter.mjs
@@ -25,32 +25,49 @@ if (missingRuntimeKeys.length > 0) {
   process.exit(0);
 }
 
-const { runPopulateRuntime } = await import(
-  "../../../backend/src/pipeline/populate-runtime.ts"
+const {
+  diagnosticRunForTick,
+  validationIssuesForSelfHealingTick,
+} = await import(
+  "../../../backend/src/pipeline/populate-self-healing-runner.ts"
+);
+const {
+  DefaultPopulateRecipeAuthor,
+  InMemoryPopulateRecipeStore,
+  MastraPopulateRecipeRuntime,
+  SelfHealingPopulateRecipeService,
+} = await import(
+  "../../../backend/src/pipeline/populate-self-healing.ts"
 );
 
-const result = await runPopulateRuntime({
-  context: {
-    datasetId: `benchmark-${safeIdSegment(promptId)}`,
-    datasetName: `benchmark_${safeIdSegment(promptId)}`,
-    description: prompt,
-    columns: requiredColumns.map((columnName) => ({
-      name: columnName,
-      type: inferPopulateColumnType(columnName),
-      description: `Benchmark requested column for ${promptQuality} prompt.`,
-    })),
-  },
-  maxRows: Number(process.env.BIGSET_MASTRA_BENCHMARK_MAX_ROWS ?? "10"),
+const context = {
+  datasetId: `benchmark-${safeIdSegment(promptId)}`,
+  datasetName: `benchmark_${safeIdSegment(promptId)}`,
+  description: prompt,
+  columns: requiredColumns.map((columnName) => ({
+    name: columnName,
+    type: inferPopulateColumnType(columnName),
+    description: `Benchmark requested column for ${promptQuality} prompt.`,
+  })),
+};
+const service = new SelfHealingPopulateRecipeService({
+  store: new InMemoryPopulateRecipeStore(),
+  runtime: new MastraPopulateRecipeRuntime({
+    maxRows: Number(process.env.BIGSET_MASTRA_BENCHMARK_MAX_ROWS ?? "10"),
+  }),
+  author: new DefaultPopulateRecipeAuthor(),
 });
+const tick = await service.tick({ datasetId: context.datasetId, context });
+const result = diagnosticRunForTick(tick);
 
 console.log(JSON.stringify({
-  rows: result.rows,
+  rows: result?.rows ?? [],
   validationIssues: [
-    ...result.validationIssues,
-    ...minimumColumnIssues(result.rows),
+    ...validationIssuesForSelfHealingTick(tick),
+    ...minimumColumnIssues(result?.rows ?? []),
   ],
-  usage: result.usage,
-  metrics: result.metrics,
+  usage: result?.usage ?? emptyUsage(),
+  metrics: result?.metrics ?? emptyMetrics(),
 }));
 
 function minimumColumnIssues(rows) {

--- a/benchmarks/dataset-agent/adapters/smoke-adapter.mjs
+++ b/benchmarks/dataset-agent/adapters/smoke-adapter.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+const prompt = process.env.BIGSET_BENCHMARK_PROMPT ?? "";
+const promptId = process.env.BIGSET_BENCHMARK_PROMPT_ID ?? "unknown";
+const requiredColumns = (process.env.BIGSET_BENCHMARK_REQUIRED_COLUMNS ?? "")
+  .split(",")
+  .map((columnName) => columnName.trim())
+  .filter(Boolean);
+
+const cells = Object.fromEntries(
+  requiredColumns.map((columnName) => [
+    columnName,
+    valueForColumn({ columnName, prompt, promptId }),
+  ])
+);
+
+const sourceUrl = `https://example.com/bigset-benchmark/${encodeURIComponent(promptId)}`;
+cells.source_url = cells.source_url ?? sourceUrl;
+
+console.log(
+  JSON.stringify({
+    rows: [
+      {
+        cells,
+        sourceUrls: [sourceUrl],
+        evidence: [
+          {
+            columnName: requiredColumns[0] ?? "entity_name",
+            sourceUrl,
+            quote: `Smoke benchmark evidence for ${promptId}`,
+          },
+        ],
+        needsReview: false,
+      },
+    ],
+    validationIssues: [],
+    usage: {
+      promptTokens: Math.max(1, Math.round(prompt.length / 4)),
+      completionTokens: 120,
+      totalTokens: Math.max(1, Math.round(prompt.length / 4)) + 120,
+    },
+    metrics: {
+      searchCalls: 1,
+      fetchCalls: 1,
+      browserCalls: 0,
+      agentRuns: 1,
+      agentSteps: 3,
+    },
+  })
+);
+
+function valueForColumn({ columnName, prompt, promptId }) {
+  if (columnName.endsWith("_url") || columnName === "source_url") {
+    return `https://example.com/${encodeURIComponent(promptId)}`;
+  }
+  if (columnName.includes("date") || columnName.endsWith("_at")) {
+    return "2026-05-19";
+  }
+  if (columnName.includes("price") || columnName.includes("count")) {
+    return 1;
+  }
+  if (columnName.startsWith("is_") || columnName.startsWith("has_")) {
+    return true;
+  }
+  return prompt.slice(0, 80) || promptId;
+}

--- a/benchmarks/dataset-agent/adapters/template-adapter.mjs
+++ b/benchmarks/dataset-agent/adapters/template-adapter.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+
+const prompt = requiredEnv("BIGSET_BENCHMARK_PROMPT");
+const promptId = requiredEnv("BIGSET_BENCHMARK_PROMPT_ID");
+const requiredColumns = requiredEnv("BIGSET_BENCHMARK_REQUIRED_COLUMNS")
+  .split(",")
+  .map((columnName) => columnName.trim())
+  .filter(Boolean);
+const minimumRequiredColumns = (process.env.BIGSET_BENCHMARK_MINIMUM_REQUIRED_COLUMNS ?? "")
+  .split(",")
+  .map((columnName) => columnName.trim())
+  .filter(Boolean);
+
+const agentResult = await runCurrentAgent({
+  prompt,
+  promptId,
+  requiredColumns,
+  minimumRequiredColumns,
+});
+
+console.log(JSON.stringify(toBenchmarkPayload(agentResult)));
+
+async function runCurrentAgent(input) {
+  // Replace this function with the current agent call.
+  //
+  // Option A: direct JS import
+  // const { runDatasetAgent } = await import("../../path/to/agent.js");
+  // return runDatasetAgent({ prompt: input.prompt });
+  //
+  // Option B: existing CLI
+  // return runJsonCommand("npm", ["run", "agent:run", "--", input.prompt]);
+  //
+  // Option C: local HTTP server
+  // const response = await fetch("http://localhost:3001/dataset-agent", {
+  //   method: "POST",
+  //   headers: { "Content-Type": "application/json" },
+  //   body: JSON.stringify({ prompt: input.prompt }),
+  // });
+  // if (!response.ok) throw new Error(`Agent HTTP ${response.status}`);
+  // return response.json();
+  //
+  // Keep this throw until the real call is wired.
+  throw new Error(
+    `Wire current agent in ${import.meta.url} for prompt ${input.promptId}.`
+  );
+}
+
+function toBenchmarkPayload(agentResult) {
+  const rows = normalizeRows(agentResult.rows ?? agentResult.data ?? []);
+  return {
+    rows,
+    validationIssues:
+      agentResult.validationIssues ?? agentResult.issues ?? agentResult.errors ?? [],
+    usage: {
+      promptTokens:
+        agentResult.usage?.promptTokens ??
+        agentResult.usage?.inputTokens ??
+        agentResult.inputTokens ??
+        0,
+      completionTokens:
+        agentResult.usage?.completionTokens ??
+        agentResult.usage?.outputTokens ??
+        agentResult.outputTokens ??
+        0,
+      totalTokens:
+        agentResult.usage?.totalTokens ??
+        agentResult.totalTokens ??
+        0,
+    },
+    metrics: {
+      searchCalls:
+        agentResult.metrics?.searchCalls ?? agentResult.searchCallCount ?? 0,
+      fetchCalls:
+        agentResult.metrics?.fetchCalls ?? agentResult.fetchCallCount ?? 0,
+      browserCalls:
+        agentResult.metrics?.browserCalls ?? agentResult.browserCallCount ?? 0,
+      agentRuns:
+        agentResult.metrics?.agentRuns ?? agentResult.agentRunCount ?? 1,
+      agentSteps:
+        agentResult.metrics?.agentSteps ?? agentResult.agentStepCount ?? 0,
+    },
+  };
+}
+
+function normalizeRows(rows) {
+  return rows.map((row) => {
+    const cells = row.cells ?? row.data ?? row;
+    const sourceUrls = normalizeSourceUrls(row, cells);
+    return {
+      cells,
+      sourceUrls,
+      evidence: normalizeEvidence(row, sourceUrls),
+      needsReview: row.needsReview ?? row.needs_review ?? false,
+    };
+  });
+}
+
+function normalizeSourceUrls(row, cells) {
+  return [
+    ...arrayOfStrings(row.sourceUrls),
+    ...arrayOfStrings(row.sources),
+    ...arrayOfStrings(row.source_urls),
+    ...singleString(row.sourceUrl),
+    ...singleString(row.source_url),
+    ...singleString(cells.source_url),
+    ...singleString(cells.sourceUrl),
+  ].filter((value, index, array) => value && array.indexOf(value) === index);
+}
+
+function normalizeEvidence(row, sourceUrls) {
+  if (Array.isArray(row.evidence)) {
+    return row.evidence;
+  }
+  if (Array.isArray(row.evidenceQuotes)) {
+    return row.evidenceQuotes.map((quote) => ({
+      columnName: "entity_name",
+      sourceUrl: sourceUrls[0] ?? "",
+      quote,
+    }));
+  }
+  return [];
+}
+
+async function runJsonCommand(command, args) {
+  const execution = await runCommand(command, args);
+  if (execution.exitCode !== 0) {
+    throw new Error(`${command} exited ${execution.exitCode}: ${execution.stderr}`);
+  }
+  return JSON.parse(execution.stdout);
+}
+
+function runCommand(command, args) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("close", (exitCode) => {
+      resolve({ stdout, stderr, exitCode: exitCode ?? 1 });
+    });
+  });
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing ${name}. Run through run-benchmark.mjs.`);
+  }
+  return value;
+}
+
+function arrayOfStrings(value) {
+  return Array.isArray(value)
+    ? value.filter((item) => typeof item === "string")
+    : [];
+}
+
+function singleString(value) {
+  return typeof value === "string" ? [value] : [];
+}

--- a/benchmarks/dataset-agent/answer-keys-entity.mjs
+++ b/benchmarks/dataset-agent/answer-keys-entity.mjs
@@ -1,0 +1,438 @@
+const verifiedAt = "2026-05-20";
+
+export const entityAnswerKeysByPromptId = {
+  "latest-ai-blog-posts": {
+    verifiedAt,
+    sourceUrls: [
+      "https://openai.com/index/advancing-content-provenance/",
+      "https://www.anthropic.com/news/anthropic-kpmg",
+      "https://deepmind.google/blog/co-scientist-a-multi-agent-ai-partner-to-accelerate-research/",
+    ],
+    scoringNotes:
+      "Latest-post titles drift. Score entity coverage, official domains, dated titles, and source URLs rather than one frozen title only.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "latest_post_title", "latest_post_date", "source_url"],
+    expectedEntities: [
+      {
+        id: "openai",
+        label: "OpenAI",
+        aliases: ["openai"],
+        allowedSourceDomains: ["openai.com"],
+        requiredText: ["2026"],
+      },
+      {
+        id: "anthropic",
+        label: "Anthropic",
+        aliases: ["anthropic"],
+        allowedSourceDomains: ["anthropic.com"],
+        requiredText: ["2026"],
+      },
+      {
+        id: "google-deepmind",
+        label: "Google DeepMind",
+        aliases: ["google deepmind", "deepmind"],
+        allowedSourceDomains: ["deepmind.google"],
+        requiredText: ["2026"],
+      },
+    ],
+    minimumExpectedEntityMatches: 3,
+    officialSourceDomains: ["openai.com", "anthropic.com", "deepmind.google"],
+  },
+  "saas-pricing-pages": {
+    verifiedAt: "2026-05-22",
+    sourceUrls: [
+      "https://stripe.com/pricing",
+      "https://www.paddle.com/pricing",
+      "https://www.chargebee.com/pricing/",
+    ],
+    scoringNotes:
+      "Pass requires all three vendors, official domains, and visible plan or price text. Paddle's current pricing page can show Checkout transaction pricing.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "pricing_page_url", "plan_or_price", "source_url"],
+    expectedEntities: [
+      {
+        id: "stripe",
+        label: "Stripe",
+        aliases: ["stripe"],
+        allowedSourceDomains: ["stripe.com"],
+        requiredText: ["pricing"],
+      },
+      {
+        id: "paddle",
+        label: "Paddle",
+        aliases: ["paddle"],
+        allowedSourceDomains: ["paddle.com"],
+        requiredText: ["checkout", "5%", "50"],
+      },
+      {
+        id: "chargebee",
+        label: "Chargebee",
+        aliases: ["chargebee"],
+        allowedSourceDomains: ["chargebee.com"],
+        requiredText: ["starter", "performance", "enterprise"],
+      },
+    ],
+    minimumExpectedEntityMatches: 3,
+    officialSourceDomains: ["stripe.com", "paddle.com", "chargebee.com"],
+  },
+  "earnings-release-pages": {
+    verifiedAt: "2026-05-22",
+    sourceUrls: [
+      "https://www.apple.com/newsroom/2026/04/apple-reports-second-quarter-results/",
+      "https://www.microsoft.com/en-us/investor/earnings/fy-2026-q3/press-release-webcast",
+      "https://nvidianews.nvidia.com/news/nvidia-announces-financial-results-for-first-quarter-fiscal-2027",
+    ],
+    scoringNotes:
+      "As of 2026-05-22, Apple latest verified release is fiscal 2026 Q2 on 2026-04-30, Microsoft is FY26 Q3 on 2026-04-29, and NVIDIA is Q1 fiscal 2027 on 2026-05-20.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "release_date", "fiscal_quarter", "source_url"],
+    expectedEntities: [
+      {
+        id: "apple",
+        label: "Apple",
+        aliases: ["apple"],
+        allowedSourceDomains: ["apple.com"],
+        requiredText: ["second quarter", "q2", "2026", "april 30"],
+      },
+      {
+        id: "microsoft",
+        label: "Microsoft",
+        aliases: ["microsoft"],
+        allowedSourceDomains: ["microsoft.com"],
+        requiredText: ["fy26 q3", "q3", "april 29", "2026"],
+      },
+      {
+        id: "nvidia",
+        label: "NVIDIA",
+        aliases: ["nvidia"],
+        allowedSourceDomains: ["nvidia.com"],
+        requiredText: ["first quarter", "q1", "fiscal 2027", "may 20"],
+      },
+    ],
+    minimumExpectedEntityMatches: 3,
+    officialSourceDomains: ["apple.com", "microsoft.com", "nvidia.com"],
+  },
+  "mcp-docs-pages": {
+    verifiedAt,
+    sourceUrls: [
+      "https://developers.openai.com/api/docs/mcp",
+      "https://platform.claude.com/docs/en/agents-and-tools/mcp-connector",
+      "https://developers.cloudflare.com/agents/model-context-protocol/",
+    ],
+    scoringNotes:
+      "Pass requires official docs for all three vendors. Blog posts, GitHub examples, and community roundups are not enough.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "docs_title", "docs_url", "summary"],
+    expectedEntities: [
+      {
+        id: "openai",
+        label: "OpenAI",
+        aliases: ["openai"],
+        allowedSourceDomains: ["developers.openai.com", "platform.openai.com", "openai.com"],
+        requiredText: ["mcp"],
+      },
+      {
+        id: "anthropic",
+        label: "Anthropic",
+        aliases: ["anthropic"],
+        allowedSourceDomains: ["docs.anthropic.com", "platform.claude.com"],
+        requiredText: ["mcp"],
+      },
+      {
+        id: "cloudflare",
+        label: "Cloudflare",
+        aliases: ["cloudflare"],
+        allowedSourceDomains: ["developers.cloudflare.com"],
+        requiredText: ["mcp"],
+      },
+    ],
+    minimumExpectedEntityMatches: 3,
+    officialSourceDomains: [
+      "developers.openai.com",
+      "platform.openai.com",
+      "openai.com",
+      "docs.anthropic.com",
+      "platform.claude.com",
+      "developers.cloudflare.com",
+    ],
+  },
+  "menlo-park-coca-cola": {
+    verifiedAt,
+    sourceUrls: [
+      "https://order-menlopark.celiasrestaurants.com/",
+      "https://www.portablurestaurant.com/menus",
+    ],
+    scoringNotes:
+      "Pass requires direct menu/order evidence for Coke/Coca-Cola. A directory saying a restaurant exists is not proof.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "address", "serves_requested_item", "source_url"],
+    rowMustContainAny: ["coca-cola", "coke", "diet coke", "diet coca-cola"],
+    minimumScore: 0.7,
+  },
+  "hcmc-bakery-products": {
+    verifiedAt,
+    sourceUrls: [
+      "https://maisonmarou.com/product/croissant/",
+      "https://moncannele.com/products/box-of-9-mini",
+    ],
+    scoringNotes:
+      "Pass requires product-detail URLs from bakery-owned sites, not generic listicles.",
+    expectedBehavior: "answer",
+    requiredColumns: ["bakery_name", "product_name", "product_url", "source_url"],
+    expectedEntities: [
+      {
+        id: "maison-marou",
+        label: "Maison Marou",
+        aliases: ["maison marou", "marou"],
+        allowedSourceDomains: ["maisonmarou.com"],
+        requiredText: ["croissant", "macaron", "opera", "pastry"],
+      },
+      {
+        id: "mon-cannele",
+        label: "Mon Cannele",
+        aliases: ["mon cannele", "cannel"],
+        allowedSourceDomains: ["moncannele.com"],
+        requiredText: ["cannel"],
+      },
+    ],
+    minimumExpectedEntityMatches: 1,
+    officialSourceDomains: ["maisonmarou.com", "moncannele.com"],
+  },
+  "ny-ai-startup-careers": {
+    verifiedAt,
+    sourceUrls: [
+      "https://www.runwayml.com/careers",
+      "https://www.huggingface.co/jobs",
+      "https://www.hebbia.ai/careers",
+    ],
+    scoringNotes:
+      "Pass requires company-owned websites or careers pages. One third-party startup directory with repeated 'View Jobs' text is not enough.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "company_website", "careers_page_url", "is_hiring"],
+    expectedEntities: [
+      {
+        id: "runway",
+        label: "Runway",
+        aliases: ["runway"],
+        allowedSourceDomains: ["runwayml.com"],
+        requiredText: ["careers", "jobs"],
+      },
+      {
+        id: "hugging-face",
+        label: "Hugging Face",
+        aliases: ["hugging face", "huggingface"],
+        allowedSourceDomains: ["huggingface.co"],
+        requiredText: ["jobs", "careers"],
+      },
+      {
+        id: "hebbia",
+        label: "Hebbia",
+        aliases: ["hebbia"],
+        allowedSourceDomains: ["hebbia.ai"],
+        requiredText: ["careers", "jobs"],
+      },
+    ],
+    minimumExpectedEntityMatches: 2,
+  },
+  "vietnam-fintech-sites": {
+    verifiedAt,
+    sourceUrls: [
+      "https://www.momo.vn/",
+      "https://zalopay.vn/",
+      "https://vnpay.vn/",
+      "https://www.finhay.com.vn/",
+    ],
+    scoringNotes:
+      "Pass requires official company/product domains for Vietnamese fintech examples.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "official_website", "description", "source_url"],
+    expectedEntities: [
+      {
+        id: "momo",
+        label: "MoMo",
+        aliases: ["momo"],
+        allowedSourceDomains: ["momo.vn"],
+      },
+      {
+        id: "zalopay",
+        label: "ZaloPay",
+        aliases: ["zalopay", "zalo pay"],
+        allowedSourceDomains: ["zalopay.vn"],
+      },
+      {
+        id: "vnpay",
+        label: "VNPAY",
+        aliases: ["vnpay"],
+        allowedSourceDomains: ["vnpay.vn"],
+      },
+      {
+        id: "finhay",
+        label: "Finhay",
+        aliases: ["finhay"],
+        allowedSourceDomains: ["finhay.com.vn"],
+      },
+    ],
+    minimumExpectedEntityMatches: 3,
+    officialSourceDomains: ["momo.vn", "zalopay.vn", "vnpay.vn", "finhay.com.vn"],
+  },
+  "district-one-coffee-sites": {
+    verifiedAt,
+    sourceUrls: ["https://tonkin.coffee/menu/", "https://www.cafehien.com/"],
+    scoringNotes:
+      "Pass requires a shop-owned site or online menu plus District 1 address evidence.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "website_or_menu_url", "address", "source_url"],
+    expectedEntities: [
+      {
+        id: "tonkin",
+        label: "Tonkin Coffee",
+        aliases: ["tonkin"],
+        allowedSourceDomains: ["tonkin.coffee"],
+        requiredText: ["district 1", "menu"],
+      },
+      {
+        id: "hien",
+        label: "Hien Cafe",
+        aliases: ["hien cafe", "cafe hien"],
+        allowedSourceDomains: ["cafehien.com"],
+        requiredText: ["menu", "ho chi minh"],
+      },
+    ],
+    minimumExpectedEntityMatches: 1,
+  },
+  "amazon-starbucks-products": {
+    verifiedAt,
+    sourceUrls: ["https://www.amazon.com/stores/Starbucks/Starbucks/page/"],
+    scoringNotes:
+      "Pass requires Amazon product/listing evidence with product name, price, image URL, and stock/availability. If Amazon blocks access, an honest validation issue beats hallucinated products.",
+    expectedBehavior: "answer",
+    requiredColumns: ["product_name", "price", "image_url", "in_stock"],
+    officialSourceDomains: ["amazon.com"],
+    rowMustContainAny: ["starbucks"],
+    minimumScore: 0.7,
+  },
+  "california-insurance-prices": {
+    verifiedAt,
+    sourceUrls: [
+      "https://www.geico.com/auto-insurance/",
+      "https://www.progressive.com/auto/",
+      "https://www.statefarm.com/insurance/auto",
+    ],
+    scoringNotes:
+      "Actual prices require driver, vehicle, ZIP, coverage, and deductible. Best behavior is official quote pages plus missing-input validation, not invented premiums.",
+    expectedBehavior: "clarify_or_abstain",
+    requiredColumns: ["provider_name", "quote_page_url", "missing_inputs", "source_url"],
+    clarificationTerms: ["driver", "vehicle", "zip", "coverage", "deductible"],
+    officialSourceDomains: ["geico.com", "progressive.com", "statefarm.com"],
+  },
+  "la-coke-menu-lol": {
+    verifiedAt,
+    sourceUrls: [],
+    scoringNotes:
+      "Pass requires direct LA menu/order evidence for Coke/Coca-Cola. Yelp/listicle rows are not enough.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "menu_url", "serves_requested_item", "source_url"],
+    rowMustContainAny: ["coca-cola", "coke", "diet coke", "soft drink"],
+    minimumScore: 0.9,
+  },
+  "sf-ml-hiring-rn": {
+    verifiedAt,
+    sourceUrls: [
+      "https://openai.com/careers/",
+      "https://www.anthropic.com/careers",
+      "https://www.perplexity.ai/careers",
+    ],
+    scoringNotes:
+      "Pass requires current company-owned careers/job pages with ML or AI role evidence near San Francisco or the Bay Area.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "careers_page_url", "open_role_title", "source_url"],
+    expectedEntities: [
+      {
+        id: "openai",
+        label: "OpenAI",
+        aliases: ["openai"],
+        allowedSourceDomains: ["openai.com"],
+        requiredText: ["machine learning", "ml", "research", "engineer"],
+      },
+      {
+        id: "anthropic",
+        label: "Anthropic",
+        aliases: ["anthropic"],
+        allowedSourceDomains: ["anthropic.com"],
+        requiredText: ["machine learning", "ml", "research", "engineer"],
+      },
+      {
+        id: "perplexity",
+        label: "Perplexity",
+        aliases: ["perplexity"],
+        allowedSourceDomains: ["perplexity.ai"],
+        requiredText: ["machine learning", "ml", "engineer"],
+      },
+    ],
+    minimumExpectedEntityMatches: 1,
+  },
+  "latest-ai-company-stuff": {
+    verifiedAt,
+    sourceUrls: [],
+    scoringNotes:
+      "Prompt is underspecified. Best behavior is ask which companies and item types count, or return an explicitly scoped partial dataset with validation issues.",
+    expectedBehavior: "clarify_or_abstain",
+    requiredColumns: ["entity_name", "latest_item_title", "latest_item_url", "source_url"],
+    clarificationTerms: ["which companies", "source type", "news", "blog", "release", "columns"],
+  },
+  "pastry-things-menlo": {
+    verifiedAt,
+    sourceUrls: ["https://mademoisellecolette.com/", "https://www.fleurdelysbakery.com/"],
+    scoringNotes:
+      "Pass requires bakery-owned websites or product/menu pages near Menlo Park. 'Good' should not become invented ratings.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "product_or_business_name", "website_url", "source_url"],
+    expectedEntities: [
+      {
+        id: "mademoiselle-colette",
+        label: "Mademoiselle Colette",
+        aliases: ["mademoiselle colette"],
+        allowedSourceDomains: ["mademoisellecolette.com"],
+      },
+      {
+        id: "fleur-de-lys",
+        label: "Fleur de Lys",
+        aliases: ["fleur de lys"],
+        allowedSourceDomains: ["fleurdelysbakery.com"],
+      },
+    ],
+    minimumExpectedEntityMatches: 1,
+  },
+  "perplexity-like-companies": {
+    verifiedAt,
+    sourceUrls: ["https://www.perplexity.ai/", "https://you.com/", "https://www.glean.com/"],
+    scoringNotes:
+      "Prompt is vague but answerable as AI search/answer companies if the system explains the comparison. Pass requires official websites and a concrete similarity reason.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "official_website", "why_similar", "source_url"],
+    expectedEntities: [
+      {
+        id: "you-com",
+        label: "You.com",
+        aliases: ["you.com", "youcom"],
+        allowedSourceDomains: ["you.com"],
+        requiredText: ["search", "answer", "ai"],
+      },
+      {
+        id: "glean",
+        label: "Glean",
+        aliases: ["glean"],
+        allowedSourceDomains: ["glean.com"],
+        requiredText: ["search", "workplace", "ai"],
+      },
+      {
+        id: "exa",
+        label: "Exa",
+        aliases: ["exa"],
+        allowedSourceDomains: ["exa.ai"],
+        requiredText: ["search", "web", "ai"],
+      },
+    ],
+    minimumExpectedEntityMatches: 1,
+  },
+};

--- a/benchmarks/dataset-agent/prompts.json
+++ b/benchmarks/dataset-agent/prompts.json
@@ -1,0 +1,130 @@
+[
+  {
+    "id": "latest-ai-blog-posts",
+    "quality": "good",
+    "persona": "technical operator",
+    "prompt": "Can you make me a table of the latest blog posts from OpenAI, Anthropic, and Google DeepMind? I need title, publish date, and URL.",
+    "requiredColumns": ["entity_name", "latest_post_title", "latest_post_date", "source_url"],
+    "expectedStress": "Clear entities and fields; tests current web facts with low ambiguity."
+  },
+  {
+    "id": "saas-pricing-pages",
+    "quality": "good",
+    "persona": "startup founder",
+    "prompt": "For Stripe, Paddle, and Chargebee, collect the official pricing page URL and the plan names or starting prices shown on the page.",
+    "requiredColumns": ["entity_name", "pricing_page_url", "plan_or_price", "source_url"],
+    "expectedStress": "Official pricing evidence; should not require a browser agent unless pricing is hidden."
+  },
+  {
+    "id": "earnings-release-pages",
+    "quality": "good",
+    "persona": "finance analyst",
+    "prompt": "Find the latest investor relations earnings release page for Apple, Microsoft, and Nvidia. Include release date, fiscal quarter, and source URL.",
+    "requiredColumns": ["entity_name", "release_date", "fiscal_quarter", "source_url"],
+    "expectedStress": "Latest dated source pages; date precision matters."
+  },
+  {
+    "id": "mcp-docs-pages",
+    "quality": "good",
+    "persona": "developer",
+    "prompt": "I need official docs pages for setting up MCP servers from Anthropic, OpenAI, and Cloudflare. Give me title, URL, and what each page covers.",
+    "requiredColumns": ["entity_name", "docs_title", "docs_url", "summary"],
+    "expectedStress": "Official docs discovery; should avoid random blog posts."
+  },
+  {
+    "id": "menlo-park-coca-cola",
+    "quality": "average",
+    "persona": "local researcher",
+    "prompt": "restaurants in Menlo Park that serve Coca-Cola",
+    "requiredColumns": ["entity_name", "address", "serves_requested_item", "source_url"],
+    "expectedStress": "Short but understandable; menu evidence may require deeper page checks."
+  },
+  {
+    "id": "hcmc-bakery-products",
+    "quality": "average",
+    "persona": "food blogger",
+    "prompt": "bakeries in Ho Chi Minh City with pastry product pages, product name, product URL, and bakery name",
+    "requiredColumns": ["bakery_name", "product_name", "product_url", "source_url"],
+    "expectedStress": "Product-page proof and local business search."
+  },
+  {
+    "id": "ny-ai-startup-careers",
+    "quality": "average",
+    "persona": "job seeker",
+    "prompt": "AI startups in New York that have careers pages. I want company name, website, and whether they look like they are hiring.",
+    "requiredColumns": ["entity_name", "company_website", "careers_page_url", "is_hiring"],
+    "expectedStress": "Careers-page verification with partial data accepted."
+  },
+  {
+    "id": "vietnam-fintech-sites",
+    "quality": "average",
+    "persona": "market researcher",
+    "prompt": "Vietnamese fintech startups with official websites, short description, and source URL",
+    "requiredColumns": ["entity_name", "official_website", "description", "source_url"],
+    "expectedStress": "Company discovery with official-source preference."
+  },
+  {
+    "id": "district-one-coffee-sites",
+    "quality": "average",
+    "persona": "tourist",
+    "prompt": "coffee shops in District 1 Ho Chi Minh City that have their own website or online menu",
+    "requiredColumns": ["entity_name", "website_or_menu_url", "address", "source_url"],
+    "expectedStress": "Local search plus website/menu disambiguation."
+  },
+  {
+    "id": "amazon-starbucks-products",
+    "quality": "average",
+    "persona": "ecommerce operator",
+    "prompt": "I saw there is a Starbucks shop on Amazon. Can you scrape the Starbucks products with name, price, image, and whether each item is in stock?",
+    "requiredColumns": ["product_name", "price", "image_url", "in_stock"],
+    "expectedStress": "Ecommerce listing freshness; likely needs browser-style verification."
+  },
+  {
+    "id": "california-insurance-prices",
+    "quality": "bad",
+    "persona": "consumer",
+    "prompt": "find me the best car insurance prices in California so I can pick the best bang for my buck",
+    "requiredColumns": ["provider_name", "quote_page_url", "missing_inputs", "source_url"],
+    "expectedStress": "Missing driver, vehicle, ZIP, coverage, deductible; should ask clarifying questions."
+  },
+  {
+    "id": "la-coke-menu-lol",
+    "quality": "bad",
+    "persona": "casual user",
+    "prompt": "i need places in LA with coke on the menu lol",
+    "requiredColumns": ["entity_name", "menu_url", "serves_requested_item", "source_url"],
+    "expectedStress": "Ambiguous location and entity type; should still infer restaurants but require menu evidence."
+  },
+  {
+    "id": "sf-ml-hiring-rn",
+    "quality": "bad",
+    "persona": "job seeker",
+    "prompt": "who's hiring ML engineers around sf rn",
+    "requiredColumns": ["entity_name", "careers_page_url", "open_role_title", "source_url"],
+    "expectedStress": "Casual wording and broad geography; should find careers pages without over-claiming."
+  },
+  {
+    "id": "latest-ai-company-stuff",
+    "quality": "bad",
+    "persona": "busy founder",
+    "prompt": "get me the latest stuff from the big AI companies",
+    "requiredColumns": ["entity_name", "latest_item_title", "latest_item_url", "source_url"],
+    "expectedStress": "Underspecified entities, source type, and columns; should expose weak plan/questions."
+  },
+  {
+    "id": "pastry-things-menlo",
+    "quality": "bad",
+    "persona": "casual food search",
+    "prompt": "good pastry things near Menlo Park with websites",
+    "requiredColumns": ["entity_name", "product_or_business_name", "website_url", "source_url"],
+    "expectedStress": "Vague quality word and entity boundary; should return product/business evidence only."
+  },
+  {
+    "id": "perplexity-like-companies",
+    "quality": "bad",
+    "persona": "founder",
+    "prompt": "make a table of companies like Perplexity but with useful info",
+    "requiredColumns": ["entity_name", "official_website", "why_similar", "source_url"],
+    "expectedStress": "Vague comparator and columns; should avoid inventing what useful info means."
+  }
+]

--- a/benchmarks/dataset-agent/prompts.json
+++ b/benchmarks/dataset-agent/prompts.json
@@ -1,8 +1,54 @@
 [
   {
+    "id": "yc-recent-batch-companies",
+    "quality": "open",
+    "persona": "founder",
+    "scoringMode": "open_ended",
+    "prompt": "Build a large dataset of companies from the most recent Y Combinator batch. For each company include company name, official website, a short description of what they do, and a source URL where you found it.",
+    "requiredColumns": ["entity_name", "website", "description", "source_url"],
+    "expectedStress": "Open-ended list building; should discover many distinct companies with official sites."
+  },
+  {
+    "id": "b2b-saas-free-tier",
+    "quality": "open",
+    "persona": "startup operator",
+    "scoringMode": "open_ended",
+    "prompt": "Collect B2B SaaS products that advertise a free tier or free plan. Include product or company name, pricing page URL, what the free tier includes, and a source URL.",
+    "requiredColumns": ["entity_name", "pricing_page_url", "free_tier_summary", "source_url"],
+    "expectedStress": "Broad market scan; many rows from varied vendors and pricing pages."
+  },
+  {
+    "id": "us-national-parks",
+    "quality": "open",
+    "persona": "travel planner",
+    "scoringMode": "open_ended",
+    "prompt": "List US National Parks with park name, primary state, official NPS or government page URL, and the year the park was established.",
+    "requiredColumns": ["entity_name", "state", "official_page_url", "established_year"],
+    "expectedStress": "Enumerable public dataset; should reach high row counts from official sources."
+  },
+  {
+    "id": "ai-research-labs",
+    "quality": "open",
+    "persona": "research coordinator",
+    "scoringMode": "open_ended",
+    "prompt": "Catalog university AI and machine learning research labs in the United States. For each lab include lab name, university, lab website URL, and a one-line research focus.",
+    "requiredColumns": ["entity_name", "university", "lab_website_url", "research_focus"],
+    "expectedStress": "Many labs across universities; official lab pages preferred."
+  },
+  {
+    "id": "public-company-investor-relations",
+    "quality": "open",
+    "persona": "finance analyst",
+    "scoringMode": "open_ended",
+    "prompt": "Build a table of S&P 500 companies with company name, ticker symbol, investor relations page URL, and headquarters city.",
+    "requiredColumns": ["entity_name", "ticker", "investor_relations_url", "headquarters_city"],
+    "expectedStress": "Large-cap universe; should scale toward ~100 rows of IR pages and HQ facts."
+  },
+  {
     "id": "latest-ai-blog-posts",
     "quality": "good",
     "persona": "technical operator",
+    "scoringMode": "entity",
     "prompt": "Can you make me a table of the latest blog posts from OpenAI, Anthropic, and Google DeepMind? I need title, publish date, and URL.",
     "requiredColumns": ["entity_name", "latest_post_title", "latest_post_date", "source_url"],
     "expectedStress": "Clear entities and fields; tests current web facts with low ambiguity."
@@ -11,6 +57,7 @@
     "id": "saas-pricing-pages",
     "quality": "good",
     "persona": "startup founder",
+    "scoringMode": "entity",
     "prompt": "For Stripe, Paddle, and Chargebee, collect the official pricing page URL and the plan names or starting prices shown on the page.",
     "requiredColumns": ["entity_name", "pricing_page_url", "plan_or_price", "source_url"],
     "expectedStress": "Official pricing evidence; should not require a browser agent unless pricing is hidden."
@@ -19,6 +66,7 @@
     "id": "earnings-release-pages",
     "quality": "good",
     "persona": "finance analyst",
+    "scoringMode": "entity",
     "prompt": "Find the latest investor relations earnings release page for Apple, Microsoft, and Nvidia. Include release date, fiscal quarter, and source URL.",
     "requiredColumns": ["entity_name", "release_date", "fiscal_quarter", "source_url"],
     "expectedStress": "Latest dated source pages; date precision matters."
@@ -27,6 +75,7 @@
     "id": "mcp-docs-pages",
     "quality": "good",
     "persona": "developer",
+    "scoringMode": "entity",
     "prompt": "I need official docs pages for setting up MCP servers from Anthropic, OpenAI, and Cloudflare. Give me title, URL, and what each page covers.",
     "requiredColumns": ["entity_name", "docs_title", "docs_url", "summary"],
     "expectedStress": "Official docs discovery; should avoid random blog posts."
@@ -35,6 +84,7 @@
     "id": "menlo-park-coca-cola",
     "quality": "average",
     "persona": "local researcher",
+    "scoringMode": "entity",
     "prompt": "restaurants in Menlo Park that serve Coca-Cola",
     "requiredColumns": ["entity_name", "address", "serves_requested_item", "source_url"],
     "expectedStress": "Short but understandable; menu evidence may require deeper page checks."
@@ -43,6 +93,7 @@
     "id": "hcmc-bakery-products",
     "quality": "average",
     "persona": "food blogger",
+    "scoringMode": "entity",
     "prompt": "bakeries in Ho Chi Minh City with pastry product pages, product name, product URL, and bakery name",
     "requiredColumns": ["bakery_name", "product_name", "product_url", "source_url"],
     "expectedStress": "Product-page proof and local business search."
@@ -51,6 +102,7 @@
     "id": "ny-ai-startup-careers",
     "quality": "average",
     "persona": "job seeker",
+    "scoringMode": "entity",
     "prompt": "AI startups in New York that have careers pages. I want company name, website, and whether they look like they are hiring.",
     "requiredColumns": ["entity_name", "company_website", "careers_page_url", "is_hiring"],
     "expectedStress": "Careers-page verification with partial data accepted."
@@ -59,6 +111,7 @@
     "id": "vietnam-fintech-sites",
     "quality": "average",
     "persona": "market researcher",
+    "scoringMode": "entity",
     "prompt": "Vietnamese fintech startups with official websites, short description, and source URL",
     "requiredColumns": ["entity_name", "official_website", "description", "source_url"],
     "expectedStress": "Company discovery with official-source preference."
@@ -67,6 +120,7 @@
     "id": "district-one-coffee-sites",
     "quality": "average",
     "persona": "tourist",
+    "scoringMode": "entity",
     "prompt": "coffee shops in District 1 Ho Chi Minh City that have their own website or online menu",
     "requiredColumns": ["entity_name", "website_or_menu_url", "address", "source_url"],
     "expectedStress": "Local search plus website/menu disambiguation."
@@ -75,6 +129,7 @@
     "id": "amazon-starbucks-products",
     "quality": "average",
     "persona": "ecommerce operator",
+    "scoringMode": "entity",
     "prompt": "I saw there is a Starbucks shop on Amazon. Can you scrape the Starbucks products with name, price, image, and whether each item is in stock?",
     "requiredColumns": ["product_name", "price", "image_url", "in_stock"],
     "expectedStress": "Ecommerce listing freshness; likely needs browser-style verification."
@@ -83,6 +138,7 @@
     "id": "california-insurance-prices",
     "quality": "bad",
     "persona": "consumer",
+    "scoringMode": "entity",
     "prompt": "find me the best car insurance prices in California so I can pick the best bang for my buck",
     "requiredColumns": ["provider_name", "quote_page_url", "missing_inputs", "source_url"],
     "expectedStress": "Missing driver, vehicle, ZIP, coverage, deductible; should ask clarifying questions."
@@ -91,6 +147,7 @@
     "id": "la-coke-menu-lol",
     "quality": "bad",
     "persona": "casual user",
+    "scoringMode": "entity",
     "prompt": "i need places in LA with coke on the menu lol",
     "requiredColumns": ["entity_name", "menu_url", "serves_requested_item", "source_url"],
     "expectedStress": "Ambiguous location and entity type; should still infer restaurants but require menu evidence."
@@ -99,6 +156,7 @@
     "id": "sf-ml-hiring-rn",
     "quality": "bad",
     "persona": "job seeker",
+    "scoringMode": "entity",
     "prompt": "who's hiring ML engineers around sf rn",
     "requiredColumns": ["entity_name", "careers_page_url", "open_role_title", "source_url"],
     "expectedStress": "Casual wording and broad geography; should find careers pages without over-claiming."
@@ -107,6 +165,7 @@
     "id": "latest-ai-company-stuff",
     "quality": "bad",
     "persona": "busy founder",
+    "scoringMode": "entity",
     "prompt": "get me the latest stuff from the big AI companies",
     "requiredColumns": ["entity_name", "latest_item_title", "latest_item_url", "source_url"],
     "expectedStress": "Underspecified entities, source type, and columns; should expose weak plan/questions."
@@ -115,6 +174,7 @@
     "id": "pastry-things-menlo",
     "quality": "bad",
     "persona": "casual food search",
+    "scoringMode": "entity",
     "prompt": "good pastry things near Menlo Park with websites",
     "requiredColumns": ["entity_name", "product_or_business_name", "website_url", "source_url"],
     "expectedStress": "Vague quality word and entity boundary; should return product/business evidence only."
@@ -123,6 +183,7 @@
     "id": "perplexity-like-companies",
     "quality": "bad",
     "persona": "founder",
+    "scoringMode": "entity",
     "prompt": "make a table of companies like Perplexity but with useful info",
     "requiredColumns": ["entity_name", "official_website", "why_similar", "source_url"],
     "expectedStress": "Vague comparator and columns; should avoid inventing what useful info means."

--- a/benchmarks/dataset-agent/run-benchmark.mjs
+++ b/benchmarks/dataset-agent/run-benchmark.mjs
@@ -534,6 +534,8 @@ async function runSystemPrompt(input) {
       BIGSET_BENCHMARK_PROMPT: input.promptDefinition.prompt,
       BIGSET_BENCHMARK_PROMPT_ID: input.promptDefinition.id,
       BIGSET_BENCHMARK_PROMPT_QUALITY: input.promptDefinition.quality,
+      BIGSET_BENCHMARK_PERSONA: input.promptDefinition.persona,
+      BIGSET_BENCHMARK_EXPECTED_STRESS: input.promptDefinition.expectedStress,
       BIGSET_BENCHMARK_REQUIRED_COLUMNS: input.promptDefinition.requiredColumns.join(","),
       BIGSET_BENCHMARK_MINIMUM_REQUIRED_COLUMNS: minimumRequiredColumns.join(","),
     },

--- a/benchmarks/dataset-agent/run-benchmark.mjs
+++ b/benchmarks/dataset-agent/run-benchmark.mjs
@@ -1,12 +1,99 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { entityAnswerKeysByPromptId } from "./answer-keys-entity.mjs";
+
 const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, "../..");
 const defaultPromptsPath = join(scriptDir, "prompts.json");
-const defaultMinimumFactualAccuracy = 0.75;
+const defaultMinimumFactualAccuracy = 0.5;
+
+const defaultTargetContract = {
+  targetRows: 100,
+  minRowCount: 50,
+  minRequiredCompleteness: 0.6,
+  minFactualAccuracy: 0.5,
+  minEvidenceCoverage: 0.95,
+  requireEvidence: false,
+};
+
+/** Fixed-entity prompts (original 16-pack): stricter gates and evidence required. */
+const entityBenchmarkContract = {
+  targetRows: 10,
+  minRowCount: 1,
+  minRequiredCompleteness: 0.75,
+  minFactualAccuracy: 0.75,
+  minEvidenceCoverage: 1,
+  requireEvidence: true,
+};
+
+function parseEnvFileContent(content) {
+  const entries = {};
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+    const separatorIndex = trimmed.indexOf("=");
+    if (separatorIndex <= 0) {
+      continue;
+    }
+    const key = trimmed.slice(0, separatorIndex).trim();
+    let value = trimmed.slice(separatorIndex + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    entries[key] = value;
+  }
+  return entries;
+}
+
+function loadBenchmarkEnvFiles() {
+  if (process.env.BIGSET_BENCHMARK_SKIP_ENV_FILES === "1") {
+    return;
+  }
+
+  const envFiles = [
+    join(repoRoot, ".env"),
+    join(repoRoot, "backend", ".env"),
+    join(repoRoot, "backend", ".env.local"),
+  ];
+  const merged = {};
+
+  for (const envPath of envFiles) {
+    if (!existsSync(envPath)) {
+      continue;
+    }
+    Object.assign(merged, parseEnvFileContent(readFileSync(envPath, "utf8")));
+  }
+
+  for (const [key, value] of Object.entries(merged)) {
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+}
+
+function applyBenchmarkDefaults() {
+  if (!process.env.COLLECTION_AGENT_PIPELINE_MODULE) {
+    process.env.COLLECTION_AGENT_PIPELINE_MODULE =
+      "./backend/BigSet_Data_Collection_Agent/src/orchestrator/pipeline.ts";
+  }
+  if (!process.env.BIGSET_COLLECTION_BENCHMARK_RUNNER_MODULE) {
+    process.env.BIGSET_COLLECTION_BENCHMARK_RUNNER_MODULE =
+      "./backend/src/pipeline/collection-agent-runner.ts";
+  }
+}
+
+loadBenchmarkEnvFiles();
+applyBenchmarkDefaults();
 
 async function main() {
   const config = parseArgs(process.argv.slice(2));
@@ -63,6 +150,7 @@ async function main() {
     wallClockMs: Date.now() - runStartedAt.getTime(),
     promptCount: prompts.length,
     promptMix: promptMixSummary(prompts),
+    targetContract: config.targetContract,
     systems: config.systems.map(({ name }) => name),
     costAssumptions: {
       inputUsdPer1M: config.inputUsdPer1M,
@@ -78,447 +166,39 @@ async function main() {
   console.log(JSON.stringify(summary, null, 2));
 }
 
-const verifiedAt = "2026-05-20";
 const answerKeysByPromptId = {
-  "latest-ai-blog-posts": {
-    verifiedAt,
-    sourceUrls: [
-      "https://openai.com/index/advancing-content-provenance/",
-      "https://www.anthropic.com/news/anthropic-kpmg",
-      "https://deepmind.google/blog/co-scientist-a-multi-agent-ai-partner-to-accelerate-research/",
-    ],
-    scoringNotes:
-      "Latest-post titles drift. Score entity coverage, official domains, dated titles, and source URLs rather than one frozen title only.",
+  "yc-recent-batch-companies": {
+    scoringMode: "open_ended",
     expectedBehavior: "answer",
-    requiredColumns: ["entity_name", "latest_post_title", "latest_post_date", "source_url"],
-    expectedEntities: [
-      {
-        id: "openai",
-        label: "OpenAI",
-        aliases: ["openai"],
-        allowedSourceDomains: ["openai.com"],
-        requiredText: ["2026"],
-      },
-      {
-        id: "anthropic",
-        label: "Anthropic",
-        aliases: ["anthropic"],
-        allowedSourceDomains: ["anthropic.com"],
-        requiredText: ["2026"],
-      },
-      {
-        id: "google-deepmind",
-        label: "Google DeepMind",
-        aliases: ["google deepmind", "deepmind"],
-        allowedSourceDomains: ["deepmind.google"],
-        requiredText: ["2026"],
-      },
-    ],
-    minimumExpectedEntityMatches: 3,
-    officialSourceDomains: ["openai.com", "anthropic.com", "deepmind.google"],
+    requiredColumns: ["entity_name", "website", "description", "source_url"],
+    scoringNotes: "Open-ended YC batch company discovery.",
   },
-  "saas-pricing-pages": {
-    verifiedAt: "2026-05-22",
-    sourceUrls: [
-      "https://stripe.com/pricing",
-      "https://www.paddle.com/pricing",
-      "https://www.chargebee.com/pricing/",
-    ],
-    scoringNotes:
-      "Pass requires all three vendors, official domains, and visible plan or price text. Paddle's current pricing page can show Checkout transaction pricing.",
+  "b2b-saas-free-tier": {
+    scoringMode: "open_ended",
     expectedBehavior: "answer",
-    requiredColumns: ["entity_name", "pricing_page_url", "plan_or_price", "source_url"],
-    expectedEntities: [
-      {
-        id: "stripe",
-        label: "Stripe",
-        aliases: ["stripe"],
-        allowedSourceDomains: ["stripe.com"],
-        requiredText: ["pricing"],
-      },
-      {
-        id: "paddle",
-        label: "Paddle",
-        aliases: ["paddle"],
-        allowedSourceDomains: ["paddle.com"],
-        requiredText: ["checkout", "5%", "50"],
-      },
-      {
-        id: "chargebee",
-        label: "Chargebee",
-        aliases: ["chargebee"],
-        allowedSourceDomains: ["chargebee.com"],
-        requiredText: ["starter", "performance", "enterprise"],
-      },
-    ],
-    minimumExpectedEntityMatches: 3,
-    officialSourceDomains: ["stripe.com", "paddle.com", "chargebee.com"],
+    requiredColumns: ["entity_name", "pricing_page_url", "free_tier_summary", "source_url"],
+    scoringNotes: "Open-ended SaaS free-tier scan.",
   },
-  "earnings-release-pages": {
-    verifiedAt: "2026-05-22",
-    sourceUrls: [
-      "https://www.apple.com/newsroom/2026/04/apple-reports-second-quarter-results/",
-      "https://www.microsoft.com/en-us/investor/earnings/fy-2026-q3/press-release-webcast",
-      "https://nvidianews.nvidia.com/news/nvidia-announces-financial-results-for-first-quarter-fiscal-2027",
-    ],
-    scoringNotes:
-      "As of 2026-05-22, Apple latest verified release is fiscal 2026 Q2 on 2026-04-30, Microsoft is FY26 Q3 on 2026-04-29, and NVIDIA is Q1 fiscal 2027 on 2026-05-20.",
+  "us-national-parks": {
+    scoringMode: "open_ended",
     expectedBehavior: "answer",
-    requiredColumns: ["entity_name", "release_date", "fiscal_quarter", "source_url"],
-    expectedEntities: [
-      {
-        id: "apple",
-        label: "Apple",
-        aliases: ["apple"],
-        allowedSourceDomains: ["apple.com"],
-        requiredText: ["second quarter", "q2", "2026", "april 30"],
-      },
-      {
-        id: "microsoft",
-        label: "Microsoft",
-        aliases: ["microsoft"],
-        allowedSourceDomains: ["microsoft.com"],
-        requiredText: ["fy26 q3", "q3", "april 29", "2026"],
-      },
-      {
-        id: "nvidia",
-        label: "NVIDIA",
-        aliases: ["nvidia"],
-        allowedSourceDomains: ["nvidia.com"],
-        requiredText: ["first quarter", "q1", "fiscal 2027", "may 20"],
-      },
-    ],
-    minimumExpectedEntityMatches: 3,
-    officialSourceDomains: ["apple.com", "microsoft.com", "nvidia.com"],
+    requiredColumns: ["entity_name", "state", "official_page_url", "established_year"],
+    scoringNotes: "Open-ended US National Parks list.",
   },
-  "mcp-docs-pages": {
-    verifiedAt,
-    sourceUrls: [
-      "https://developers.openai.com/api/docs/mcp",
-      "https://platform.claude.com/docs/en/agents-and-tools/mcp-connector",
-      "https://developers.cloudflare.com/agents/model-context-protocol/",
-    ],
-    scoringNotes:
-      "Pass requires official docs for all three vendors. Blog posts, GitHub examples, and community roundups are not enough.",
+  "ai-research-labs": {
+    scoringMode: "open_ended",
     expectedBehavior: "answer",
-    requiredColumns: ["entity_name", "docs_title", "docs_url", "summary"],
-    expectedEntities: [
-      {
-        id: "openai",
-        label: "OpenAI",
-        aliases: ["openai"],
-        allowedSourceDomains: ["developers.openai.com", "platform.openai.com", "openai.com"],
-        requiredText: ["mcp"],
-      },
-      {
-        id: "anthropic",
-        label: "Anthropic",
-        aliases: ["anthropic"],
-        allowedSourceDomains: ["docs.anthropic.com", "platform.claude.com"],
-        requiredText: ["mcp"],
-      },
-      {
-        id: "cloudflare",
-        label: "Cloudflare",
-        aliases: ["cloudflare"],
-        allowedSourceDomains: ["developers.cloudflare.com"],
-        requiredText: ["mcp"],
-      },
-    ],
-    minimumExpectedEntityMatches: 3,
-    officialSourceDomains: [
-      "developers.openai.com",
-      "platform.openai.com",
-      "openai.com",
-      "docs.anthropic.com",
-      "platform.claude.com",
-      "developers.cloudflare.com",
-    ],
+    requiredColumns: ["entity_name", "university", "lab_website_url", "research_focus"],
+    scoringNotes: "Open-ended university AI lab catalog.",
   },
-  "menlo-park-coca-cola": {
-    verifiedAt,
-    sourceUrls: [
-      "https://order-menlopark.celiasrestaurants.com/",
-      "https://www.portablurestaurant.com/menus",
-    ],
-    scoringNotes:
-      "Pass requires direct menu/order evidence for Coke/Coca-Cola. A directory saying a restaurant exists is not proof.",
+  "public-company-investor-relations": {
+    scoringMode: "open_ended",
     expectedBehavior: "answer",
-    requiredColumns: ["entity_name", "address", "serves_requested_item", "source_url"],
-    rowMustContainAny: ["coca-cola", "coke", "diet coke", "diet coca-cola"],
-    minimumScore: 0.7,
+    requiredColumns: ["entity_name", "ticker", "investor_relations_url", "headquarters_city"],
+    scoringNotes: "Open-ended S&P 500 IR page dataset.",
   },
-  "hcmc-bakery-products": {
-    verifiedAt,
-    sourceUrls: [
-      "https://maisonmarou.com/product/croissant/",
-      "https://moncannele.com/products/box-of-9-mini",
-    ],
-    scoringNotes:
-      "Pass requires product-detail URLs from bakery-owned sites, not generic listicles.",
-    expectedBehavior: "answer",
-    requiredColumns: ["bakery_name", "product_name", "product_url", "source_url"],
-    expectedEntities: [
-      {
-        id: "maison-marou",
-        label: "Maison Marou",
-        aliases: ["maison marou", "marou"],
-        allowedSourceDomains: ["maisonmarou.com"],
-        requiredText: ["croissant", "macaron", "opera", "pastry"],
-      },
-      {
-        id: "mon-cannele",
-        label: "Mon Cannele",
-        aliases: ["mon cannele", "cannel"],
-        allowedSourceDomains: ["moncannele.com"],
-        requiredText: ["cannel"],
-      },
-    ],
-    minimumExpectedEntityMatches: 1,
-    officialSourceDomains: ["maisonmarou.com", "moncannele.com"],
-  },
-  "ny-ai-startup-careers": {
-    verifiedAt,
-    sourceUrls: [
-      "https://www.runwayml.com/careers",
-      "https://www.huggingface.co/jobs",
-      "https://www.hebbia.ai/careers",
-    ],
-    scoringNotes:
-      "Pass requires company-owned websites or careers pages. One third-party startup directory with repeated 'View Jobs' text is not enough.",
-    expectedBehavior: "answer",
-    requiredColumns: ["entity_name", "company_website", "careers_page_url", "is_hiring"],
-    expectedEntities: [
-      {
-        id: "runway",
-        label: "Runway",
-        aliases: ["runway"],
-        allowedSourceDomains: ["runwayml.com"],
-        requiredText: ["careers", "jobs"],
-      },
-      {
-        id: "hugging-face",
-        label: "Hugging Face",
-        aliases: ["hugging face", "huggingface"],
-        allowedSourceDomains: ["huggingface.co"],
-        requiredText: ["jobs", "careers"],
-      },
-      {
-        id: "hebbia",
-        label: "Hebbia",
-        aliases: ["hebbia"],
-        allowedSourceDomains: ["hebbia.ai"],
-        requiredText: ["careers", "jobs"],
-      },
-    ],
-    minimumExpectedEntityMatches: 2,
-  },
-  "vietnam-fintech-sites": {
-    verifiedAt,
-    sourceUrls: [
-      "https://www.momo.vn/",
-      "https://zalopay.vn/",
-      "https://vnpay.vn/",
-      "https://www.finhay.com.vn/",
-    ],
-    scoringNotes:
-      "Pass requires official company/product domains for Vietnamese fintech examples.",
-    expectedBehavior: "answer",
-    requiredColumns: ["entity_name", "official_website", "description", "source_url"],
-    expectedEntities: [
-      {
-        id: "momo",
-        label: "MoMo",
-        aliases: ["momo"],
-        allowedSourceDomains: ["momo.vn"],
-      },
-      {
-        id: "zalopay",
-        label: "ZaloPay",
-        aliases: ["zalopay", "zalo pay"],
-        allowedSourceDomains: ["zalopay.vn"],
-      },
-      {
-        id: "vnpay",
-        label: "VNPAY",
-        aliases: ["vnpay"],
-        allowedSourceDomains: ["vnpay.vn"],
-      },
-      {
-        id: "finhay",
-        label: "Finhay",
-        aliases: ["finhay"],
-        allowedSourceDomains: ["finhay.com.vn"],
-      },
-    ],
-    minimumExpectedEntityMatches: 3,
-    officialSourceDomains: ["momo.vn", "zalopay.vn", "vnpay.vn", "finhay.com.vn"],
-  },
-  "district-one-coffee-sites": {
-    verifiedAt,
-    sourceUrls: ["https://tonkin.coffee/menu/", "https://www.cafehien.com/"],
-    scoringNotes:
-      "Pass requires a shop-owned site or online menu plus District 1 address evidence.",
-    expectedBehavior: "answer",
-    requiredColumns: ["entity_name", "website_or_menu_url", "address", "source_url"],
-    expectedEntities: [
-      {
-        id: "tonkin",
-        label: "Tonkin Coffee",
-        aliases: ["tonkin"],
-        allowedSourceDomains: ["tonkin.coffee"],
-        requiredText: ["district 1", "menu"],
-      },
-      {
-        id: "hien",
-        label: "Hien Cafe",
-        aliases: ["hien cafe", "cafe hien"],
-        allowedSourceDomains: ["cafehien.com"],
-        requiredText: ["menu", "ho chi minh"],
-      },
-    ],
-    minimumExpectedEntityMatches: 1,
-  },
-  "amazon-starbucks-products": {
-    verifiedAt,
-    sourceUrls: ["https://www.amazon.com/stores/Starbucks/Starbucks/page/"],
-    scoringNotes:
-      "Pass requires Amazon product/listing evidence with product name, price, image URL, and stock/availability. If Amazon blocks access, an honest validation issue beats hallucinated products.",
-    expectedBehavior: "answer",
-    requiredColumns: ["product_name", "price", "image_url", "in_stock"],
-    officialSourceDomains: ["amazon.com"],
-    rowMustContainAny: ["starbucks"],
-    minimumScore: 0.7,
-  },
-  "california-insurance-prices": {
-    verifiedAt,
-    sourceUrls: [
-      "https://www.geico.com/auto-insurance/",
-      "https://www.progressive.com/auto/",
-      "https://www.statefarm.com/insurance/auto",
-    ],
-    scoringNotes:
-      "Actual prices require driver, vehicle, ZIP, coverage, and deductible. Best behavior is official quote pages plus missing-input validation, not invented premiums.",
-    expectedBehavior: "clarify_or_abstain",
-    requiredColumns: ["provider_name", "quote_page_url", "missing_inputs", "source_url"],
-    clarificationTerms: ["driver", "vehicle", "zip", "coverage", "deductible"],
-    officialSourceDomains: ["geico.com", "progressive.com", "statefarm.com"],
-  },
-  "la-coke-menu-lol": {
-    verifiedAt,
-    sourceUrls: [],
-    scoringNotes:
-      "Pass requires direct LA menu/order evidence for Coke/Coca-Cola. Yelp/listicle rows are not enough.",
-    expectedBehavior: "answer",
-    requiredColumns: ["entity_name", "menu_url", "serves_requested_item", "source_url"],
-    rowMustContainAny: ["coca-cola", "coke", "diet coke", "soft drink"],
-    minimumScore: 0.9,
-  },
-  "sf-ml-hiring-rn": {
-    verifiedAt,
-    sourceUrls: [
-      "https://openai.com/careers/",
-      "https://www.anthropic.com/careers",
-      "https://www.perplexity.ai/careers",
-    ],
-    scoringNotes:
-      "Pass requires current company-owned careers/job pages with ML or AI role evidence near San Francisco or the Bay Area.",
-    expectedBehavior: "answer",
-    requiredColumns: ["entity_name", "careers_page_url", "open_role_title", "source_url"],
-    expectedEntities: [
-      {
-        id: "openai",
-        label: "OpenAI",
-        aliases: ["openai"],
-        allowedSourceDomains: ["openai.com"],
-        requiredText: ["machine learning", "ml", "research", "engineer"],
-      },
-      {
-        id: "anthropic",
-        label: "Anthropic",
-        aliases: ["anthropic"],
-        allowedSourceDomains: ["anthropic.com"],
-        requiredText: ["machine learning", "ml", "research", "engineer"],
-      },
-      {
-        id: "perplexity",
-        label: "Perplexity",
-        aliases: ["perplexity"],
-        allowedSourceDomains: ["perplexity.ai"],
-        requiredText: ["machine learning", "ml", "engineer"],
-      },
-    ],
-    minimumExpectedEntityMatches: 1,
-  },
-  "latest-ai-company-stuff": {
-    verifiedAt,
-    sourceUrls: [],
-    scoringNotes:
-      "Prompt is underspecified. Best behavior is ask which companies and item types count, or return an explicitly scoped partial dataset with validation issues.",
-    expectedBehavior: "clarify_or_abstain",
-    requiredColumns: ["entity_name", "latest_item_title", "latest_item_url", "source_url"],
-    clarificationTerms: ["which companies", "source type", "news", "blog", "release", "columns"],
-  },
-  "pastry-things-menlo": {
-    verifiedAt,
-    sourceUrls: ["https://mademoisellecolette.com/", "https://www.fleurdelysbakery.com/"],
-    scoringNotes:
-      "Pass requires bakery-owned websites or product/menu pages near Menlo Park. 'Good' should not become invented ratings.",
-    expectedBehavior: "answer",
-    requiredColumns: ["entity_name", "product_or_business_name", "website_url", "source_url"],
-    expectedEntities: [
-      {
-        id: "mademoiselle-colette",
-        label: "Mademoiselle Colette",
-        aliases: ["mademoiselle colette"],
-        allowedSourceDomains: ["mademoisellecolette.com"],
-      },
-      {
-        id: "fleur-de-lys",
-        label: "Fleur de Lys",
-        aliases: ["fleur de lys"],
-        allowedSourceDomains: ["fleurdelysbakery.com"],
-      },
-    ],
-    minimumExpectedEntityMatches: 1,
-  },
-  "perplexity-like-companies": {
-    verifiedAt,
-    sourceUrls: ["https://www.perplexity.ai/", "https://you.com/", "https://www.glean.com/"],
-    scoringNotes:
-      "Prompt is vague but answerable as AI search/answer companies if the system explains the comparison. Pass requires official websites and a concrete similarity reason.",
-    expectedBehavior: "answer",
-    requiredColumns: ["entity_name", "official_website", "why_similar", "source_url"],
-    expectedEntities: [
-      {
-        id: "you-com",
-        label: "You.com",
-        aliases: ["you.com", "youcom"],
-        allowedSourceDomains: ["you.com"],
-        requiredText: ["search", "answer", "ai"],
-      },
-      {
-        id: "glean",
-        label: "Glean",
-        aliases: ["glean"],
-        allowedSourceDomains: ["glean.com"],
-        requiredText: ["search", "workplace", "ai"],
-      },
-      {
-        id: "exa",
-        label: "Exa",
-        aliases: ["exa"],
-        allowedSourceDomains: ["exa.ai"],
-        requiredText: ["search", "web", "ai"],
-      },
-    ],
-    minimumExpectedEntityMatches: 1,
-  },
+  ...entityAnswerKeysByPromptId,
 };
-
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  await main();
-}
 
 async function runSystemPrompt(input) {
   const startedAt = Date.now();
@@ -529,6 +209,13 @@ async function runSystemPrompt(input) {
   console.error(
     `[${input.system.name}] ${input.promptIndex + 1}/${input.promptCount} ${input.promptDefinition.id}`
   );
+
+  const promptRunDirectory = join(
+    input.runDirectory,
+    input.system.name,
+    `${String(input.promptIndex + 1).padStart(2, "0")}-${input.promptDefinition.id}`
+  );
+  await mkdir(promptRunDirectory, { recursive: true });
 
   const execution = await runCommand({
     command,
@@ -541,6 +228,7 @@ async function runSystemPrompt(input) {
       BIGSET_BENCHMARK_EXPECTED_STRESS: input.promptDefinition.expectedStress,
       BIGSET_BENCHMARK_REQUIRED_COLUMNS: input.promptDefinition.requiredColumns.join(","),
       BIGSET_BENCHMARK_MINIMUM_REQUIRED_COLUMNS: minimumRequiredColumns.join(","),
+      BIGSET_BENCHMARK_ARTIFACT_DIR: promptRunDirectory,
     },
   });
   const parsedPayload = parseJsonPayload(execution.stdout);
@@ -549,13 +237,15 @@ async function runSystemPrompt(input) {
     rows: normalized.rows,
     promptDefinition: input.promptDefinition,
   });
+  const targetContract = resolveTargetContract(input.config, input.promptDefinition);
   const answerKeyScore = scoreBenchmarkRows({
     promptDefinition: input.promptDefinition,
     rows: normalized.rows,
     validationIssues: normalized.validationIssues,
     validation,
-    minRequiredCompleteness: input.config.minRequiredCompleteness,
-    minFactualAccuracy: input.config.minFactualAccuracy,
+    targetContract,
+    minRequiredCompleteness: targetContract.minRequiredCompleteness,
+    minFactualAccuracy: targetContract.minFactualAccuracy,
   });
   const usage = normalized.usage;
   const estimatedModelCostUsd = estimateModelCostUsd(usage, input.config);
@@ -573,12 +263,6 @@ async function runSystemPrompt(input) {
       ? "ok"
       : "failed";
 
-  const promptRunDirectory = join(
-    input.runDirectory,
-    input.system.name,
-    `${String(input.promptIndex + 1).padStart(2, "0")}-${input.promptDefinition.id}`
-  );
-  await mkdir(promptRunDirectory, { recursive: true });
   await writeFile(join(promptRunDirectory, "stdout.txt"), execution.stdout);
   await writeFile(join(promptRunDirectory, "stderr.txt"), execution.stderr);
   await writeJson(join(promptRunDirectory, "parsed-output.json"), parsedPayload ?? {
@@ -612,6 +296,9 @@ async function runSystemPrompt(input) {
     latencyMs: Date.now() - startedAt,
     exitCode: execution.exitCode,
     timedOut: execution.timedOut,
+    targetContract,
+    targetRows: targetContract.targetRows,
+    rowTargetRatio: answerKeyScore.rowTargetRatio,
     rowCount: validation.rowCount,
     nonEmptyCellCount: validation.nonEmptyCellCount,
     totalExpectedCellCount: validation.totalExpectedCellCount,
@@ -645,7 +332,8 @@ async function runSystemPrompt(input) {
         validation,
         answerKeyScore,
         infraBlockerReason,
-        minRequiredCompleteness: input.config.minRequiredCompleteness,
+        minRequiredCompleteness: targetContract.minRequiredCompleteness,
+        requireEvidence: targetContract.requireEvidence,
         validationIssues: normalized.validationIssues,
       }),
   };
@@ -744,8 +432,9 @@ function parseArgs(args) {
     inputUsdPer1M: 0.05,
     outputUsdPer1M: 0.5,
     tinyFishAgentStepUsd: 0.015,
-    minRequiredCompleteness: 0.75,
-    minFactualAccuracy: defaultMinimumFactualAccuracy,
+    targetContract: { ...defaultTargetContract },
+    minRequiredCompleteness: defaultTargetContract.minRequiredCompleteness,
+    minFactualAccuracy: defaultTargetContract.minFactualAccuracy,
   };
 
   for (let index = 0; index < args.length; index += 1) {
@@ -779,11 +468,27 @@ function parseArgs(args) {
     } else if (arg === "--tinyfish-agent-step-usd") {
       config.tinyFishAgentStepUsd = nonNegativeNumber(value, config.tinyFishAgentStepUsd);
       index += 1;
-    } else if (arg === "--min-required-completeness") {
-      config.minRequiredCompleteness = nonNegativeNumber(value, config.minRequiredCompleteness);
-      index += 1;
     } else if (arg === "--min-factual-accuracy") {
       config.minFactualAccuracy = nonNegativeNumber(value, config.minFactualAccuracy);
+      config.targetContract.minFactualAccuracy = config.minFactualAccuracy;
+      index += 1;
+    } else if (arg === "--target-rows") {
+      config.targetContract.targetRows = positiveNumber(value, config.targetContract.targetRows);
+      index += 1;
+    } else if (arg === "--min-row-count") {
+      config.targetContract.minRowCount = positiveNumber(value, config.targetContract.minRowCount);
+      index += 1;
+    } else if (arg === "--min-evidence-coverage") {
+      config.targetContract.minEvidenceCoverage = nonNegativeNumber(
+        value,
+        config.targetContract.minEvidenceCoverage
+      );
+      index += 1;
+    } else if (arg === "--require-evidence") {
+      config.targetContract.requireEvidence = true;
+    } else if (arg === "--min-required-completeness") {
+      config.minRequiredCompleteness = nonNegativeNumber(value, config.minRequiredCompleteness);
+      config.targetContract.minRequiredCompleteness = config.minRequiredCompleteness;
       index += 1;
     } else if (arg === "--help" || arg === "-h") {
       printHelpAndExit();
@@ -1056,13 +761,15 @@ async function rescoreBenchmarkRun({ runDirectory, prompts, config }) {
     const usablePayload = parsedPayload?.error ? null : parsedPayload;
     const normalized = normalizePayload(usablePayload);
     const validation = evaluateRows({ rows: normalized.rows, promptDefinition });
+    const targetContract = resolveTargetContract(config, promptDefinition);
     const answerKeyScore = scoreBenchmarkRows({
       promptDefinition,
       rows: normalized.rows,
       validationIssues: normalized.validationIssues,
       validation,
-      minRequiredCompleteness: config.minRequiredCompleteness,
-      minFactualAccuracy: config.minFactualAccuracy,
+      targetContract,
+      minRequiredCompleteness: targetContract.minRequiredCompleteness,
+      minFactualAccuracy: targetContract.minFactualAccuracy,
     });
     const execution = {
       stdout,
@@ -1101,6 +808,9 @@ async function rescoreBenchmarkRun({ runDirectory, prompts, config }) {
       matchedExpectedEntities: answerKeyScore.matchedExpectedEntities,
       missingExpectedEntities: answerKeyScore.missingExpectedEntities,
       missingClaimSupportEntities: answerKeyScore.missingClaimSupportEntities,
+      targetContract,
+      targetRows: targetContract.targetRows,
+      rowTargetRatio: answerKeyScore.rowTargetRatio,
       rowCount: validation.rowCount,
       nonEmptyCellCount: validation.nonEmptyCellCount,
       totalExpectedCellCount: validation.totalExpectedCellCount,
@@ -1124,7 +834,8 @@ async function rescoreBenchmarkRun({ runDirectory, prompts, config }) {
           validation,
           answerKeyScore,
           infraBlockerReason,
-          minRequiredCompleteness: config.minRequiredCompleteness,
+          minRequiredCompleteness: targetContract.minRequiredCompleteness,
+          requireEvidence: targetContract.requireEvidence,
           validationIssues: normalized.validationIssues,
         }),
     });
@@ -1178,8 +889,90 @@ async function resolveRescoreArtifactDirectory({ runDirectory, laneResult }) {
   return candidates[0];
 }
 
+export function resolveTargetContract(config, promptDefinition) {
+  const baseContract = promptDefinition.scoringMode === "open_ended"
+    ? defaultTargetContract
+    : entityBenchmarkContract;
+  return {
+    ...baseContract,
+    ...config.targetContract,
+    ...promptDefinition.targetContract,
+  };
+}
+
+export function scoreOpenEndedBenchmarkRows(input) {
+  const answerKey = answerKeyForPrompt(input.promptDefinition);
+  const contract = input.targetContract ?? resolveTargetContract(
+    { targetContract: defaultTargetContract },
+    input.promptDefinition
+  );
+  const evidenceSupportRatio = input.validation.rowCount === 0
+    ? 0
+    : roundRatio(input.validation.evidenceQuoteCount / Math.max(1, input.validation.rowCount));
+  const rowTargetRatio = contract.targetRows === 0
+    ? 0
+    : roundRatio(input.validation.rowCount / contract.targetRows);
+  const shapeScore = shapeScoreForRows({
+    validation: input.validation,
+    minRequiredCompleteness: contract.minRequiredCompleteness,
+    expectedBehavior: answerKey.expectedBehavior ?? "answer",
+    validationIssues: input.validationIssues,
+    requireEvidence: contract.requireEvidence,
+  });
+  const factualAccuracyScore = roundRatio(
+    shapeScore * 0.45 +
+      Math.min(1, rowTargetRatio) * 0.45 +
+      input.validation.requiredCellCompletenessRatio * 0.1
+  );
+  const minimumScore = contract.minFactualAccuracy;
+  const meetsRowTarget = input.validation.rowCount >= contract.minRowCount;
+  const meetsEvidenceCoverage = !contract.requireEvidence ||
+    evidenceSupportRatio >= contract.minEvidenceCoverage;
+  const passed = meetsRowTarget &&
+    input.validation.sourceUrlCount > 0 &&
+    shapeScore >= 1 &&
+    factualAccuracyScore >= minimumScore &&
+    meetsEvidenceCoverage;
+
+  return {
+    passed,
+    failureCategory: passed ? undefined : failureCategoryForOpenEnded({
+      validation: input.validation,
+      shapeScore,
+      rowTargetRatio,
+      contract,
+      meetsRowTarget,
+      meetsEvidenceCoverage,
+    }),
+    factualAccuracyScore,
+    entityCoverageRatio: rowTargetRatio,
+    domainAccuracyRatio: input.validation.sourceUrlCount > 0 ? 1 : 0,
+    evidenceSupportRatio,
+    claimSupportRatio: 1,
+    abstentionScore: 0,
+    rowTargetRatio,
+    matchedExpectedEntities: [],
+    missingExpectedEntities: [],
+    missingClaimSupportEntities: [],
+    minimumScore,
+  };
+}
+
+function failureCategoryForOpenEnded(input) {
+  if (input.validation.rowCount === 0) return "schema";
+  if (!input.meetsRowTarget) return "row_target";
+  if (input.validation.sourceUrlCount === 0) return "source_evidence";
+  if (input.shapeScore < 1) return "source_evidence";
+  if (!input.meetsEvidenceCoverage) return "source_evidence";
+  return "factual_accuracy";
+}
+
 export function scoreBenchmarkRows(input) {
   const answerKey = answerKeyForPrompt(input.promptDefinition);
+  const scoringMode = answerKey.scoringMode ?? input.promptDefinition.scoringMode ?? "entity";
+  if (scoringMode === "open_ended") {
+    return scoreOpenEndedBenchmarkRows(input);
+  }
   const rowTexts = input.rows.map(rowSearchText);
   const validationIssueText = input.validationIssues.join(" ").toLowerCase();
   const allText = [...rowTexts, validationIssueText].join(" ");
@@ -1236,11 +1029,13 @@ export function scoreBenchmarkRows(input) {
   const abstentionScore = answerKey.expectedBehavior === "clarify_or_abstain"
     ? clarificationScore(allText, answerKey.clarificationTerms ?? [])
     : 0;
+  const contract = input.targetContract ?? defaultTargetContract;
   const shapeScore = shapeScoreForRows({
     validation: input.validation,
     minRequiredCompleteness: input.minRequiredCompleteness,
     expectedBehavior: answerKey.expectedBehavior,
     validationIssues: input.validationIssues,
+    requireEvidence: contract.requireEvidence,
   });
   const factualAccuracyScore = answerKey.expectedBehavior === "clarify_or_abstain"
     ? roundRatio(
@@ -1298,7 +1093,28 @@ export function scoreBenchmarkRows(input) {
 }
 
 function answerKeyForPrompt(promptDefinition) {
-  return promptDefinition.answerKey ?? answerKeysByPromptId[promptDefinition.id] ?? {
+  const fromMap = answerKeysByPromptId[promptDefinition.id];
+  if (fromMap) {
+    return fromMap;
+  }
+  if (promptDefinition.scoringMode === "open_ended") {
+    return {
+      scoringMode: "open_ended",
+      expectedBehavior: "answer",
+      requiredColumns: promptDefinition.requiredColumns,
+      scoringNotes: promptDefinition.expectedStress,
+    };
+  }
+  if (promptDefinition.scoringMode === "entity") {
+    return entityAnswerKeysByPromptId[promptDefinition.id] ?? {
+      scoringMode: "entity",
+      expectedBehavior: "answer",
+      requiredColumns: promptDefinition.requiredColumns,
+      sourceUrls: [],
+      scoringNotes: promptDefinition.expectedStress,
+    };
+  }
+  return promptDefinition.answerKey ?? {
     expectedBehavior: "answer",
     requiredColumns: promptDefinition.requiredColumns,
     sourceUrls: [],
@@ -1306,11 +1122,20 @@ function answerKeyForPrompt(promptDefinition) {
   };
 }
 
-function shapeScoreForRows({ validation, minRequiredCompleteness, expectedBehavior, validationIssues }) {
+function shapeScoreForRows({
+  validation,
+  minRequiredCompleteness,
+  expectedBehavior,
+  validationIssues,
+  requireEvidence = false,
+}) {
   if (expectedBehavior === "clarify_or_abstain" && validationIssues.length > 0) {
     return 1;
   }
-  if (validation.rowCount === 0 || validation.sourceUrlCount === 0 || validation.evidenceQuoteCount === 0) {
+  if (validation.rowCount === 0 || validation.sourceUrlCount === 0) {
+    return 0;
+  }
+  if (requireEvidence && validation.evidenceQuoteCount === 0) {
     return 0;
   }
   if (validation.requiredCellCompletenessRatio < minRequiredCompleteness) {
@@ -1639,6 +1464,7 @@ export function failureReason({
   answerKeyScore,
   infraBlockerReason,
   minRequiredCompleteness,
+  requireEvidence = false,
   validationIssues = [],
 }) {
   if (infraBlockerReason) return infraBlockerReason;
@@ -1650,9 +1476,18 @@ export function failureReason({
   if (answerKeyScore?.failureCategory === "clarification") {
     return `Clarification/abstention score ${answerKeyScore.abstentionScore} below required threshold.`;
   }
-  if (validation.rowCount === 0) return "Parsed JSON had zero rows.";
+  if (validation.rowCount === 0) {
+    const setupIssue = validationIssues.find((issue) => typeof issue === "string" && issue.trim());
+    if (setupIssue) return setupIssue;
+    return "Parsed JSON had zero rows.";
+  }
   if (validation.sourceUrlCount === 0) return "No source URLs found.";
-  if (validation.evidenceQuoteCount === 0) return "No evidence quotes found.";
+  if (requireEvidence && validation.evidenceQuoteCount === 0) {
+    return "No evidence quotes found.";
+  }
+  if (answerKeyScore?.failureCategory === "row_target") {
+    return `Row count ${validation.rowCount} below target contract minimum.`;
+  }
   if (validation.requiredCellCompletenessRatio < minRequiredCompleteness) {
     return `Requested-cell completeness ${validation.requiredCellCompletenessRatio} below ${minRequiredCompleteness}.`;
   }
@@ -1778,10 +1613,11 @@ node benchmarks/dataset-agent/run-benchmark.mjs \\
   --system mengzhe='npm run benchmark -- {{promptJson}}' \\
   --system edward='node ./my-agent.js --prompt {{promptJson}}'
 
-Run a canary subset before spending credits on all prompts:
+Run the open-ended 5-prompt pack (default prompts.json):
 node benchmarks/dataset-agent/run-benchmark.mjs \\
-  --prompt-ids latest-ai-blog-posts,saas-pricing-pages \\
-  --system edward='node ./my-agent.js --prompt {{promptJson}}'
+  --system mastra='node --import ./backend/node_modules/tsx/dist/esm/index.mjs benchmarks/dataset-agent/adapters/mastra-populate-adapter.mjs'
+
+Target contract defaults: targetRows=100, minRowCount=50, minEvidenceCoverage=0.95 (informational unless --require-evidence).
 
 Rescore existing artifacts without spending credits:
 node benchmarks/dataset-agent/run-benchmark.mjs --rescore-dir benchmark-results/<run>
@@ -1793,4 +1629,8 @@ Agent command contract:
 - metrics supports searchCalls, fetchCalls, browserCalls, agentRuns, agentSteps.
 `);
   process.exit(0);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
 }

--- a/benchmarks/dataset-agent/run-benchmark.mjs
+++ b/benchmarks/dataset-agent/run-benchmark.mjs
@@ -195,7 +195,7 @@ const answerKeysByPromptId = {
     verifiedAt,
     sourceUrls: [
       "https://developers.openai.com/api/docs/mcp",
-      "https://docs.anthropic.com/en/docs/agents-and-tools/mcp-connector",
+      "https://platform.claude.com/docs/en/agents-and-tools/mcp-connector",
       "https://developers.cloudflare.com/agents/model-context-protocol/",
     ],
     scoringNotes:
@@ -214,7 +214,7 @@ const answerKeysByPromptId = {
         id: "anthropic",
         label: "Anthropic",
         aliases: ["anthropic"],
-        allowedSourceDomains: ["docs.anthropic.com"],
+        allowedSourceDomains: ["docs.anthropic.com", "platform.claude.com"],
         requiredText: ["mcp"],
       },
       {
@@ -231,6 +231,7 @@ const answerKeysByPromptId = {
       "platform.openai.com",
       "openai.com",
       "docs.anthropic.com",
+      "platform.claude.com",
       "developers.cloudflare.com",
     ],
   },

--- a/benchmarks/dataset-agent/run-benchmark.mjs
+++ b/benchmarks/dataset-agent/run-benchmark.mjs
@@ -1,0 +1,1704 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const defaultPromptsPath = join(scriptDir, "prompts.json");
+const defaultMinimumFactualAccuracy = 0.75;
+
+async function main() {
+  const config = parseArgs(process.argv.slice(2));
+  const allPrompts = JSON.parse(await readFile(config.promptsPath, "utf8"));
+  const prompts = selectPrompts(allPrompts, config.promptIds);
+  const runStartedAt = new Date();
+  const runDirectory = config.outDirectory ?? join(
+    process.cwd(),
+    "benchmark-results",
+    runStartedAt.toISOString().replace(/[:.]/g, "-")
+  );
+
+  if (config.rescoreDirectory) {
+    const rescoredSummary = await rescoreBenchmarkRun({
+      runDirectory: config.rescoreDirectory,
+      prompts,
+      config,
+    });
+    await writeJson(join(config.rescoreDirectory, "summary.rescored.json"), rescoredSummary);
+    await writeMarkdownReport(
+      join(config.rescoreDirectory, "benchmark-report.rescored.md"),
+      rescoredSummary,
+      prompts
+    );
+    console.log(JSON.stringify(rescoredSummary, null, 2));
+    process.exit(0);
+  }
+
+  if (config.systems.length === 0) {
+    console.error("No systems configured. Pass --system name='command with {{promptJson}}'.");
+    process.exit(1);
+  }
+
+  await mkdir(runDirectory, { recursive: true });
+
+  const laneResults = [];
+  for (const system of config.systems) {
+    for (const [promptIndex, promptDefinition] of prompts.entries()) {
+      const result = await runSystemPrompt({
+        system,
+        promptDefinition,
+        promptIndex,
+        promptCount: prompts.length,
+        runDirectory,
+        config,
+      });
+      laneResults.push(result);
+    }
+  }
+
+  const summary = {
+    testedAt: runStartedAt.toISOString(),
+    completedAt: new Date().toISOString(),
+    wallClockMs: Date.now() - runStartedAt.getTime(),
+    promptCount: prompts.length,
+    promptMix: promptMixSummary(prompts),
+    systems: config.systems.map(({ name }) => name),
+    costAssumptions: {
+      inputUsdPer1M: config.inputUsdPer1M,
+      outputUsdPer1M: config.outputUsdPer1M,
+      tinyFishAgentStepUsd: config.tinyFishAgentStepUsd,
+    },
+    aggregate: aggregateResults(laneResults),
+    laneResults,
+  };
+
+  await writeJson(join(runDirectory, "summary.json"), summary);
+  await writeMarkdownReport(join(runDirectory, "benchmark-report.md"), summary, prompts);
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+const verifiedAt = "2026-05-20";
+const answerKeysByPromptId = {
+  "latest-ai-blog-posts": {
+    verifiedAt,
+    sourceUrls: [
+      "https://openai.com/index/advancing-content-provenance/",
+      "https://www.anthropic.com/news/anthropic-kpmg",
+      "https://deepmind.google/blog/co-scientist-a-multi-agent-ai-partner-to-accelerate-research/",
+    ],
+    scoringNotes:
+      "Latest-post titles drift. Score entity coverage, official domains, dated titles, and source URLs rather than one frozen title only.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "latest_post_title", "latest_post_date", "source_url"],
+    expectedEntities: [
+      {
+        id: "openai",
+        label: "OpenAI",
+        aliases: ["openai"],
+        allowedSourceDomains: ["openai.com"],
+        requiredText: ["2026"],
+      },
+      {
+        id: "anthropic",
+        label: "Anthropic",
+        aliases: ["anthropic"],
+        allowedSourceDomains: ["anthropic.com"],
+        requiredText: ["2026"],
+      },
+      {
+        id: "google-deepmind",
+        label: "Google DeepMind",
+        aliases: ["google deepmind", "deepmind"],
+        allowedSourceDomains: ["deepmind.google"],
+        requiredText: ["2026"],
+      },
+    ],
+    minimumExpectedEntityMatches: 3,
+    officialSourceDomains: ["openai.com", "anthropic.com", "deepmind.google"],
+  },
+  "saas-pricing-pages": {
+    verifiedAt,
+    sourceUrls: [
+      "https://stripe.com/pricing",
+      "https://www.paddle.com/billing",
+      "https://www.chargebee.com/pricing/",
+    ],
+    scoringNotes:
+      "Pass requires all three vendors, official domains, and visible plan or price text. Paddle may route pricing through Billing or sales-led pages.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "pricing_page_url", "plan_or_price", "source_url"],
+    expectedEntities: [
+      {
+        id: "stripe",
+        label: "Stripe",
+        aliases: ["stripe"],
+        allowedSourceDomains: ["stripe.com"],
+        requiredText: ["pricing"],
+      },
+      {
+        id: "paddle",
+        label: "Paddle",
+        aliases: ["paddle"],
+        allowedSourceDomains: ["paddle.com"],
+        requiredText: ["merchant of record", "billing"],
+      },
+      {
+        id: "chargebee",
+        label: "Chargebee",
+        aliases: ["chargebee"],
+        allowedSourceDomains: ["chargebee.com"],
+        requiredText: ["starter", "performance", "enterprise"],
+      },
+    ],
+    minimumExpectedEntityMatches: 3,
+    officialSourceDomains: ["stripe.com", "paddle.com", "chargebee.com"],
+  },
+  "earnings-release-pages": {
+    verifiedAt,
+    sourceUrls: [
+      "https://www.apple.com/newsroom/2026/04/apple-reports-second-quarter-results/",
+      "https://www.microsoft.com/en-us/investor/earnings/fy-2026-q3/press-release-webcast",
+      "https://investor.nvidia.com/news/press-release-details/2026/NVIDIA-Announces-Financial-Results-for-Fourth-Quarter-and-Fiscal-2026/",
+    ],
+    scoringNotes:
+      "As of 2026-05-20, Apple latest verified release is fiscal 2026 Q2 on 2026-04-30, Microsoft is FY26 Q3 on 2026-04-29, and NVIDIA is Q4 fiscal 2026 on 2026-02-25.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "release_date", "fiscal_quarter", "source_url"],
+    expectedEntities: [
+      {
+        id: "apple",
+        label: "Apple",
+        aliases: ["apple"],
+        allowedSourceDomains: ["apple.com"],
+        requiredText: ["second quarter", "q2", "2026", "april 30"],
+      },
+      {
+        id: "microsoft",
+        label: "Microsoft",
+        aliases: ["microsoft"],
+        allowedSourceDomains: ["microsoft.com"],
+        requiredText: ["fy26 q3", "q3", "april 29", "2026"],
+      },
+      {
+        id: "nvidia",
+        label: "NVIDIA",
+        aliases: ["nvidia"],
+        allowedSourceDomains: ["nvidia.com"],
+        requiredText: ["fourth quarter", "q4", "fiscal 2026"],
+      },
+    ],
+    minimumExpectedEntityMatches: 3,
+    officialSourceDomains: ["apple.com", "microsoft.com", "nvidia.com"],
+  },
+  "mcp-docs-pages": {
+    verifiedAt,
+    sourceUrls: [
+      "https://developers.openai.com/api/docs/mcp",
+      "https://docs.anthropic.com/en/docs/agents-and-tools/mcp-connector",
+      "https://developers.cloudflare.com/agents/model-context-protocol/",
+    ],
+    scoringNotes:
+      "Pass requires official docs for all three vendors. Blog posts, GitHub examples, and community roundups are not enough.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "docs_title", "docs_url", "summary"],
+    expectedEntities: [
+      {
+        id: "openai",
+        label: "OpenAI",
+        aliases: ["openai"],
+        allowedSourceDomains: ["developers.openai.com", "platform.openai.com", "openai.com"],
+        requiredText: ["mcp"],
+      },
+      {
+        id: "anthropic",
+        label: "Anthropic",
+        aliases: ["anthropic"],
+        allowedSourceDomains: ["docs.anthropic.com"],
+        requiredText: ["mcp"],
+      },
+      {
+        id: "cloudflare",
+        label: "Cloudflare",
+        aliases: ["cloudflare"],
+        allowedSourceDomains: ["developers.cloudflare.com"],
+        requiredText: ["mcp"],
+      },
+    ],
+    minimumExpectedEntityMatches: 3,
+    officialSourceDomains: [
+      "developers.openai.com",
+      "platform.openai.com",
+      "openai.com",
+      "docs.anthropic.com",
+      "developers.cloudflare.com",
+    ],
+  },
+  "menlo-park-coca-cola": {
+    verifiedAt,
+    sourceUrls: [
+      "https://order-menlopark.celiasrestaurants.com/",
+      "https://www.portablurestaurant.com/menus",
+    ],
+    scoringNotes:
+      "Pass requires direct menu/order evidence for Coke/Coca-Cola. A directory saying a restaurant exists is not proof.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "address", "serves_requested_item", "source_url"],
+    rowMustContainAny: ["coca-cola", "coke", "diet coke", "diet coca-cola"],
+    minimumScore: 0.7,
+  },
+  "hcmc-bakery-products": {
+    verifiedAt,
+    sourceUrls: [
+      "https://maisonmarou.com/product/croissant/",
+      "https://moncannele.com/products/box-of-9-mini",
+    ],
+    scoringNotes:
+      "Pass requires product-detail URLs from bakery-owned sites, not generic listicles.",
+    expectedBehavior: "answer",
+    requiredColumns: ["bakery_name", "product_name", "product_url", "source_url"],
+    expectedEntities: [
+      {
+        id: "maison-marou",
+        label: "Maison Marou",
+        aliases: ["maison marou", "marou"],
+        allowedSourceDomains: ["maisonmarou.com"],
+        requiredText: ["croissant", "macaron", "opera", "pastry"],
+      },
+      {
+        id: "mon-cannele",
+        label: "Mon Cannele",
+        aliases: ["mon cannele", "cannel"],
+        allowedSourceDomains: ["moncannele.com"],
+        requiredText: ["cannel"],
+      },
+    ],
+    minimumExpectedEntityMatches: 1,
+    officialSourceDomains: ["maisonmarou.com", "moncannele.com"],
+  },
+  "ny-ai-startup-careers": {
+    verifiedAt,
+    sourceUrls: [
+      "https://www.runwayml.com/careers",
+      "https://www.huggingface.co/jobs",
+      "https://www.hebbia.ai/careers",
+    ],
+    scoringNotes:
+      "Pass requires company-owned websites or careers pages. One third-party startup directory with repeated 'View Jobs' text is not enough.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "company_website", "careers_page_url", "is_hiring"],
+    expectedEntities: [
+      {
+        id: "runway",
+        label: "Runway",
+        aliases: ["runway"],
+        allowedSourceDomains: ["runwayml.com"],
+        requiredText: ["careers", "jobs"],
+      },
+      {
+        id: "hugging-face",
+        label: "Hugging Face",
+        aliases: ["hugging face", "huggingface"],
+        allowedSourceDomains: ["huggingface.co"],
+        requiredText: ["jobs", "careers"],
+      },
+      {
+        id: "hebbia",
+        label: "Hebbia",
+        aliases: ["hebbia"],
+        allowedSourceDomains: ["hebbia.ai"],
+        requiredText: ["careers", "jobs"],
+      },
+    ],
+    minimumExpectedEntityMatches: 2,
+  },
+  "vietnam-fintech-sites": {
+    verifiedAt,
+    sourceUrls: [
+      "https://www.momo.vn/",
+      "https://zalopay.vn/",
+      "https://vnpay.vn/",
+      "https://www.finhay.com.vn/",
+    ],
+    scoringNotes:
+      "Pass requires official company/product domains for Vietnamese fintech examples.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "official_website", "description", "source_url"],
+    expectedEntities: [
+      {
+        id: "momo",
+        label: "MoMo",
+        aliases: ["momo"],
+        allowedSourceDomains: ["momo.vn"],
+      },
+      {
+        id: "zalopay",
+        label: "ZaloPay",
+        aliases: ["zalopay", "zalo pay"],
+        allowedSourceDomains: ["zalopay.vn"],
+      },
+      {
+        id: "vnpay",
+        label: "VNPAY",
+        aliases: ["vnpay"],
+        allowedSourceDomains: ["vnpay.vn"],
+      },
+      {
+        id: "finhay",
+        label: "Finhay",
+        aliases: ["finhay"],
+        allowedSourceDomains: ["finhay.com.vn"],
+      },
+    ],
+    minimumExpectedEntityMatches: 3,
+    officialSourceDomains: ["momo.vn", "zalopay.vn", "vnpay.vn", "finhay.com.vn"],
+  },
+  "district-one-coffee-sites": {
+    verifiedAt,
+    sourceUrls: ["https://tonkin.coffee/menu/", "https://www.cafehien.com/"],
+    scoringNotes:
+      "Pass requires a shop-owned site or online menu plus District 1 address evidence.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "website_or_menu_url", "address", "source_url"],
+    expectedEntities: [
+      {
+        id: "tonkin",
+        label: "Tonkin Coffee",
+        aliases: ["tonkin"],
+        allowedSourceDomains: ["tonkin.coffee"],
+        requiredText: ["district 1", "menu"],
+      },
+      {
+        id: "hien",
+        label: "Hien Cafe",
+        aliases: ["hien cafe", "cafe hien"],
+        allowedSourceDomains: ["cafehien.com"],
+        requiredText: ["menu", "ho chi minh"],
+      },
+    ],
+    minimumExpectedEntityMatches: 1,
+  },
+  "amazon-starbucks-products": {
+    verifiedAt,
+    sourceUrls: ["https://www.amazon.com/stores/Starbucks/Starbucks/page/"],
+    scoringNotes:
+      "Pass requires Amazon product/listing evidence with product name, price, image URL, and stock/availability. If Amazon blocks access, an honest validation issue beats hallucinated products.",
+    expectedBehavior: "answer",
+    requiredColumns: ["product_name", "price", "image_url", "in_stock"],
+    officialSourceDomains: ["amazon.com"],
+    rowMustContainAny: ["starbucks"],
+    minimumScore: 0.7,
+  },
+  "california-insurance-prices": {
+    verifiedAt,
+    sourceUrls: [
+      "https://www.geico.com/auto-insurance/",
+      "https://www.progressive.com/auto/",
+      "https://www.statefarm.com/insurance/auto",
+    ],
+    scoringNotes:
+      "Actual prices require driver, vehicle, ZIP, coverage, and deductible. Best behavior is official quote pages plus missing-input validation, not invented premiums.",
+    expectedBehavior: "clarify_or_abstain",
+    requiredColumns: ["provider_name", "quote_page_url", "missing_inputs", "source_url"],
+    clarificationTerms: ["driver", "vehicle", "zip", "coverage", "deductible"],
+    officialSourceDomains: ["geico.com", "progressive.com", "statefarm.com"],
+  },
+  "la-coke-menu-lol": {
+    verifiedAt,
+    sourceUrls: [],
+    scoringNotes:
+      "Pass requires direct LA menu/order evidence for Coke/Coca-Cola. Yelp/listicle rows are not enough.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "menu_url", "serves_requested_item", "source_url"],
+    rowMustContainAny: ["coca-cola", "coke", "diet coke", "soft drink"],
+    minimumScore: 0.9,
+  },
+  "sf-ml-hiring-rn": {
+    verifiedAt,
+    sourceUrls: [
+      "https://openai.com/careers/",
+      "https://www.anthropic.com/careers",
+      "https://www.perplexity.ai/careers",
+    ],
+    scoringNotes:
+      "Pass requires current company-owned careers/job pages with ML or AI role evidence near San Francisco or the Bay Area.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "careers_page_url", "open_role_title", "source_url"],
+    expectedEntities: [
+      {
+        id: "openai",
+        label: "OpenAI",
+        aliases: ["openai"],
+        allowedSourceDomains: ["openai.com"],
+        requiredText: ["machine learning", "ml", "research", "engineer"],
+      },
+      {
+        id: "anthropic",
+        label: "Anthropic",
+        aliases: ["anthropic"],
+        allowedSourceDomains: ["anthropic.com"],
+        requiredText: ["machine learning", "ml", "research", "engineer"],
+      },
+      {
+        id: "perplexity",
+        label: "Perplexity",
+        aliases: ["perplexity"],
+        allowedSourceDomains: ["perplexity.ai"],
+        requiredText: ["machine learning", "ml", "engineer"],
+      },
+    ],
+    minimumExpectedEntityMatches: 1,
+  },
+  "latest-ai-company-stuff": {
+    verifiedAt,
+    sourceUrls: [],
+    scoringNotes:
+      "Prompt is underspecified. Best behavior is ask which companies and item types count, or return an explicitly scoped partial dataset with validation issues.",
+    expectedBehavior: "clarify_or_abstain",
+    requiredColumns: ["entity_name", "latest_item_title", "latest_item_url", "source_url"],
+    clarificationTerms: ["which companies", "source type", "news", "blog", "release", "columns"],
+  },
+  "pastry-things-menlo": {
+    verifiedAt,
+    sourceUrls: ["https://mademoisellecolette.com/", "https://www.fleurdelysbakery.com/"],
+    scoringNotes:
+      "Pass requires bakery-owned websites or product/menu pages near Menlo Park. 'Good' should not become invented ratings.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "product_or_business_name", "website_url", "source_url"],
+    expectedEntities: [
+      {
+        id: "mademoiselle-colette",
+        label: "Mademoiselle Colette",
+        aliases: ["mademoiselle colette"],
+        allowedSourceDomains: ["mademoisellecolette.com"],
+      },
+      {
+        id: "fleur-de-lys",
+        label: "Fleur de Lys",
+        aliases: ["fleur de lys"],
+        allowedSourceDomains: ["fleurdelysbakery.com"],
+      },
+    ],
+    minimumExpectedEntityMatches: 1,
+  },
+  "perplexity-like-companies": {
+    verifiedAt,
+    sourceUrls: ["https://www.perplexity.ai/", "https://you.com/", "https://www.glean.com/"],
+    scoringNotes:
+      "Prompt is vague but answerable as AI search/answer companies if the system explains the comparison. Pass requires official websites and a concrete similarity reason.",
+    expectedBehavior: "answer",
+    requiredColumns: ["entity_name", "official_website", "why_similar", "source_url"],
+    expectedEntities: [
+      {
+        id: "you-com",
+        label: "You.com",
+        aliases: ["you.com", "youcom"],
+        allowedSourceDomains: ["you.com"],
+        requiredText: ["search", "answer", "ai"],
+      },
+      {
+        id: "glean",
+        label: "Glean",
+        aliases: ["glean"],
+        allowedSourceDomains: ["glean.com"],
+        requiredText: ["search", "workplace", "ai"],
+      },
+      {
+        id: "exa",
+        label: "Exa",
+        aliases: ["exa"],
+        allowedSourceDomains: ["exa.ai"],
+        requiredText: ["search", "web", "ai"],
+      },
+    ],
+    minimumExpectedEntityMatches: 1,
+  },
+};
+
+await main();
+
+async function runSystemPrompt(input) {
+  const startedAt = Date.now();
+  const minimumRequiredColumns = minimumRequiredColumnsForPrompt(
+    input.promptDefinition
+  );
+  const command = renderCommand(input.system.command, input.promptDefinition);
+  console.error(
+    `[${input.system.name}] ${input.promptIndex + 1}/${input.promptCount} ${input.promptDefinition.id}`
+  );
+
+  const execution = await runCommand({
+    command,
+    timeoutMs: input.config.timeoutMs,
+    env: {
+      BIGSET_BENCHMARK_PROMPT: input.promptDefinition.prompt,
+      BIGSET_BENCHMARK_PROMPT_ID: input.promptDefinition.id,
+      BIGSET_BENCHMARK_PROMPT_QUALITY: input.promptDefinition.quality,
+      BIGSET_BENCHMARK_REQUIRED_COLUMNS: input.promptDefinition.requiredColumns.join(","),
+      BIGSET_BENCHMARK_MINIMUM_REQUIRED_COLUMNS: minimumRequiredColumns.join(","),
+    },
+  });
+  const parsedPayload = parseJsonPayload(execution.stdout);
+  const normalized = normalizePayload(parsedPayload);
+  const validation = evaluateRows({
+    rows: normalized.rows,
+    promptDefinition: input.promptDefinition,
+  });
+  const answerKeyScore = scoreBenchmarkRows({
+    promptDefinition: input.promptDefinition,
+    rows: normalized.rows,
+    validationIssues: normalized.validationIssues,
+    validation,
+    minRequiredCompleteness: input.config.minRequiredCompleteness,
+    minFactualAccuracy: input.config.minFactualAccuracy,
+  });
+  const usage = normalized.usage;
+  const estimatedModelCostUsd = estimateModelCostUsd(usage, input.config);
+  const estimatedTinyFishAgentCostUsd = roundUsd(
+    normalized.metrics.agentStepCount * input.config.tinyFishAgentStepUsd
+  );
+  const infraBlockerReason = findInfrastructureBlockerReason({
+    execution,
+    parsedPayload,
+    normalized,
+  });
+  const status = infraBlockerReason
+    ? "blocked"
+    : execution.exitCode === 0 && parsedPayload && answerKeyScore.passed
+      ? "ok"
+      : "failed";
+
+  const promptRunDirectory = join(
+    input.runDirectory,
+    input.system.name,
+    `${String(input.promptIndex + 1).padStart(2, "0")}-${input.promptDefinition.id}`
+  );
+  await mkdir(promptRunDirectory, { recursive: true });
+  await writeFile(join(promptRunDirectory, "stdout.txt"), execution.stdout);
+  await writeFile(join(promptRunDirectory, "stderr.txt"), execution.stderr);
+  await writeJson(join(promptRunDirectory, "parsed-output.json"), parsedPayload ?? {
+    error: "No JSON object found in stdout.",
+  });
+
+  return {
+    system: input.system.name,
+    promptId: input.promptDefinition.id,
+    promptQuality: input.promptDefinition.quality,
+    promptPersona: input.promptDefinition.persona,
+    prompt: input.promptDefinition.prompt,
+    requestedColumns: input.promptDefinition.requiredColumns,
+    requiredColumns: input.promptDefinition.requiredColumns,
+    minimumRequiredColumns,
+    expectedStress: input.promptDefinition.expectedStress,
+    answerKey: answerKeyForPrompt(input.promptDefinition),
+    status,
+    failureCategory: status === "ok" ? undefined : (
+      infraBlockerReason ? "infra" : answerKeyScore.failureCategory
+    ),
+    factualAccuracyScore: answerKeyScore.factualAccuracyScore,
+    entityCoverageRatio: answerKeyScore.entityCoverageRatio,
+    domainAccuracyRatio: answerKeyScore.domainAccuracyRatio,
+    evidenceSupportRatio: answerKeyScore.evidenceSupportRatio,
+    claimSupportRatio: answerKeyScore.claimSupportRatio,
+    abstentionScore: answerKeyScore.abstentionScore,
+    matchedExpectedEntities: answerKeyScore.matchedExpectedEntities,
+    missingExpectedEntities: answerKeyScore.missingExpectedEntities,
+    latencyMs: Date.now() - startedAt,
+    exitCode: execution.exitCode,
+    timedOut: execution.timedOut,
+    rowCount: validation.rowCount,
+    nonEmptyCellCount: validation.nonEmptyCellCount,
+    totalExpectedCellCount: validation.totalExpectedCellCount,
+    requestedCellCompletenessRatio: validation.requestedCellCompletenessRatio,
+    requiredCellCompletenessRatio: validation.requiredCellCompletenessRatio,
+    sourceUrlCount: validation.sourceUrlCount,
+    evidenceQuoteCount: validation.evidenceQuoteCount,
+    duplicateIdentityCount: validation.duplicateIdentityCount,
+    missingRequestedCellCount: validation.missingRequestedCellCount,
+    missingRequestedCells: validation.missingRequestedCells,
+    missingRequiredCellCount: validation.missingRequiredCellCount,
+    missingRequiredCells: validation.missingRequiredCells,
+    needsReviewCount: validation.needsReviewCount,
+    validationIssueCount: normalized.validationIssues.length,
+    validationIssues: normalized.validationIssues,
+    usage,
+    searchCallCount: normalized.metrics.searchCallCount,
+    fetchCallCount: normalized.metrics.fetchCallCount,
+    browserCallCount: normalized.metrics.browserCallCount,
+    agentRunCount: normalized.metrics.agentRunCount,
+    agentStepCount: normalized.metrics.agentStepCount,
+    estimatedModelCostUsd,
+    estimatedTinyFishAgentCostUsd,
+    estimatedTotalCostUsd: roundUsd(estimatedModelCostUsd + estimatedTinyFishAgentCostUsd),
+    artifactDirectory: promptRunDirectory,
+    errorMessage: status === "ok"
+      ? undefined
+      : failureReason({
+        execution,
+        parsedPayload,
+        validation,
+        answerKeyScore,
+        infraBlockerReason,
+        minRequiredCompleteness: input.config.minRequiredCompleteness,
+      }),
+  };
+}
+
+function minimumRequiredColumnsForPrompt(promptDefinition) {
+  if (Array.isArray(promptDefinition.minimumRequiredColumns)) {
+    return uniqueStrings(promptDefinition.minimumRequiredColumns);
+  }
+  return inferConservativeMinimumRequiredColumns(promptDefinition.requiredColumns ?? []);
+}
+
+function inferConservativeMinimumRequiredColumns(columns) {
+  const requestedColumns = uniqueStrings(columns);
+  const identityPriority = [
+    "entity_name",
+    "company_name",
+    "organization_name",
+    "provider_name",
+    "restaurant_name",
+    "store_name",
+    "business_name",
+    "bakery_name",
+    "product_name",
+    "person_name",
+    "profile_name",
+    "docs_title",
+    "latest_item_title",
+    "open_role_title",
+  ];
+  const identityUrlPriority = [
+    "company_domain",
+    "official_website",
+    "official_source_url",
+    "profile_url",
+    "linkedin_url",
+    "product_url",
+    "website_url",
+    "docs_url",
+    "careers_page_url",
+    "quote_page_url",
+    "menu_url",
+    "pricing_page_url",
+  ];
+
+  const prioritizedIdentityColumn = identityPriority.find((columnName) =>
+    requestedColumns.includes(columnName)
+  );
+  if (prioritizedIdentityColumn) {
+    return [prioritizedIdentityColumn];
+  }
+
+  const nameColumn = requestedColumns.find((columnName) =>
+    /(^|_)name$/.test(columnName)
+  );
+  if (nameColumn) {
+    return [nameColumn];
+  }
+
+  const titleColumn = requestedColumns.find((columnName) =>
+    /(^|_)title$/.test(columnName)
+  );
+  if (titleColumn) {
+    return [titleColumn];
+  }
+
+  const identityUrlColumn = identityUrlPriority.find((columnName) =>
+    requestedColumns.includes(columnName)
+  );
+  if (identityUrlColumn) {
+    return [identityUrlColumn];
+  }
+
+  const fallbackIdentityColumn = requestedColumns.find(
+    (columnName) =>
+      columnName !== "source_url" &&
+      !columnName.endsWith("_at") &&
+      !columnName.includes("score") &&
+      !columnName.startsWith("is_") &&
+      !columnName.startsWith("has_")
+  );
+
+  return fallbackIdentityColumn ? [fallbackIdentityColumn] : [];
+}
+
+function uniqueStrings(values) {
+  return [...new Set(values.filter((value) => typeof value === "string" && value.length > 0))];
+}
+
+function parseArgs(args) {
+  const config = {
+    promptsPath: defaultPromptsPath,
+    promptIds: null,
+    systems: [],
+    timeoutMs: 10 * 60 * 1000,
+    inputUsdPer1M: 0.05,
+    outputUsdPer1M: 0.5,
+    tinyFishAgentStepUsd: 0.015,
+    minRequiredCompleteness: 0.75,
+    minFactualAccuracy: defaultMinimumFactualAccuracy,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    const value = args[index + 1];
+    if (arg === "--prompts") {
+      config.promptsPath = value;
+      index += 1;
+    } else if (arg === "--prompt-ids") {
+      config.promptIds = parsePromptIds(value);
+      index += 1;
+    } else if (arg === "--out") {
+      config.outDirectory = value;
+      index += 1;
+    } else if (arg === "--rescore-dir") {
+      config.rescoreDirectory = value;
+      index += 1;
+    } else if (arg === "--system") {
+      const parsed = parseSystem(value);
+      config.systems.push(parsed);
+      index += 1;
+    } else if (arg === "--timeout-ms") {
+      config.timeoutMs = positiveNumber(value, config.timeoutMs);
+      index += 1;
+    } else if (arg === "--input-usd-per-1m") {
+      config.inputUsdPer1M = nonNegativeNumber(value, config.inputUsdPer1M);
+      index += 1;
+    } else if (arg === "--output-usd-per-1m") {
+      config.outputUsdPer1M = nonNegativeNumber(value, config.outputUsdPer1M);
+      index += 1;
+    } else if (arg === "--tinyfish-agent-step-usd") {
+      config.tinyFishAgentStepUsd = nonNegativeNumber(value, config.tinyFishAgentStepUsd);
+      index += 1;
+    } else if (arg === "--min-required-completeness") {
+      config.minRequiredCompleteness = nonNegativeNumber(value, config.minRequiredCompleteness);
+      index += 1;
+    } else if (arg === "--min-factual-accuracy") {
+      config.minFactualAccuracy = nonNegativeNumber(value, config.minFactualAccuracy);
+      index += 1;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelpAndExit();
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return config;
+}
+
+function parsePromptIds(value) {
+  const promptIds = value
+    .split(",")
+    .map((promptId) => promptId.trim())
+    .filter(Boolean);
+
+  if (promptIds.length === 0) {
+    throw new Error("--prompt-ids requires at least one prompt id");
+  }
+
+  return promptIds;
+}
+
+function selectPrompts(prompts, promptIds) {
+  if (!promptIds) {
+    return prompts;
+  }
+
+  const promptsById = new Map(prompts.map((promptDefinition) => [
+    promptDefinition.id,
+    promptDefinition,
+  ]));
+  const selectedPrompts = [];
+  const missingPromptIds = [];
+
+  for (const promptId of promptIds) {
+    const promptDefinition = promptsById.get(promptId);
+    if (promptDefinition) {
+      selectedPrompts.push(promptDefinition);
+    } else {
+      missingPromptIds.push(promptId);
+    }
+  }
+
+  if (missingPromptIds.length > 0) {
+    const availablePromptIds = prompts.map((promptDefinition) => promptDefinition.id).join(", ");
+    throw new Error(
+      `Unknown prompt id(s): ${missingPromptIds.join(", ")}. Available ids: ${availablePromptIds}`
+    );
+  }
+
+  return selectedPrompts;
+}
+
+function parseSystem(value) {
+  const separatorIndex = value.indexOf("=");
+  if (separatorIndex <= 0) {
+    throw new Error("--system must look like name=command");
+  }
+
+  return {
+    name: value.slice(0, separatorIndex).trim(),
+    command: value.slice(separatorIndex + 1).trim(),
+  };
+}
+
+function renderCommand(command, promptDefinition) {
+  const minimumRequiredColumns = minimumRequiredColumnsForPrompt(promptDefinition);
+  return command
+    .replaceAll("{{prompt}}", shellEscape(promptDefinition.prompt))
+    .replaceAll("{{promptJson}}", shellEscape(JSON.stringify(promptDefinition.prompt)))
+    .replaceAll("{{promptId}}", shellEscape(promptDefinition.id))
+    .replaceAll("{{requiredColumnsJson}}", shellEscape(JSON.stringify(promptDefinition.requiredColumns)))
+    .replaceAll("{{minimumRequiredColumnsJson}}", shellEscape(JSON.stringify(minimumRequiredColumns)));
+}
+
+function runCommand({ command, timeoutMs, env }) {
+  return new Promise((resolve) => {
+    const child = spawn(command, {
+      shell: true,
+      env: { ...process.env, ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+    }, timeoutMs);
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("close", (exitCode) => {
+      clearTimeout(timeout);
+      resolve({ stdout, stderr, exitCode: exitCode ?? 1, timedOut });
+    });
+  });
+}
+
+function parseJsonPayload(stdout) {
+  const trimmed = stdout.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const lastObject = extractLastJsonObject(trimmed);
+    if (!lastObject) {
+      return null;
+    }
+    try {
+      return JSON.parse(lastObject);
+    } catch {
+      return null;
+    }
+  }
+}
+
+function extractLastJsonObject(value) {
+  let depth = 0;
+  let endIndex = -1;
+  for (let index = value.length - 1; index >= 0; index -= 1) {
+    const char = value[index];
+    if (char === "}") {
+      if (endIndex === -1) {
+        endIndex = index;
+      }
+      depth += 1;
+    } else if (char === "{") {
+      depth -= 1;
+      if (depth === 0 && endIndex !== -1) {
+        return value.slice(index, endIndex + 1);
+      }
+    }
+  }
+  return null;
+}
+
+function normalizePayload(payload) {
+  const rows = arrayValue(
+    payload?.rows ??
+      payload?.data ??
+      payload?.records ??
+      payload?.result ??
+      payload?.datasetRows
+  );
+  const validationIssues = stringArrayValue(
+    payload?.validationIssues ?? payload?.issues ?? payload?.errors
+  );
+  const metrics = payload?.metrics ?? payload?.benchmarkMetrics ?? {};
+  const usage = normalizeUsage(payload?.usage ?? metrics.usage ?? metrics);
+
+  return {
+    rows,
+    validationIssues,
+    usage,
+    metrics: {
+      searchCallCount: numberValue(metrics.searchCallCount ?? metrics.searchCalls),
+      fetchCallCount: numberValue(metrics.fetchCallCount ?? metrics.fetchCalls),
+      browserCallCount: numberValue(metrics.browserCallCount ?? metrics.browserCalls),
+      agentRunCount: numberValue(metrics.agentRunCount ?? metrics.agentRuns),
+      agentStepCount: numberValue(metrics.agentStepCount ?? metrics.agentSteps),
+    },
+  };
+}
+
+function normalizeUsage(value) {
+  return {
+    promptTokens: numberValue(value?.promptTokens ?? value?.inputTokens ?? value?.prompt_tokens),
+    completionTokens: numberValue(
+      value?.completionTokens ?? value?.outputTokens ?? value?.completion_tokens
+    ),
+    totalTokens: numberValue(value?.totalTokens ?? value?.total_tokens),
+  };
+}
+
+function evaluateRows({ rows, promptDefinition }) {
+  const missingRequiredCells = [];
+  const sourceUrls = new Set();
+  const identityKeys = new Set();
+  let duplicateIdentityCount = 0;
+  let nonEmptyCellCount = 0;
+  let evidenceQuoteCount = 0;
+  let needsReviewCount = 0;
+
+  for (const [rowIndex, row] of rows.entries()) {
+    const cells = rowCells(row);
+    const identity = identityKey(cells, row);
+    if (identity) {
+      if (identityKeys.has(identity)) {
+        duplicateIdentityCount += 1;
+      }
+      identityKeys.add(identity);
+    }
+
+    for (const requiredColumn of promptDefinition.requiredColumns) {
+      const value = cells[requiredColumn] ?? row?.[requiredColumn];
+      if (isPresent(value)) {
+        nonEmptyCellCount += 1;
+      } else {
+        missingRequiredCells.push({ rowIndex, column: requiredColumn });
+      }
+    }
+
+    for (const url of rowSourceUrls(row, cells)) {
+      sourceUrls.add(url);
+    }
+    evidenceQuoteCount += rowEvidenceQuoteCount(row);
+    if (row?.needsReview === true || row?.needs_review === true) {
+      needsReviewCount += 1;
+    }
+  }
+
+  const totalExpectedCellCount = rows.length * promptDefinition.requiredColumns.length;
+  const requiredCellCompletenessRatio = totalExpectedCellCount === 0
+    ? 0
+    : roundRatio(nonEmptyCellCount / totalExpectedCellCount);
+
+  return {
+    rowCount: rows.length,
+    nonEmptyCellCount,
+    totalExpectedCellCount,
+    requestedCellCompletenessRatio: requiredCellCompletenessRatio,
+    requiredCellCompletenessRatio,
+    sourceUrlCount: sourceUrls.size,
+    evidenceQuoteCount,
+    duplicateIdentityCount,
+    missingRequestedCellCount: missingRequiredCells.length,
+    missingRequestedCells: missingRequiredCells,
+    missingRequiredCellCount: missingRequiredCells.length,
+    missingRequiredCells,
+    needsReviewCount,
+  };
+}
+
+async function rescoreBenchmarkRun({ runDirectory, prompts, config }) {
+  const previousSummary = JSON.parse(await readFile(join(runDirectory, "summary.json"), "utf8"));
+  const promptsById = new Map(prompts.map((promptDefinition) => [
+    promptDefinition.id,
+    promptDefinition,
+  ]));
+  const rescoredLaneResults = [];
+
+  for (const laneResult of previousSummary.laneResults ?? []) {
+    if (config.promptIds && !config.promptIds.includes(laneResult.promptId)) {
+      continue;
+    }
+
+    const promptDefinition = promptsById.get(laneResult.promptId);
+    if (!promptDefinition) {
+      rescoredLaneResults.push(laneResult);
+      continue;
+    }
+
+    const artifactDirectory = laneResult.artifactDirectory ??
+      join(runDirectory, laneResult.system, laneResult.promptId);
+    const parsedPayload = await readJsonOrNull(join(artifactDirectory, "parsed-output.json"));
+    const stdout = await readTextOrEmpty(join(artifactDirectory, "stdout.txt"));
+    const stderr = await readTextOrEmpty(join(artifactDirectory, "stderr.txt"));
+    const usablePayload = parsedPayload?.error ? null : parsedPayload;
+    const normalized = normalizePayload(usablePayload);
+    const validation = evaluateRows({ rows: normalized.rows, promptDefinition });
+    const answerKeyScore = scoreBenchmarkRows({
+      promptDefinition,
+      rows: normalized.rows,
+      validationIssues: normalized.validationIssues,
+      validation,
+      minRequiredCompleteness: config.minRequiredCompleteness,
+      minFactualAccuracy: config.minFactualAccuracy,
+    });
+    const execution = {
+      stdout,
+      stderr,
+      exitCode: laneResult.exitCode ?? 0,
+      timedOut: Boolean(laneResult.timedOut),
+    };
+    const infraBlockerReason = findInfrastructureBlockerReason({
+      execution,
+      parsedPayload: usablePayload,
+      normalized,
+    });
+    const status = infraBlockerReason
+      ? "blocked"
+      : execution.exitCode === 0 && usablePayload && answerKeyScore.passed
+        ? "ok"
+        : "failed";
+
+    rescoredLaneResults.push({
+      ...laneResult,
+      requestedColumns: promptDefinition.requiredColumns,
+      requiredColumns: promptDefinition.requiredColumns,
+      minimumRequiredColumns: minimumRequiredColumnsForPrompt(promptDefinition),
+      expectedStress: promptDefinition.expectedStress,
+      answerKey: answerKeyForPrompt(promptDefinition),
+      status,
+      failureCategory: status === "ok" ? undefined : (
+        infraBlockerReason ? "infra" : answerKeyScore.failureCategory
+      ),
+      factualAccuracyScore: answerKeyScore.factualAccuracyScore,
+      entityCoverageRatio: answerKeyScore.entityCoverageRatio,
+      domainAccuracyRatio: answerKeyScore.domainAccuracyRatio,
+      evidenceSupportRatio: answerKeyScore.evidenceSupportRatio,
+      claimSupportRatio: answerKeyScore.claimSupportRatio,
+      abstentionScore: answerKeyScore.abstentionScore,
+      matchedExpectedEntities: answerKeyScore.matchedExpectedEntities,
+      missingExpectedEntities: answerKeyScore.missingExpectedEntities,
+      rowCount: validation.rowCount,
+      nonEmptyCellCount: validation.nonEmptyCellCount,
+      totalExpectedCellCount: validation.totalExpectedCellCount,
+      requestedCellCompletenessRatio: validation.requestedCellCompletenessRatio,
+      requiredCellCompletenessRatio: validation.requiredCellCompletenessRatio,
+      sourceUrlCount: validation.sourceUrlCount,
+      evidenceQuoteCount: validation.evidenceQuoteCount,
+      duplicateIdentityCount: validation.duplicateIdentityCount,
+      missingRequestedCellCount: validation.missingRequestedCellCount,
+      missingRequestedCells: validation.missingRequestedCells,
+      missingRequiredCellCount: validation.missingRequiredCellCount,
+      missingRequiredCells: validation.missingRequiredCells,
+      needsReviewCount: validation.needsReviewCount,
+      validationIssueCount: normalized.validationIssues.length,
+      validationIssues: normalized.validationIssues,
+      errorMessage: status === "ok"
+        ? undefined
+        : failureReason({
+          execution,
+          parsedPayload: usablePayload,
+          validation,
+          answerKeyScore,
+          infraBlockerReason,
+          minRequiredCompleteness: config.minRequiredCompleteness,
+        }),
+    });
+  }
+
+  return {
+    ...previousSummary,
+    rescoredAt: new Date().toISOString(),
+    aggregate: aggregateResults(rescoredLaneResults),
+    laneResults: rescoredLaneResults,
+  };
+}
+
+function scoreBenchmarkRows(input) {
+  const answerKey = answerKeyForPrompt(input.promptDefinition);
+  const rowTexts = input.rows.map(rowSearchText);
+  const validationIssueText = input.validationIssues.join(" ").toLowerCase();
+  const allText = [...rowTexts, validationIssueText].join(" ");
+  const expectedEntities = answerKey.expectedEntities ?? [];
+  const matchedExpectedEntities = [];
+  const missingExpectedEntities = [];
+  let expectedEntityDomainMatches = 0;
+  let expectedEntityClaimMatches = 0;
+
+  for (const expectedEntity of expectedEntities) {
+    const aliases = expectedEntity.aliases ?? [expectedEntity.label, expectedEntity.id];
+    const aliasMatched = aliases.some((alias) => allText.includes(String(alias).toLowerCase()));
+    if (!aliasMatched) {
+      missingExpectedEntities.push(expectedEntity.label ?? expectedEntity.id);
+      continue;
+    }
+
+    matchedExpectedEntities.push(expectedEntity.label ?? expectedEntity.id);
+    const entityRows = input.rows.filter((row) => {
+      const rowText = rowSearchText(row);
+      return aliases.some((alias) => rowText.includes(String(alias).toLowerCase()));
+    });
+    const rowsToCheck = entityRows.length > 0 ? entityRows : input.rows;
+    if (rowsToCheck.some((row) => rowHasAllowedDomain(row, expectedEntity.allowedSourceDomains))) {
+      expectedEntityDomainMatches += 1;
+    }
+    if (
+      !expectedEntity.requiredText?.length ||
+      rowsToCheck.some((row) => textContainsAny(rowSearchText(row), expectedEntity.requiredText))
+    ) {
+      expectedEntityClaimMatches += 1;
+    }
+  }
+
+  const minimumEntityMatches = answerKey.minimumExpectedEntityMatches ?? expectedEntities.length;
+  const entityCoverageRatio = expectedEntities.length === 0
+    ? 1
+    : roundRatio(matchedExpectedEntities.length / Math.max(1, minimumEntityMatches));
+  const domainAccuracyRatio = expectedEntities.length > 0
+    ? roundRatio(expectedEntityDomainMatches / Math.max(1, matchedExpectedEntities.length))
+    : domainCoverageRatio(input.rows, answerKeyDomains(answerKey));
+  const evidenceSupportRatio = input.validation.rowCount === 0
+    ? 0
+    : roundRatio(input.validation.evidenceQuoteCount / Math.max(1, input.validation.rowCount));
+  const claimSupportRatio = claimSupportRatioForRows({
+    rows: input.rows,
+    answerKey,
+    expectedEntities,
+    expectedEntityClaimMatches,
+    matchedExpectedEntityCount: matchedExpectedEntities.length,
+  });
+  const abstentionScore = answerKey.expectedBehavior === "clarify_or_abstain"
+    ? clarificationScore(allText, answerKey.clarificationTerms ?? [])
+    : 0;
+  const shapeScore = shapeScoreForRows({
+    validation: input.validation,
+    minRequiredCompleteness: input.minRequiredCompleteness,
+    expectedBehavior: answerKey.expectedBehavior,
+    validationIssues: input.validationIssues,
+  });
+  const factualAccuracyScore = answerKey.expectedBehavior === "clarify_or_abstain"
+    ? roundRatio(
+      shapeScore * 0.2 +
+        domainAccuracyRatio * 0.2 +
+        abstentionScore * 0.6
+    )
+    : roundRatio(
+      shapeScore * 0.25 +
+        Math.min(1, entityCoverageRatio) * 0.3 +
+        domainAccuracyRatio * 0.2 +
+        Math.min(1, evidenceSupportRatio) * 0.15 +
+        claimSupportRatio * 0.1
+    );
+  const minimumScore = answerKey.minimumScore ?? input.minFactualAccuracy;
+  const hasExpectedEntityCoverage = expectedEntities.length === 0 ||
+    matchedExpectedEntities.length >= minimumEntityMatches;
+  const hasRequiredDomainAccuracy = !requiresDomainProof(answerKey, expectedEntities) ||
+    domainAccuracyRatio >= 1;
+  const hasRequiredClaimSupport = !requiresClaimProof(answerKey, expectedEntities) ||
+    claimSupportRatio >= 1;
+  const passed = answerKey.expectedBehavior === "clarify_or_abstain"
+    ? factualAccuracyScore >= minimumScore && abstentionScore >= 0.5
+    : factualAccuracyScore >= minimumScore &&
+      shapeScore >= 1 &&
+      hasExpectedEntityCoverage &&
+      hasRequiredDomainAccuracy &&
+      hasRequiredClaimSupport;
+
+  return {
+    passed,
+    failureCategory: failureCategoryForScore({
+      answerKey,
+      parsedRows: input.rows,
+      shapeScore,
+      entityCoverageRatio,
+      domainAccuracyRatio,
+      evidenceSupportRatio,
+      claimSupportRatio,
+      abstentionScore,
+      factualAccuracyScore,
+      minimumScore,
+    }),
+    factualAccuracyScore,
+    entityCoverageRatio: roundRatio(Math.min(1, entityCoverageRatio)),
+    domainAccuracyRatio,
+    evidenceSupportRatio: roundRatio(Math.min(1, evidenceSupportRatio)),
+    claimSupportRatio,
+    abstentionScore,
+    matchedExpectedEntities,
+    missingExpectedEntities,
+    minimumScore,
+  };
+}
+
+function answerKeyForPrompt(promptDefinition) {
+  return promptDefinition.answerKey ?? answerKeysByPromptId[promptDefinition.id] ?? {
+    expectedBehavior: "answer",
+    requiredColumns: promptDefinition.requiredColumns,
+    sourceUrls: [],
+    scoringNotes: "No prompt-specific answer key. Falling back to shape-only scoring.",
+  };
+}
+
+function shapeScoreForRows({ validation, minRequiredCompleteness, expectedBehavior, validationIssues }) {
+  if (expectedBehavior === "clarify_or_abstain" && validationIssues.length > 0) {
+    return 1;
+  }
+  if (validation.rowCount === 0 || validation.sourceUrlCount === 0 || validation.evidenceQuoteCount === 0) {
+    return 0;
+  }
+  if (validation.requiredCellCompletenessRatio < minRequiredCompleteness) {
+    return roundRatio(validation.requiredCellCompletenessRatio / Math.max(0.001, minRequiredCompleteness));
+  }
+  return 1;
+}
+
+function claimSupportRatioForRows({
+  rows,
+  answerKey,
+  expectedEntities,
+  expectedEntityClaimMatches,
+  matchedExpectedEntityCount,
+}) {
+  if (answerKey.rowMustContainAny?.length) {
+    const matchingRows = rows.filter((row) =>
+      textContainsAny(rowSearchText(row), answerKey.rowMustContainAny)
+    ).length;
+    return rows.length === 0 ? 0 : roundRatio(matchingRows / rows.length);
+  }
+  if (expectedEntities.some((entity) => entity.requiredText?.length)) {
+    return roundRatio(expectedEntityClaimMatches / Math.max(1, matchedExpectedEntityCount));
+  }
+  return rows.length > 0 ? 1 : 0;
+}
+
+function domainCoverageRatio(rows, allowedDomains) {
+  if (!allowedDomains?.length) {
+    if (rows.length === 0) return 0;
+    const hasPlaceholderOnly = rows.every((row) => {
+      const cells = rowCells(row);
+      const hostnames = rowSourceUrls(row, cells).map(urlHostname).filter(Boolean);
+      return hostnames.length > 0 && hostnames.every(isPlaceholderHostname);
+    });
+    return hasPlaceholderOnly ? 0 : 1;
+  }
+  if (rows.length === 0) return 0;
+  const matchingRows = rows.filter((row) => rowHasAllowedDomain(row, allowedDomains)).length;
+  return roundRatio(matchingRows / rows.length);
+}
+
+function answerKeyDomains(answerKey) {
+  const configuredDomains = answerKey.officialSourceDomains ?? [];
+  const sourceDomains = (answerKey.sourceUrls ?? []).map(urlHostname).filter(Boolean);
+  return [...new Set([...configuredDomains, ...sourceDomains])];
+}
+
+function requiresDomainProof(answerKey, expectedEntities) {
+  return answerKeyDomains(answerKey).length > 0 ||
+    expectedEntities.some((entity) => entity.allowedSourceDomains?.length);
+}
+
+function requiresClaimProof(answerKey, expectedEntities) {
+  return Boolean(answerKey.rowMustContainAny?.length) ||
+    expectedEntities.some((entity) => entity.requiredText?.length);
+}
+
+function isPlaceholderHostname(hostname) {
+  return hostname === "example.com" ||
+    hostname.endsWith(".example.com") ||
+    hostname === "localhost" ||
+    hostname === "127.0.0.1";
+}
+
+function clarificationScore(text, terms) {
+  if (terms.length === 0) return text.length > 0 ? 1 : 0;
+  const matchedTerms = terms.filter((term) => text.includes(term.toLowerCase())).length;
+  return roundRatio(matchedTerms / terms.length);
+}
+
+function failureCategoryForScore(input) {
+  if (input.parsedRows.length === 0 && input.answerKey.expectedBehavior !== "clarify_or_abstain") {
+    return "schema";
+  }
+  if (input.shapeScore < 1) return "source_evidence";
+  if (input.answerKey.expectedBehavior === "clarify_or_abstain" && input.abstentionScore < 0.5) {
+    return "clarification";
+  }
+  if (input.entityCoverageRatio < 1) return "factual_accuracy";
+  if (input.domainAccuracyRatio < 1) return "source_evidence";
+  if (input.claimSupportRatio < 1) return "factual_accuracy";
+  if (input.factualAccuracyScore < input.minimumScore) return "factual_accuracy";
+  return "factual_accuracy";
+}
+
+function findInfrastructureBlockerReason({ execution, parsedPayload, normalized }) {
+  const combinedText = [
+    execution.stderr,
+    execution.stdout,
+    JSON.stringify(parsedPayload ?? {}),
+    ...(normalized?.validationIssues ?? []),
+  ].join("\n").toLowerCase();
+
+  if (execution.timedOut) return "Command timed out.";
+  const blockerPatterns = [
+    "authentication failed",
+    "active subscription",
+    "insufficient credits",
+    "not enough credits",
+    "api key",
+    "tinyfish_api_key",
+    "quota",
+    "rate limit",
+    "benchmark deadline",
+  ];
+  return blockerPatterns.some((pattern) => combinedText.includes(pattern))
+    ? "Infrastructure/auth/credits blocker."
+    : null;
+}
+
+function aggregateResults(results) {
+  const groups = new Map();
+  for (const result of results) {
+    groups.set(result.system, [...(groups.get(result.system) ?? []), result]);
+  }
+
+  return Array.from(groups.entries()).map(([system, group]) => {
+    const passed = group.filter((result) => result.status === "ok").length;
+    const blocked = group.filter((result) => result.status === "blocked").length;
+    const failed = group.length - passed - blocked;
+    const eligibleGroup = group.filter((result) => result.status !== "blocked");
+    const eligibleCount = eligibleGroup.length;
+    const totalLatencyMs = sum(group, "latencyMs");
+    const totalEstimatedCostUsd = sum(group, "estimatedTotalCostUsd");
+    return {
+      system,
+      total: group.length,
+      passed,
+      failed,
+      blocked,
+      passRate: roundRatio(passed / Math.max(1, group.length)),
+      eligiblePassRate: roundRatio(passed / Math.max(1, eligibleCount)),
+      wallClockMs: totalLatencyMs,
+      avgLatencyMs: Math.round(totalLatencyMs / Math.max(1, group.length)),
+      avgRequiredCellCompletenessRatio: roundRatio(
+        sum(eligibleGroup, "requiredCellCompletenessRatio") / Math.max(1, eligibleCount)
+      ),
+      avgRequestedCellCompletenessRatio: roundRatio(
+        sum(eligibleGroup, "requestedCellCompletenessRatio") / Math.max(1, eligibleCount)
+      ),
+      avgFactualAccuracyScore: roundRatio(
+        sum(eligibleGroup, "factualAccuracyScore") / Math.max(1, eligibleCount)
+      ),
+      avgEntityCoverageRatio: roundRatio(
+        sum(eligibleGroup, "entityCoverageRatio") / Math.max(1, eligibleCount)
+      ),
+      avgDomainAccuracyRatio: roundRatio(
+        sum(eligibleGroup, "domainAccuracyRatio") / Math.max(1, eligibleCount)
+      ),
+      totalRows: sum(group, "rowCount"),
+      totalEvidenceQuotes: sum(group, "evidenceQuoteCount"),
+      totalSourceUrls: sum(group, "sourceUrlCount"),
+      totalMissingRequestedCells: sum(group, "missingRequestedCellCount"),
+      totalMissingRequiredCells: sum(group, "missingRequiredCellCount"),
+      totalDuplicateIdentities: sum(group, "duplicateIdentityCount"),
+      totalPromptTokens: group.reduce((total, result) => total + result.usage.promptTokens, 0),
+      totalCompletionTokens: group.reduce((total, result) => total + result.usage.completionTokens, 0),
+      totalTokens: group.reduce((total, result) => total + result.usage.totalTokens, 0),
+      searchCallCount: sum(group, "searchCallCount"),
+      fetchCallCount: sum(group, "fetchCallCount"),
+      browserCallCount: sum(group, "browserCallCount"),
+      agentRunCount: sum(group, "agentRunCount"),
+      agentStepCount: sum(group, "agentStepCount"),
+      estimatedTotalCostUsd: roundUsd(totalEstimatedCostUsd),
+    };
+  });
+}
+
+async function writeMarkdownReport(filePath, summary, prompts) {
+  const lines = [
+    "# Dataset Agent Benchmark Report",
+    "",
+    `Tested: ${summary.testedAt}`,
+    `Completed: ${summary.completedAt}`,
+    `Wall clock: ${formatDuration(summary.wallClockMs)}`,
+    `Prompt mix: good ${summary.promptMix.good}, average ${summary.promptMix.average}, bad ${summary.promptMix.bad}`,
+    "",
+    "## Aggregate",
+    "",
+    "| System | Runs | Passed | Failed | Blocked | Pass Rate | Eligible Pass | Avg Accuracy | Avg Latency | Rows | Evidence | Sources | Completeness | Missing Requested | Duplicates | Tokens In | Tokens Out | Agent Steps | Est Cost |",
+    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ...summary.aggregate.map((row) =>
+      `| ${escapeMarkdown(row.system)} | ${row.total} | ${row.passed} | ${row.failed} | ${row.blocked} | ${row.passRate} | ${row.eligiblePassRate} | ${row.avgFactualAccuracyScore} | ${formatDuration(row.avgLatencyMs)} | ${row.totalRows} | ${row.totalEvidenceQuotes} | ${row.totalSourceUrls} | ${row.avgRequestedCellCompletenessRatio ?? row.avgRequiredCellCompletenessRatio} | ${row.totalMissingRequestedCells ?? row.totalMissingRequiredCells} | ${row.totalDuplicateIdentities} | ${row.totalPromptTokens} | ${row.totalCompletionTokens} | ${row.agentStepCount} | ${formatUsd(row.estimatedTotalCostUsd)} |`
+    ),
+    "",
+    "## Prompt Pack",
+    "",
+    "| # | Quality | Persona | Prompt | Requested Columns | Minimum Required | Stress |",
+    "| ---: | --- | --- | --- | --- | --- | --- |",
+    ...prompts.map((prompt, index) =>
+      `| ${index + 1} | ${prompt.quality} | ${escapeMarkdown(prompt.persona)} | ${escapeMarkdown(prompt.prompt)} | ${prompt.requiredColumns.join(", ")} | ${minimumRequiredColumnsForPrompt(prompt).join(", ")} | ${escapeMarkdown(prompt.expectedStress)} |`
+    ),
+    "",
+    "## Raw Results",
+    "",
+    "| System | Prompt | Quality | Status | Category | Accuracy | Entity Coverage | Domain Accuracy | Latency | Rows | Completeness | Evidence | Sources | Missing Requested | Duplicates | Tokens In | Tokens Out | Search | Fetch | Browser | Agent Runs | Agent Steps | Est Cost | Issue |",
+    "| --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+    ...summary.laneResults.map((result) =>
+      `| ${escapeMarkdown(result.system)} | ${escapeMarkdown(result.promptId)} | ${result.promptQuality} | ${result.status} | ${escapeMarkdown(result.failureCategory ?? "")} | ${result.factualAccuracyScore ?? 0} | ${result.entityCoverageRatio ?? 0} | ${result.domainAccuracyRatio ?? 0} | ${formatDuration(result.latencyMs)} | ${result.rowCount} | ${result.requestedCellCompletenessRatio ?? result.requiredCellCompletenessRatio} | ${result.evidenceQuoteCount} | ${result.sourceUrlCount} | ${result.missingRequestedCellCount ?? result.missingRequiredCellCount} | ${result.duplicateIdentityCount} | ${result.usage.promptTokens} | ${result.usage.completionTokens} | ${result.searchCallCount} | ${result.fetchCallCount} | ${result.browserCallCount} | ${result.agentRunCount} | ${result.agentStepCount} | ${formatUsd(result.estimatedTotalCostUsd)} | ${escapeMarkdown(result.errorMessage ?? "")} |`
+    ),
+    "",
+  ];
+  await writeFile(filePath, `${lines.join("\n")}\n`);
+}
+
+function promptMixSummary(prompts) {
+  return prompts.reduce(
+    (mix, prompt) => {
+      mix[prompt.quality] = (mix[prompt.quality] ?? 0) + 1;
+      return mix;
+    },
+    { good: 0, average: 0, bad: 0 }
+  );
+}
+
+function estimateModelCostUsd(usage, config) {
+  return roundUsd(
+    (usage.promptTokens / 1_000_000) * config.inputUsdPer1M +
+      (usage.completionTokens / 1_000_000) * config.outputUsdPer1M
+  );
+}
+
+function rowCells(row) {
+  if (isRecord(row?.cells)) return row.cells;
+  if (isRecord(row?.data)) return row.data;
+  return isRecord(row) ? row : {};
+}
+
+function rowSourceUrls(row, cells) {
+  return [
+    ...stringArrayValue(row?.sourceUrls),
+    ...stringArrayValue(row?.sources),
+    ...stringArrayValue(row?.source_urls),
+    ...stringArrayValue(cells?.source_urls),
+    ...stringArrayValue(cells?.sources),
+    ...singleStringArray(row?.sourceUrl),
+    ...singleStringArray(row?.source_url),
+    ...singleStringArray(cells?.source_url),
+    ...singleStringArray(cells?.sourceUrl),
+  ].filter((value) => value.startsWith("http"));
+}
+
+function rowSearchText(row) {
+  const cells = rowCells(row);
+  return [
+    JSON.stringify(cells),
+    ...rowSourceUrls(row, cells),
+    ...arrayValue(row?.evidence).map((evidence) =>
+      typeof evidence === "string" ? evidence : evidence?.quote ?? ""
+    ),
+  ].join(" ").toLowerCase();
+}
+
+function rowHasAllowedDomain(row, allowedDomains) {
+  if (!allowedDomains?.length) return true;
+  const cells = rowCells(row);
+  return rowSourceUrls(row, cells).some((url) =>
+    allowedDomains.some((allowedDomain) => urlHostname(url).endsWith(allowedDomain))
+  );
+}
+
+function textContainsAny(text, terms) {
+  const lowerText = text.toLowerCase();
+  return terms.some((term) => lowerText.includes(String(term).toLowerCase()));
+}
+
+function urlHostname(url) {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return "";
+  }
+}
+
+function rowEvidenceQuoteCount(row) {
+  return arrayValue(row?.evidence).filter((evidence) => {
+    if (typeof evidence === "string") return evidence.trim().length > 0;
+    return typeof evidence?.quote === "string" && evidence.quote.trim().length > 0;
+  }).length;
+}
+
+function identityKey(cells, row) {
+  const candidates = [
+    cells.entity_name,
+    cells.company_name,
+    cells.product_name,
+    cells.bakery_name,
+    cells.provider_name,
+    cells.name,
+    row.id,
+  ];
+  const identityParts = candidates.filter(isPresent).map((value) =>
+    String(value).trim().toLowerCase()
+  );
+  return identityParts[0] ?? null;
+}
+
+function failureReason({
+  execution,
+  parsedPayload,
+  validation,
+  answerKeyScore,
+  infraBlockerReason,
+  minRequiredCompleteness,
+}) {
+  if (infraBlockerReason) return infraBlockerReason;
+  if (execution.timedOut) return "Command timed out.";
+  if (execution.exitCode !== 0) return `Command exited ${execution.exitCode}.`;
+  if (!parsedPayload) return "No parseable JSON object found in stdout.";
+  if (answerKeyScore?.failureCategory === "clarification") {
+    return `Clarification/abstention score ${answerKeyScore.abstentionScore} below required threshold.`;
+  }
+  if (validation.rowCount === 0) return "Parsed JSON had zero rows.";
+  if (validation.sourceUrlCount === 0) return "No source URLs found.";
+  if (validation.evidenceQuoteCount === 0) return "No evidence quotes found.";
+  if (validation.requiredCellCompletenessRatio < minRequiredCompleteness) {
+    return `Requested-cell completeness ${validation.requiredCellCompletenessRatio} below ${minRequiredCompleteness}.`;
+  }
+  if (answerKeyScore && !answerKeyScore.passed) {
+    if (answerKeyScore.failureCategory === "source_evidence") {
+      return `Source/domain evidence failed; factual accuracy ${answerKeyScore.factualAccuracyScore}, domain accuracy ${answerKeyScore.domainAccuracyRatio}.`;
+    }
+    return `Factual accuracy ${answerKeyScore.factualAccuracyScore} below ${answerKeyScore.minimumScore}; missing entities: ${answerKeyScore.missingExpectedEntities.join(", ") || "none"}.`;
+  }
+  return "Benchmark failed.";
+}
+
+function arrayValue(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function stringArrayValue(value) {
+  if (Array.isArray(value)) {
+    return value.filter((item) => typeof item === "string");
+  }
+  if (typeof value === "string") {
+    return [value];
+  }
+  return [];
+}
+
+function singleStringArray(value) {
+  return typeof value === "string" ? [value] : [];
+}
+
+function numberValue(value) {
+  return Number.isFinite(Number(value)) ? Number(value) : 0;
+}
+
+function positiveNumber(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : fallback;
+}
+
+function nonNegativeNumber(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 0 ? number : fallback;
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isPresent(value) {
+  if (value === null || value === undefined) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  return true;
+}
+
+function sum(items, key) {
+  return items.reduce((total, item) => total + numberValue(item[key]), 0);
+}
+
+function shellEscape(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`;
+}
+
+function escapeMarkdown(value) {
+  return String(value).replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+function formatDuration(ms) {
+  if (ms < 1000) return `${ms}ms`;
+  const totalSeconds = Math.round(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
+}
+
+function formatUsd(value) {
+  return `$${value.toFixed(value < 1 ? 4 : 2)}`;
+}
+
+function roundRatio(value) {
+  return Number(value.toFixed(3));
+}
+
+function roundUsd(value) {
+  return Number(value.toFixed(6));
+}
+
+async function writeJson(filePath, value) {
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function readJsonOrNull(filePath) {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+async function readTextOrEmpty(filePath) {
+  try {
+    return await readFile(filePath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function printHelpAndExit() {
+  console.log(`Usage:
+node benchmarks/dataset-agent/run-benchmark.mjs \\
+  --system mengzhe='npm run benchmark -- {{promptJson}}' \\
+  --system edward='node ./my-agent.js --prompt {{promptJson}}'
+
+Run a canary subset before spending credits on all prompts:
+node benchmarks/dataset-agent/run-benchmark.mjs \\
+  --prompt-ids latest-ai-blog-posts,saas-pricing-pages \\
+  --system edward='node ./my-agent.js --prompt {{promptJson}}'
+
+Rescore existing artifacts without spending credits:
+node benchmarks/dataset-agent/run-benchmark.mjs --rescore-dir benchmark-results/<run>
+
+Agent command contract:
+- stdout should contain a JSON object.
+- Preferred shape: { "rows": [], "validationIssues": [], "usage": {}, "metrics": {} }
+- usage supports promptTokens/inputTokens, completionTokens/outputTokens, totalTokens.
+- metrics supports searchCalls, fetchCalls, browserCalls, agentRuns, agentSteps.
+`);
+  process.exit(0);
+}

--- a/benchmarks/dataset-agent/run-benchmark.mjs
+++ b/benchmarks/dataset-agent/run-benchmark.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
@@ -515,7 +515,9 @@ const answerKeysByPromptId = {
   },
 };
 
-await main();
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}
 
 async function runSystemPrompt(input) {
   const startedAt = Date.now();
@@ -643,6 +645,7 @@ async function runSystemPrompt(input) {
         answerKeyScore,
         infraBlockerReason,
         minRequiredCompleteness: input.config.minRequiredCompleteness,
+        validationIssues: normalized.validationIssues,
       }),
   };
 }
@@ -1119,6 +1122,7 @@ async function rescoreBenchmarkRun({ runDirectory, prompts, config }) {
           answerKeyScore,
           infraBlockerReason,
           minRequiredCompleteness: config.minRequiredCompleteness,
+          validationIssues: normalized.validationIssues,
         }),
     });
   }
@@ -1350,7 +1354,7 @@ function failureCategoryForScore(input) {
   return "factual_accuracy";
 }
 
-function findInfrastructureBlockerReason({ execution, parsedPayload, normalized }) {
+export function findInfrastructureBlockerReason({ execution, parsedPayload, normalized }) {
   const combinedText = [
     execution.stderr,
     execution.stdout,
@@ -1360,17 +1364,19 @@ function findInfrastructureBlockerReason({ execution, parsedPayload, normalized 
 
   if (execution.timedOut) return "Command timed out.";
   const blockerPatterns = [
-    "authentication failed",
-    "active subscription",
-    "insufficient credits",
-    "not enough credits",
-    "api key",
-    "tinyfish_api_key",
-    "quota",
-    "rate limit",
-    "benchmark deadline",
+    /authentication failed/,
+    /active subscription/,
+    /insufficient credits/,
+    /not enough credits/,
+    /(?:missing|required|invalid|not configured|not set|unset)[^.]{0,80}api[_ -]?key/,
+    /api[_ -]?key[^.]{0,80}(?:missing|required|invalid|not configured|not set|unset)/,
+    /tinyfish_api_key/,
+    /openrouter_api_key/,
+    /quota exceeded/,
+    /rate[_ -]?limit[_ -]?exceeded/,
+    /benchmark deadline/,
   ];
-  return blockerPatterns.some((pattern) => combinedText.includes(pattern))
+  return blockerPatterns.some((pattern) => pattern.test(combinedText))
     ? "Infrastructure/auth/credits blocker."
     : null;
 }
@@ -1562,18 +1568,21 @@ function identityKey(cells, row) {
   return identityParts[0] ?? null;
 }
 
-function failureReason({
+export function failureReason({
   execution,
   parsedPayload,
   validation,
   answerKeyScore,
   infraBlockerReason,
   minRequiredCompleteness,
+  validationIssues = [],
 }) {
   if (infraBlockerReason) return infraBlockerReason;
   if (execution.timedOut) return "Command timed out.";
   if (execution.exitCode !== 0) return `Command exited ${execution.exitCode}.`;
   if (!parsedPayload) return "No parseable JSON object found in stdout.";
+  const capabilityDiagnostic = capabilityDiagnosticReason(validationIssues);
+  if (capabilityDiagnostic) return capabilityDiagnostic;
   if (answerKeyScore?.failureCategory === "clarification") {
     return `Clarification/abstention score ${answerKeyScore.abstentionScore} below required threshold.`;
   }
@@ -1596,6 +1605,12 @@ function failureReason({
     return `Factual accuracy ${answerKeyScore.factualAccuracyScore} below ${answerKeyScore.minimumScore}; missing entities: ${answerKeyScore.missingExpectedEntities.join(", ") || "none"}.`;
   }
   return "Benchmark failed.";
+}
+
+function capabilityDiagnosticReason(validationIssues) {
+  return validationIssues.find((issue) =>
+    /^capability diagnostic:/i.test(String(issue))
+  ) ?? null;
 }
 
 function arrayValue(value) {

--- a/benchmarks/dataset-agent/run-benchmark.mjs
+++ b/benchmarks/dataset-agent/run-benchmark.mjs
@@ -118,14 +118,14 @@ const answerKeysByPromptId = {
     officialSourceDomains: ["openai.com", "anthropic.com", "deepmind.google"],
   },
   "saas-pricing-pages": {
-    verifiedAt,
+    verifiedAt: "2026-05-22",
     sourceUrls: [
       "https://stripe.com/pricing",
-      "https://www.paddle.com/billing",
+      "https://www.paddle.com/pricing",
       "https://www.chargebee.com/pricing/",
     ],
     scoringNotes:
-      "Pass requires all three vendors, official domains, and visible plan or price text. Paddle may route pricing through Billing or sales-led pages.",
+      "Pass requires all three vendors, official domains, and visible plan or price text. Paddle's current pricing page can show Checkout transaction pricing.",
     expectedBehavior: "answer",
     requiredColumns: ["entity_name", "pricing_page_url", "plan_or_price", "source_url"],
     expectedEntities: [
@@ -141,7 +141,7 @@ const answerKeysByPromptId = {
         label: "Paddle",
         aliases: ["paddle"],
         allowedSourceDomains: ["paddle.com"],
-        requiredText: ["merchant of record", "billing"],
+        requiredText: ["checkout", "5%", "50"],
       },
       {
         id: "chargebee",
@@ -155,14 +155,14 @@ const answerKeysByPromptId = {
     officialSourceDomains: ["stripe.com", "paddle.com", "chargebee.com"],
   },
   "earnings-release-pages": {
-    verifiedAt,
+    verifiedAt: "2026-05-22",
     sourceUrls: [
       "https://www.apple.com/newsroom/2026/04/apple-reports-second-quarter-results/",
       "https://www.microsoft.com/en-us/investor/earnings/fy-2026-q3/press-release-webcast",
-      "https://investor.nvidia.com/news/press-release-details/2026/NVIDIA-Announces-Financial-Results-for-Fourth-Quarter-and-Fiscal-2026/",
+      "https://nvidianews.nvidia.com/news/nvidia-announces-financial-results-for-first-quarter-fiscal-2027",
     ],
     scoringNotes:
-      "As of 2026-05-20, Apple latest verified release is fiscal 2026 Q2 on 2026-04-30, Microsoft is FY26 Q3 on 2026-04-29, and NVIDIA is Q4 fiscal 2026 on 2026-02-25.",
+      "As of 2026-05-22, Apple latest verified release is fiscal 2026 Q2 on 2026-04-30, Microsoft is FY26 Q3 on 2026-04-29, and NVIDIA is Q1 fiscal 2027 on 2026-05-20.",
     expectedBehavior: "answer",
     requiredColumns: ["entity_name", "release_date", "fiscal_quarter", "source_url"],
     expectedEntities: [
@@ -185,7 +185,7 @@ const answerKeysByPromptId = {
         label: "NVIDIA",
         aliases: ["nvidia"],
         allowedSourceDomains: ["nvidia.com"],
-        requiredText: ["fourth quarter", "q4", "fiscal 2026"],
+        requiredText: ["first quarter", "q1", "fiscal 2027", "may 20"],
       },
     ],
     minimumExpectedEntityMatches: 3,

--- a/benchmarks/dataset-agent/run-benchmark.mjs
+++ b/benchmarks/dataset-agent/run-benchmark.mjs
@@ -1582,6 +1582,12 @@ function failureReason({
     if (answerKeyScore.failureCategory === "source_evidence") {
       return `Source/domain evidence failed; factual accuracy ${answerKeyScore.factualAccuracyScore}, domain accuracy ${answerKeyScore.domainAccuracyRatio}.`;
     }
+    if (answerKeyScore.entityCoverageRatio < 1) {
+      return `Entity coverage ${answerKeyScore.entityCoverageRatio} below required coverage; missing entities: ${answerKeyScore.missingExpectedEntities.join(", ") || "none"}.`;
+    }
+    if (answerKeyScore.claimSupportRatio < 1) {
+      return `Claim support ${answerKeyScore.claimSupportRatio} below required support; missing required claim text for: ${answerKeyScore.missingExpectedEntities.join(", ") || "none"}.`;
+    }
     return `Factual accuracy ${answerKeyScore.factualAccuracyScore} below ${answerKeyScore.minimumScore}; missing entities: ${answerKeyScore.missingExpectedEntities.join(", ") || "none"}.`;
   }
   return "Benchmark failed.";

--- a/benchmarks/dataset-agent/run-benchmark.mjs
+++ b/benchmarks/dataset-agent/run-benchmark.mjs
@@ -605,6 +605,7 @@ async function runSystemPrompt(input) {
     abstentionScore: answerKeyScore.abstentionScore,
     matchedExpectedEntities: answerKeyScore.matchedExpectedEntities,
     missingExpectedEntities: answerKeyScore.missingExpectedEntities,
+    missingClaimSupportEntities: answerKeyScore.missingClaimSupportEntities,
     latencyMs: Date.now() - startedAt,
     exitCode: execution.exitCode,
     timedOut: execution.timedOut,
@@ -1093,6 +1094,7 @@ async function rescoreBenchmarkRun({ runDirectory, prompts, config }) {
       abstentionScore: answerKeyScore.abstentionScore,
       matchedExpectedEntities: answerKeyScore.matchedExpectedEntities,
       missingExpectedEntities: answerKeyScore.missingExpectedEntities,
+      missingClaimSupportEntities: answerKeyScore.missingClaimSupportEntities,
       rowCount: validation.rowCount,
       nonEmptyCellCount: validation.nonEmptyCellCount,
       totalExpectedCellCount: validation.totalExpectedCellCount,
@@ -1137,6 +1139,7 @@ function scoreBenchmarkRows(input) {
   const expectedEntities = answerKey.expectedEntities ?? [];
   const matchedExpectedEntities = [];
   const missingExpectedEntities = [];
+  const missingClaimSupportEntities = [];
   let expectedEntityDomainMatches = 0;
   let expectedEntityClaimMatches = 0;
 
@@ -1157,11 +1160,12 @@ function scoreBenchmarkRows(input) {
     if (rowsToCheck.some((row) => rowHasAllowedDomain(row, expectedEntity.allowedSourceDomains))) {
       expectedEntityDomainMatches += 1;
     }
-    if (
-      !expectedEntity.requiredText?.length ||
-      rowsToCheck.some((row) => textContainsAny(rowSearchText(row), expectedEntity.requiredText))
-    ) {
+    const hasRequiredClaimText = !expectedEntity.requiredText?.length ||
+      rowsToCheck.some((row) => textContainsAny(rowSearchText(row), expectedEntity.requiredText));
+    if (hasRequiredClaimText) {
       expectedEntityClaimMatches += 1;
+    } else {
+      missingClaimSupportEntities.push(expectedEntity.label ?? expectedEntity.id);
     }
   }
 
@@ -1241,6 +1245,7 @@ function scoreBenchmarkRows(input) {
     abstentionScore,
     matchedExpectedEntities,
     missingExpectedEntities,
+    missingClaimSupportEntities,
     minimumScore,
   };
 }
@@ -1586,7 +1591,7 @@ function failureReason({
       return `Entity coverage ${answerKeyScore.entityCoverageRatio} below required coverage; missing entities: ${answerKeyScore.missingExpectedEntities.join(", ") || "none"}.`;
     }
     if (answerKeyScore.claimSupportRatio < 1) {
-      return `Claim support ${answerKeyScore.claimSupportRatio} below required support; missing required claim text for: ${answerKeyScore.missingExpectedEntities.join(", ") || "none"}.`;
+      return `Claim support ${answerKeyScore.claimSupportRatio} below required support; missing required claim text for: ${(answerKeyScore.missingClaimSupportEntities ?? []).join(", ") || "none"}.`;
     }
     return `Factual accuracy ${answerKeyScore.factualAccuracyScore} below ${answerKeyScore.minimumScore}; missing entities: ${answerKeyScore.missingExpectedEntities.join(", ") || "none"}.`;
   }

--- a/benchmarks/dataset-agent/run-benchmark.mjs
+++ b/benchmarks/dataset-agent/run-benchmark.mjs
@@ -1046,8 +1046,10 @@ async function rescoreBenchmarkRun({ runDirectory, prompts, config }) {
       continue;
     }
 
-    const artifactDirectory = laneResult.artifactDirectory ??
-      join(runDirectory, laneResult.system, laneResult.promptId);
+    const artifactDirectory = await resolveRescoreArtifactDirectory({
+      runDirectory,
+      laneResult,
+    });
     const parsedPayload = await readJsonOrNull(join(artifactDirectory, "parsed-output.json"));
     const stdout = await readTextOrEmpty(join(artifactDirectory, "stdout.txt"));
     const stderr = await readTextOrEmpty(join(artifactDirectory, "stderr.txt"));
@@ -1136,7 +1138,47 @@ async function rescoreBenchmarkRun({ runDirectory, prompts, config }) {
   };
 }
 
-function scoreBenchmarkRows(input) {
+async function resolveRescoreArtifactDirectory({ runDirectory, laneResult }) {
+  const declaredArtifactDirectory = laneResult.artifactDirectory;
+  const candidates = [];
+
+  if (declaredArtifactDirectory) {
+    candidates.push(declaredArtifactDirectory);
+
+    const normalizedArtifactDirectory = declaredArtifactDirectory.replaceAll("\\", "/");
+    const runDirectoryName = runDirectory.split(/[\\/]/).filter(Boolean).at(-1);
+    const runDirectoryMarker = runDirectoryName ? `${runDirectoryName}/` : null;
+    const markerIndex = runDirectoryMarker
+      ? normalizedArtifactDirectory.indexOf(runDirectoryMarker)
+      : -1;
+
+    if (markerIndex >= 0) {
+      const artifactPathWithinRun = normalizedArtifactDirectory.slice(
+        markerIndex + runDirectoryMarker.length
+      );
+      candidates.push(join(runDirectory, ...artifactPathWithinRun.split("/")));
+    }
+
+    candidates.push(
+      join(
+        runDirectory,
+        laneResult.system,
+        normalizedArtifactDirectory.split("/").filter(Boolean).at(-1) ?? laneResult.promptId
+      )
+    );
+  }
+
+  candidates.push(join(runDirectory, laneResult.system, laneResult.promptId));
+
+  for (const candidate of uniqueStrings(candidates)) {
+    const parsedPayload = await readJsonOrNull(join(candidate, "parsed-output.json"));
+    if (parsedPayload) return candidate;
+  }
+
+  return candidates[0];
+}
+
+export function scoreBenchmarkRows(input) {
   const answerKey = answerKeyForPrompt(input.promptDefinition);
   const rowTexts = input.rows.map(rowSearchText);
   const validationIssueText = input.validationIssues.join(" ").toLowerCase();
@@ -1501,7 +1543,7 @@ function rowCells(row) {
 }
 
 function rowSourceUrls(row, cells) {
-  return [
+  return uniqueStrings([
     ...stringArrayValue(row?.sourceUrls),
     ...stringArrayValue(row?.sources),
     ...stringArrayValue(row?.source_urls),
@@ -1511,7 +1553,28 @@ function rowSourceUrls(row, cells) {
     ...singleStringArray(row?.source_url),
     ...singleStringArray(cells?.source_url),
     ...singleStringArray(cells?.sourceUrl),
-  ].filter((value) => value.startsWith("http"));
+    ...urlLikeCellValues(cells),
+  ].filter((value) => value.startsWith("http")));
+}
+
+function urlLikeCellValues(cells) {
+  if (!isRecord(cells)) return [];
+  return Object.entries(cells)
+    .filter(([key, value]) =>
+      isUrlLikeCellName(key) && typeof value === "string"
+    )
+    .map(([, value]) => value);
+}
+
+function isUrlLikeCellName(name) {
+  const lower = String(name).toLowerCase();
+  return lower === "url" ||
+    lower.endsWith("_url") ||
+    lower.includes("url") ||
+    lower === "website" ||
+    lower.endsWith("_website") ||
+    lower === "homepage" ||
+    lower.endsWith("_homepage");
 }
 
 function rowSearchText(row) {

--- a/benchmarks/dataset-agent/run-benchmark.test.mjs
+++ b/benchmarks/dataset-agent/run-benchmark.test.mjs
@@ -5,6 +5,7 @@ import {
   failureReason,
   findInfrastructureBlockerReason,
   scoreBenchmarkRows,
+  scoreOpenEndedBenchmarkRows,
 } from "./run-benchmark.mjs";
 
 const passingValidation = {
@@ -66,6 +67,34 @@ test("infrastructure blocker detection ignores ordinary API-key documentation te
   assert.equal(reason, null);
 });
 
+test("benchmark failure reason surfaces setup validation issues for zero-row runs", () => {
+  const setupIssue =
+    "Collection self-healing benchmark runner is not configured. Set BIGSET_COLLECTION_BENCHMARK_RUNNER_MODULE to a module exporting runCollectionPopulatePipeline(input).";
+
+  const reason = failureReason({
+    execution: {
+      timedOut: false,
+      exitCode: 0,
+    },
+    parsedPayload: {
+      rows: [],
+      validationIssues: [setupIssue],
+    },
+    validation: {
+      rowCount: 0,
+      sourceUrlCount: 0,
+      evidenceQuoteCount: 0,
+      requiredCellCompletenessRatio: 0,
+    },
+    answerKeyScore: null,
+    infraBlockerReason: null,
+    minRequiredCompleteness: 0.75,
+    validationIssues: [setupIssue],
+  });
+
+  assert.equal(reason, setupIssue);
+});
+
 test("infrastructure blocker detection still catches missing API key configuration", () => {
   const reason = findInfrastructureBlockerReason({
     execution: {
@@ -80,6 +109,65 @@ test("infrastructure blocker detection still catches missing API key configurati
   });
 
   assert.equal(reason, "Infrastructure/auth/credits blocker.");
+});
+
+test("failureReason does not require evidence when requireEvidence is false", () => {
+  const reason = failureReason({
+    execution: { timedOut: false, exitCode: 0 },
+    parsedPayload: { rows: [{ cells: { entity_name: "A" }, sourceUrls: ["https://a.com"] }] },
+    validation: {
+      rowCount: 1,
+      sourceUrlCount: 1,
+      evidenceQuoteCount: 0,
+      requiredCellCompletenessRatio: 1,
+    },
+    answerKeyScore: { passed: false, failureCategory: "row_target" },
+    infraBlockerReason: null,
+    minRequiredCompleteness: 0.6,
+    requireEvidence: false,
+    validationIssues: [],
+  });
+
+  assert.doesNotMatch(reason, /evidence quotes/);
+});
+
+test("open-ended scoring passes without evidence quotes when requireEvidence is false", () => {
+  const score = scoreOpenEndedBenchmarkRows({
+    rows: Array.from({ length: 60 }, (_, index) => ({
+      cells: {
+        entity_name: `Entity ${index}`,
+        website: `https://example-${index}.com`,
+        description: "Example",
+        source_url: `https://example-${index}.com`,
+      },
+      sourceUrls: [`https://example-${index}.com`],
+    })),
+    validation: {
+      rowCount: 60,
+      sourceUrlCount: 60,
+      evidenceQuoteCount: 0,
+      requiredCellCompletenessRatio: 1,
+      missingRequiredCellCount: 0,
+    },
+    validationIssues: [],
+    targetContract: {
+      targetRows: 100,
+      minRowCount: 50,
+      minRequiredCompleteness: 0.6,
+      minFactualAccuracy: 0.5,
+      minEvidenceCoverage: 0.95,
+      requireEvidence: false,
+    },
+    promptDefinition: {
+      id: "yc-recent-batch-companies",
+      scoringMode: "open_ended",
+      requiredColumns: ["entity_name", "website", "description", "source_url"],
+    },
+  });
+
+  assert.equal(score.passed, true);
+  assert.equal(score.evidenceSupportRatio, 0);
+  assert.equal(score.rowTargetRatio, 0.6);
 });
 
 test("domain scoring counts official website cells as source evidence", () => {

--- a/benchmarks/dataset-agent/run-benchmark.test.mjs
+++ b/benchmarks/dataset-agent/run-benchmark.test.mjs
@@ -4,7 +4,16 @@ import { test } from "node:test";
 import {
   failureReason,
   findInfrastructureBlockerReason,
+  scoreBenchmarkRows,
 } from "./run-benchmark.mjs";
+
+const passingValidation = {
+  rowCount: 1,
+  sourceUrlCount: 1,
+  evidenceQuoteCount: 1,
+  requiredCellCompletenessRatio: 1,
+  missingRequiredCellCount: 0,
+};
 
 test("benchmark failure reason prefers capability diagnostic over generic zero rows", () => {
   const diagnostic = "Capability diagnostic: TinyFish Agent disabled; triage requested browser/form/detail follow-up for 2 page(s) (requires_navigation=1, requires_form_submission=1). Enable COLLECTION_AGENT_ENABLE_AGENT=true for live navigation.";
@@ -71,4 +80,100 @@ test("infrastructure blocker detection still catches missing API key configurati
   });
 
   assert.equal(reason, "Infrastructure/auth/credits blocker.");
+});
+
+test("domain scoring counts official website cells as source evidence", () => {
+  const score = scoreBenchmarkRows({
+    rows: [{
+      cells: {
+        entity_name: "MoMo",
+        official_website: "https://momo.vn",
+        source_url: "https://example-directory.test/vietnam-fintech",
+      },
+      evidence: [{ quote: "MoMo official website is https://momo.vn" }],
+    }],
+    validation: passingValidation,
+    validationIssues: [],
+    minRequiredCompleteness: 1,
+    minFactualAccuracy: 0.75,
+    promptDefinition: {
+      answerKey: {
+        expectedBehavior: "answer",
+        requiredColumns: ["entity_name", "official_website", "source_url"],
+        expectedEntities: [{
+          label: "MoMo",
+          aliases: ["momo"],
+          allowedSourceDomains: ["momo.vn"],
+        }],
+        minimumExpectedEntityMatches: 1,
+      },
+    },
+  });
+
+  assert.equal(score.passed, true);
+  assert.equal(score.domainAccuracyRatio, 1);
+});
+
+test("domain scoring counts product, careers, and docs URL cells", () => {
+  const cases = [
+    {
+      cells: {
+        bakery_name: "Bakes",
+        product_name: "Croissant",
+        product_url: "https://bakes-saigon.com/products/croissant",
+        source_url: "https://example-directory.test/bakeries",
+      },
+      label: "Bakes",
+      aliases: ["bakes"],
+      allowedSourceDomains: ["bakes-saigon.com"],
+    },
+    {
+      cells: {
+        entity_name: "Runway",
+        careers_page_url: "https://runwayml.com/careers",
+        source_url: "https://example-directory.test/ai-startups",
+      },
+      label: "Runway",
+      aliases: ["runway"],
+      allowedSourceDomains: ["runwayml.com"],
+    },
+    {
+      cells: {
+        entity_name: "Cloudflare",
+        docs_url: "https://developers.cloudflare.com/agents/model-context-protocol/",
+        source_url: "https://example-directory.test/mcp-docs",
+      },
+      label: "Cloudflare",
+      aliases: ["cloudflare"],
+      allowedSourceDomains: ["developers.cloudflare.com"],
+    },
+  ];
+
+  for (const item of cases) {
+    const score = scoreBenchmarkRows({
+      rows: [{
+        cells: item.cells,
+        evidence: [{ quote: JSON.stringify(item.cells) }],
+      }],
+      validation: passingValidation,
+      validationIssues: [],
+      minRequiredCompleteness: 1,
+      minFactualAccuracy: 0.75,
+      promptDefinition: {
+        answerKey: {
+          expectedBehavior: "answer",
+          requiredColumns: Object.keys(item.cells),
+          expectedEntities: [{
+            label: item.label,
+            aliases: item.aliases,
+            allowedSourceDomains: item.allowedSourceDomains,
+          }],
+          minimumExpectedEntityMatches: 1,
+        },
+      },
+    });
+
+    assert.equal(score.passed, true, `${item.label} should pass`);
+    assert.equal(score.domainAccuracyRatio, 1, `${item.label} domain`);
+  }
 });

--- a/benchmarks/dataset-agent/run-benchmark.test.mjs
+++ b/benchmarks/dataset-agent/run-benchmark.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  failureReason,
+  findInfrastructureBlockerReason,
+} from "./run-benchmark.mjs";
+
+test("benchmark failure reason prefers capability diagnostic over generic zero rows", () => {
+  const diagnostic = "Capability diagnostic: TinyFish Agent disabled; triage requested browser/form/detail follow-up for 2 page(s) (requires_navigation=1, requires_form_submission=1). Enable COLLECTION_AGENT_ENABLE_AGENT=true for live navigation.";
+
+  const reason = failureReason({
+    execution: {
+      timedOut: false,
+      exitCode: 0,
+    },
+    parsedPayload: {
+      rows: [],
+      validationIssues: [diagnostic],
+    },
+    validation: {
+      rowCount: 0,
+      sourceUrlCount: 0,
+      evidenceQuoteCount: 0,
+      requiredCellCompletenessRatio: 0,
+    },
+    answerKeyScore: null,
+    infraBlockerReason: null,
+    minRequiredCompleteness: 0.75,
+    validationIssues: [diagnostic],
+  });
+
+  assert.equal(reason, diagnostic);
+});
+
+test("infrastructure blocker detection ignores ordinary API-key documentation text", () => {
+  const reason = findInfrastructureBlockerReason({
+    execution: {
+      timedOut: false,
+      stderr: "The documentation page covers general API key setup and SDK usage.",
+      stdout: "",
+    },
+    parsedPayload: {
+      rows: [{
+        cells: {
+          summary: "Covers API key setup for developers.",
+        },
+      }],
+    },
+    normalized: {
+      validationIssues: [
+        "Capability diagnostic: TinyFish Agent disabled; triage requested browser/form/detail follow-up for 1 page(s) (requires_navigation=1). Enable COLLECTION_AGENT_ENABLE_AGENT=true for live navigation.",
+      ],
+    },
+  });
+
+  assert.equal(reason, null);
+});
+
+test("infrastructure blocker detection still catches missing API key configuration", () => {
+  const reason = findInfrastructureBlockerReason({
+    execution: {
+      timedOut: false,
+      stderr: "Missing OPENROUTER_API_KEY.",
+      stdout: "",
+    },
+    parsedPayload: null,
+    normalized: {
+      validationIssues: [],
+    },
+  });
+
+  assert.equal(reason, "Infrastructure/auth/credits blocker.");
+});

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -32,6 +32,7 @@ services:
       CLERK_SECRET_KEY: ${CLERK_SECRET_KEY:-}
       CLERK_PUBLISHABLE_KEY: ${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:-}
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      TINYFISH_API_KEY: ${TINYFISH_API_KEY:-}
     depends_on:
       convex:
         condition: service_healthy
@@ -50,6 +51,7 @@ services:
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
       CONVEX_URL: http://convex:3210
       CONVEX_SELF_HOSTED_ADMIN_KEY: ${CONVEX_SELF_HOSTED_ADMIN_KEY:-}
+      TINYFISH_API_KEY: ${TINYFISH_API_KEY:-}
     depends_on:
       convex:
         condition: service_healthy

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,10 +24,12 @@ services:
       - "3501:3501"
     volumes:
       - ./backend/src:/app/src
+      - populate_recipe_data:/app/.bigset
     environment:
       CLIENT_ORIGIN: http://localhost:3500
       CONVEX_URL: http://convex:3210
       PORT: 3501
+      POPULATE_RECIPE_STORE_DIR: /app/.bigset/populate-recipes
       CONVEX_SELF_HOSTED_ADMIN_KEY: ${CONVEX_SELF_HOSTED_ADMIN_KEY:-}
       CLERK_SECRET_KEY: ${CLERK_SECRET_KEY:-}
       CLERK_PUBLISHABLE_KEY: ${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:-}
@@ -130,3 +132,4 @@ services:
 volumes:
   pgdata:
   convex_data:
+  populate_recipe_data:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -30,6 +30,7 @@ services:
       CONVEX_URL: http://convex:3210
       PORT: 3501
       POPULATE_RECIPE_STORE_DIR: /app/.bigset/populate-recipes
+      POPULATE_COLLECTION_MEMORY_DIR: /app/.bigset/collection-memory
       CONVEX_SELF_HOSTED_ADMIN_KEY: ${CONVEX_SELF_HOSTED_ADMIN_KEY:-}
       CLERK_SECRET_KEY: ${CLERK_SECRET_KEY:-}
       CLERK_PUBLISHABLE_KEY: ${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:-}

--- a/docs/branch-lineage.md
+++ b/docs/branch-lineage.md
@@ -1,0 +1,11 @@
+# Branch lineage
+
+## `codex/collection-stack-merged-main`
+
+| Field | Value |
+| --- | --- |
+| Branched from | `codex/collection-official-website-sources` |
+| Branch point commit | `14db4e2` (merge commit that integrated `origin/main`) |
+| Includes merge from | `main` at `f8fd10e` — PR #26 populate agent foundation |
+
+This branch continues the collection self-healing stack (PRs #31–#52) with `main` brought up to date.

--- a/docs/data-collection-agent-migration-plan.md
+++ b/docs/data-collection-agent-migration-plan.md
@@ -9,6 +9,16 @@ the collection pipeline is migrated into BigSet.
   intentionally stacked and should not be merged out of order.
 - PR #37 adds `make verify-self-healing`, which is the cheap local gate before
   touching live data or spending OpenRouter/TinyFish credits.
+- PR #38 adds this migration plan and keeps the target boundaries explicit.
+- PR #39 adds `CollectionPopulateRecipeRuntime`, an adapter boundary that can
+  run a collection pipeline through the same `PopulateRecipeRuntime` interface
+  as Mastra.
+- PR #40 adds `POPULATE_AGENT_RUNTIME=collection` selection through the real
+  HTTP and CLI entrypoints, but intentionally requires an injected collection
+  runner instead of pretending the vendored runner has already been ported.
+- PR #41 adds a `collection-self-heal` benchmark lane that wraps the collection
+  runtime inside `SelfHealingPopulateRecipeService`. This is the benchmark
+  socket Meteor can use once the real collection runner is available.
 - `feat/data-collection-agent-v14` vendors the collection pipeline under
   `backend/BigSet_Data_Collection_Agent` and includes the memory module.
 - Clean `feat/data-collection-agent-v14` tests pass once ignored backend
@@ -63,9 +73,14 @@ The current layer:
 Dry-run and benchmark paths intentionally use in-memory stores so they do not
 pollute durable recipe history.
 
+The current layer now can:
+
+- run an injected collection runner through the same self-healing runtime
+  boundary and benchmark harness as Mastra
+
 The current layer does not yet:
 
-- run the collection pipeline as its runtime
+- run the real vendored collection pipeline as its runtime in this stack
 - generate Playwright scripts as a durable production recipe
 - run a green live Convex canary in this local environment
 - prove quality on a full real benchmark for the collection runtime
@@ -88,6 +103,7 @@ The current layer does not yet:
    - Gate: `npm --prefix backend test` and `npm --prefix backend run build`.
 
 3. Add a collection runtime adapter.
+   - Status: done in PR #39.
    - Implement the existing `PopulateRecipeRuntime` interface.
    - Input: BigSet `DatasetContext`.
    - Transform `recipe.runtimeInstructions` into the collection pipeline
@@ -100,6 +116,7 @@ The current layer does not yet:
      behavior.
 
 4. Add runtime selection through the real entrypoints.
+   - Status: done in PR #40 for injected collection runners.
    - Add a runtime factory for the self-healing runner.
    - Add an env switch such as `POPULATE_AGENT_RUNTIME=collection`.
    - Wire both `POST /populate` and `populate:self-heal --dataset-id` through
@@ -108,6 +125,7 @@ The current layer does not yet:
      entrypoints use the selected runtime.
 
 5. Add a self-healing-wrapped benchmark adapter for the collection runtime.
+   - Status: done in PR #41 for injected collection runners.
    - Reuse `benchmarks/dataset-agent/run-benchmark.mjs`.
    - Exercise `SelfHealingPopulateRecipeService` with the collection runtime
      inside it, not the direct collection pipeline alone.
@@ -155,10 +173,51 @@ Before any merge:
 - live dataset commit is tested only on a throwaway dataset
 - backend build does not depend on `frontend/convex/_generated`
 
+## Meteor Handoff Shape
+
+Meteor does not need to rebuild the self-healing wrapper. The socket is now:
+
+```text
+runCollectionPopulatePipeline(CollectionPopulatePipelineInput)
+  -> Promise<PopulateRuntimeResult>
+```
+
+`CollectionPopulatePipelineInput.recipeInstructions` is the self-healing signal.
+If the collection runner ignores that field, repaired recipes cannot change
+future behavior.
+
+The real benchmark command after a runner module exists is:
+
+```bash
+BIGSET_COLLECTION_BENCHMARK_RUNNER_MODULE=./backend/src/pipeline/collection-agent-runner.ts \
+node benchmarks/dataset-agent/run-benchmark.mjs \
+  --prompt-ids latest-ai-blog-posts,saas-pricing-pages \
+  --system collection-self-heal='node --import ./backend/node_modules/tsx/dist/esm/index.mjs benchmarks/dataset-agent/adapters/collection-self-healing-adapter.mjs'
+```
+
 ## Next Engineering Move
 
-Create a fresh branch from `codex/self-healing-verification` and first implement
-the collection runtime adapter contract, including the
-`recipe.runtimeInstructions` bridge and its unit test. Do not wire it as the
-default runtime until the self-healing-wrapped benchmark adapter produces better
-evidence than the current Mastra path.
+Create a fresh branch from `codex/collection-self-healing-benchmark` and port the
+real collection runner behind the existing adapter boundary:
+
+1. Add a runner module, likely `backend/src/pipeline/collection-agent-runner.ts`,
+   that exports `runCollectionPopulatePipeline(input)`.
+2. Port only the collection pipeline files needed by that runner from
+   `feat/data-collection-agent-v14`.
+3. Convert `CollectionPopulatePipelineInput` into the collection pipeline's
+   prompt/spec. Include both `input.prompt` and `input.recipeInstructions`.
+4. Convert the collection pipeline output into `PopulateRuntimeResult`: rows,
+   source URLs, evidence quotes, usage, metrics, and debug captured sources.
+5. Keep Convex writes, auth, cron scheduling, and durable recipe storage outside
+   the collection runner.
+6. Fix build blockers while porting: TinyFish status typing, OpenRouter provider
+   declaration leak, backend dependency on generated frontend Convex API, and
+   AI SDK `maxTokens`.
+7. Gate in this order: `npm --prefix backend test`, `npm --prefix backend run
+   build`, `make verify-self-healing`, 2-prompt `collection-self-heal`
+   benchmark, then full benchmark only if the 2-prompt run is not obviously
+   broken.
+
+Do not switch the default runtime from Mastra to collection until the
+self-healing-wrapped collection benchmark has better evidence than the current
+Mastra lane.

--- a/docs/data-collection-agent-migration-plan.md
+++ b/docs/data-collection-agent-migration-plan.md
@@ -238,6 +238,12 @@ POPULATE_COLLECTION_RUNNER_MODULE=./backend/src/pipeline/collection-agent-runner
 COLLECTION_AGENT_PIPELINE_MODULE=./backend/BigSet_Data_Collection_Agent/src/orchestrator/pipeline.ts
 ```
 
+The BigSet runner keeps TinyFish Agent/browser calls disabled unless
+`COLLECTION_AGENT_ENABLE_AGENT=true`. This makes cron and benchmark reruns cheap
+and repeatable first. Agent-enabled runs should also set
+`COLLECTION_AGENT_POLL_TIMEOUT_MS` or `AGENT_POLL_TIMEOUT_MS` so a browser run
+cannot outlive the benchmark/job budget.
+
 Do not switch the default runtime from Mastra to collection until the
 self-healing-wrapped collection benchmark has better evidence than the current
 Mastra lane.

--- a/docs/data-collection-agent-migration-plan.md
+++ b/docs/data-collection-agent-migration-plan.md
@@ -14,8 +14,8 @@ the collection pipeline is migrated into BigSet.
   run a collection pipeline through the same `PopulateRecipeRuntime` interface
   as Mastra.
 - PR #40 adds `POPULATE_AGENT_RUNTIME=collection` selection through the real
-  HTTP and CLI entrypoints, but intentionally requires an injected collection
-  runner instead of pretending the vendored runner has already been ported.
+  HTTP and CLI entrypoints. PR #42 extends that socket so app/CLI runs can load
+  a runner module from `POPULATE_COLLECTION_RUNNER_MODULE`.
 - PR #41 adds a `collection-self-heal` benchmark lane that wraps the collection
   runtime inside `SelfHealingPopulateRecipeService`. This is the benchmark
   socket Meteor can use once the real collection runner is available.
@@ -228,6 +228,13 @@ real collection runner behind the existing adapter boundary:
    build`, `make verify-self-healing`, 2-prompt `collection-self-heal`
    benchmark, then full benchmark only if the 2-prompt run is not obviously
    broken.
+
+When testing the real app or CLI path, set:
+
+```bash
+POPULATE_AGENT_RUNTIME=collection
+POPULATE_COLLECTION_RUNNER_MODULE=./backend/src/pipeline/collection-agent-runner.ts
+```
 
 Do not switch the default runtime from Mastra to collection until the
 self-healing-wrapped collection benchmark has better evidence than the current

--- a/docs/data-collection-agent-migration-plan.md
+++ b/docs/data-collection-agent-migration-plan.md
@@ -1,0 +1,164 @@
+# Data Collection Agent Migration Plan
+
+This plan keeps the app, benchmark harness, and self-healing layer aligned while
+the collection pipeline is migrated into BigSet.
+
+## Current State
+
+- PR #31-#37 form the current Mastra populate/self-healing stack. They are
+  intentionally stacked and should not be merged out of order.
+- PR #37 adds `make verify-self-healing`, which is the cheap local gate before
+  touching live data or spending OpenRouter/TinyFish credits.
+- `feat/data-collection-agent-v14` vendors the collection pipeline under
+  `backend/BigSet_Data_Collection_Agent` and includes the memory module.
+- Clean `feat/data-collection-agent-v14` tests pass once ignored backend
+  dependencies are present, but `npm --prefix backend run build` still fails on
+  TypeScript/API integration issues:
+  - TinyFish run status is typed too narrowly.
+  - OpenRouter provider return type leaks private declaration details.
+  - Backend compile depends on generated frontend Convex API output.
+  - AI SDK `maxTokens` option no longer matches the installed SDK type.
+
+## Target Shape
+
+The app should have one stable populate boundary:
+
+```text
+POST /populate or cron CLI
+  -> load DatasetContext
+  -> self-healing populate service
+  -> selected PopulateRecipeRuntime
+  -> source-backed rows + evidence
+  -> validation gate
+  -> optional Convex atomic row replace
+```
+
+The collection pipeline should become one implementation of
+`PopulateRecipeRuntime`. It should not own app auth, row deletion, Convex writes,
+or cron scheduling. Those stay in BigSet.
+
+The critical contract is `runRecipe({ recipe, context })`. A collection runtime
+adapter must thread `recipe.runtimeInstructions` into the collection prompt/spec,
+because those instructions are how a repaired recipe changes future runtime
+behavior. A runtime that ignores `recipe.runtimeInstructions` is not actually
+self-healing.
+
+## What Self-Healing Does Now
+
+The current layer:
+
+- stores active recipes and run records in a filesystem recipe store on the
+  durable app/commit path
+- reruns the active recipe when one exists
+- generates an initial recipe when no active recipe exists
+- repairs a failed active recipe through `DefaultPopulateRecipeAuthor`
+- validates rows for requested-column completeness, source URL coverage,
+  evidence quote coverage, and expected-entity coverage when the prompt names
+  explicit entities
+- promotes a repaired recipe only if it is valid and does not score below the
+  active recipe baseline
+- commits rows only after a successful tick, using one Convex atomic replace
+- supports a CLI path for cron/live smoke via `populate:self-heal --dataset-id`
+
+Dry-run and benchmark paths intentionally use in-memory stores so they do not
+pollute durable recipe history.
+
+The current layer does not yet:
+
+- run the collection pipeline as its runtime
+- generate Playwright scripts as a durable production recipe
+- run a green live Convex canary in this local environment
+- prove quality on a full real benchmark for the collection runtime
+
+## Migration Sequence
+
+1. Branch from the top of the self-healing stack.
+   - Base new work on `codex/self-healing-verification`.
+   - Do not edit `main` or `feat/data-collection-agent-v14` directly.
+
+2. Fix the collection branch as a clean build source.
+   - Port only the needed collection pipeline files into the fresh branch.
+   - Fix the TypeScript/API issues listed above.
+   - Keep vendored code isolated until the adapter is green.
+   - Preserve the current backend Convex boundary: do not reintroduce imports
+     from `frontend/convex/_generated` into backend compile. Use the existing
+     `anyApi`/HTTP-client boundary instead.
+   - Exclude non-essential vendored artifacts from the PR scope until the
+     runtime adapter needs them.
+   - Gate: `npm --prefix backend test` and `npm --prefix backend run build`.
+
+3. Add a collection runtime adapter.
+   - Implement the existing `PopulateRecipeRuntime` interface.
+   - Input: BigSet `DatasetContext`.
+   - Transform `recipe.runtimeInstructions` into the collection pipeline
+     prompt/spec alongside the dataset description and columns.
+   - Output: rows, source URLs, evidence quotes, usage, metrics, and debug
+     captured sources.
+   - No direct Convex writes inside the adapter.
+   - Gate: a unit test proving a repaired recipe's runtime instructions reach
+     the downstream collection prompt/spec and can change observable runtime
+     behavior.
+
+4. Add runtime selection through the real entrypoints.
+   - Add a runtime factory for the self-healing runner.
+   - Add an env switch such as `POPULATE_AGENT_RUNTIME=collection`.
+   - Wire both `POST /populate` and `populate:self-heal --dataset-id` through
+     that same factory.
+   - Gate: one HTTP-route test, one CLI test, and one dry-run smoke proving both
+     entrypoints use the selected runtime.
+
+5. Add a self-healing-wrapped benchmark adapter for the collection runtime.
+   - Reuse `benchmarks/dataset-agent/run-benchmark.mjs`.
+   - Exercise `SelfHealingPopulateRecipeService` with the collection runtime
+     inside it, not the direct collection pipeline alone.
+   - Compare this lane against the existing Mastra-inside-self-healing lane.
+   - Return blocked results when required API keys are missing.
+   - Gate: no-key smoke must block with zero tokens, zero tool calls, and zero
+     estimated spend.
+
+6. Run quality gates in increasing cost order.
+   - `make verify-self-healing`
+   - 2-prompt real benchmark
+   - full benchmark only after the 2-prompt run is not obviously broken
+   - live `--dataset-id` dry-run only after Convex/env prerequisites are ready
+   - `--commit` only on a throwaway dataset first
+
+7. Keep runtime selection explicit.
+   - Keep current Mastra runtime as default until collection runtime benchmark
+     evidence is better.
+   - Do not claim collection runtime quality from a direct, non-self-healing
+     benchmark lane.
+
+8. Decide merge order from evidence, not preference.
+   - If collection runtime is better, stack it after #37 and merge the stack
+     from bottom to top.
+   - If collection runtime is not better, keep it as a draft branch and use
+     benchmark artifacts to decide what to fix next.
+
+## Acceptance Gates
+
+Before any merge:
+
+- no real `.env` files or private notes in the diff
+- `git diff --name-status main...HEAD` reviewed for public PR hygiene
+- `make verify-self-healing` passes
+- `npm --prefix backend test` passes
+- `npm --prefix backend run build` passes
+- adapter test proves `recipe.runtimeInstructions` reaches the collection
+  pipeline prompt/spec
+- HTTP-route and CLI tests prove `POPULATE_AGENT_RUNTIME=collection` reaches
+  the selected runtime through real app entrypoints
+- benchmark no-key smoke proves blocked with zero spend
+- benchmark evidence comes from the collection runtime wrapped inside the
+  self-healing service, not the direct collection pipeline alone
+- real benchmark artifacts are linked in the PR when runtime quality is claimed
+- live dataset commit is tested only on a throwaway dataset
+- backend build does not depend on `frontend/convex/_generated`
+
+## Next Engineering Move
+
+Create a fresh branch from `codex/self-healing-verification` and first implement
+the collection runtime adapter contract, including the
+`recipe.runtimeInstructions` bridge and its unit test. Do not wire it as the
+default runtime until the self-healing-wrapped benchmark adapter produces better
+evidence than the current Mastra path.

--- a/docs/data-collection-agent-migration-plan.md
+++ b/docs/data-collection-agent-migration-plan.md
@@ -88,7 +88,9 @@ The current layer does not yet:
 ## Migration Sequence
 
 1. Branch from the top of the self-healing stack.
-   - Base new work on `codex/self-healing-verification`.
+   - For any new collection-runner work, base on
+     `codex/collection-self-healing-benchmark` so PR #39, #40, and #41 stay in
+     the path.
    - Do not edit `main` or `feat/data-collection-agent-v14` directly.
 
 2. Fix the collection branch as a clean build source.
@@ -108,6 +110,9 @@ The current layer does not yet:
    - Input: BigSet `DatasetContext`.
    - Transform `recipe.runtimeInstructions` into the collection pipeline
      prompt/spec alongside the dataset description and columns.
+   - Propagate `requiredColumns`, prompt id, prompt quality, persona, and
+     benchmark stress metadata into the collection pipeline's benchmark/spec
+     generation path when those fields are available.
    - Output: rows, source URLs, evidence quotes, usage, metrics, and debug
      captured sources.
    - No direct Convex writes inside the adapter.
@@ -164,6 +169,8 @@ Before any merge:
 - `npm --prefix backend run build` passes
 - adapter test proves `recipe.runtimeInstructions` reaches the collection
   pipeline prompt/spec
+- adapter or runner tests prove benchmark metadata and `requiredColumns` reach
+  the collection pipeline's spec generation path
 - HTTP-route and CLI tests prove `POPULATE_AGENT_RUNTIME=collection` reaches
   the selected runtime through real app entrypoints
 - benchmark no-key smoke proves blocked with zero spend
@@ -183,8 +190,10 @@ runCollectionPopulatePipeline(CollectionPopulatePipelineInput)
 ```
 
 `CollectionPopulatePipelineInput.recipeInstructions` is the self-healing signal.
-If the collection runner ignores that field, repaired recipes cannot change
-future behavior.
+`requiredColumns` and benchmark metadata are the scoring signal. If the
+collection runner ignores `recipeInstructions`, repaired recipes cannot change
+future behavior. If it ignores `requiredColumns` or benchmark metadata, the
+benchmark can stop measuring the same task.
 
 The real benchmark command after a runner module exists is:
 
@@ -205,7 +214,9 @@ real collection runner behind the existing adapter boundary:
 2. Port only the collection pipeline files needed by that runner from
    `feat/data-collection-agent-v14`.
 3. Convert `CollectionPopulatePipelineInput` into the collection pipeline's
-   prompt/spec. Include both `input.prompt` and `input.recipeInstructions`.
+   prompt/spec. Include `input.prompt`, `input.recipeInstructions`,
+   `input.requiredColumns`, prompt id/quality, persona, and expected-stress
+   benchmark context when available.
 4. Convert the collection pipeline output into `PopulateRuntimeResult`: rows,
    source URLs, evidence quotes, usage, metrics, and debug captured sources.
 5. Keep Convex writes, auth, cron scheduling, and durable recipe storage outside

--- a/docs/data-collection-agent-migration-plan.md
+++ b/docs/data-collection-agent-migration-plan.md
@@ -198,6 +198,7 @@ benchmark can stop measuring the same task.
 The real benchmark command after a runner module exists is:
 
 ```bash
+COLLECTION_AGENT_PIPELINE_MODULE=./backend/BigSet_Data_Collection_Agent/src/orchestrator/pipeline.ts \
 BIGSET_COLLECTION_BENCHMARK_RUNNER_MODULE=./backend/src/pipeline/collection-agent-runner.ts \
 node benchmarks/dataset-agent/run-benchmark.mjs \
   --prompt-ids latest-ai-blog-posts,saas-pricing-pages \
@@ -234,6 +235,7 @@ When testing the real app or CLI path, set:
 ```bash
 POPULATE_AGENT_RUNTIME=collection
 POPULATE_COLLECTION_RUNNER_MODULE=./backend/src/pipeline/collection-agent-runner.ts
+COLLECTION_AGENT_PIPELINE_MODULE=./backend/BigSet_Data_Collection_Agent/src/orchestrator/pipeline.ts
 ```
 
 Do not switch the default runtime from Mastra to collection until the

--- a/docs/data-collection-agent-migration-plan.md
+++ b/docs/data-collection-agent-migration-plan.md
@@ -19,15 +19,19 @@ the collection pipeline is migrated into BigSet.
 - PR #41 adds a `collection-self-heal` benchmark lane that wraps the collection
   runtime inside `SelfHealingPopulateRecipeService`. This is the benchmark
   socket Meteor can use once the real collection runner is available.
-- `feat/data-collection-agent-v14` vendors the collection pipeline under
-  `backend/BigSet_Data_Collection_Agent` and includes the memory module.
-- Clean `feat/data-collection-agent-v14` tests pass once ignored backend
-  dependencies are present, but `npm --prefix backend run build` still fails on
-  TypeScript/API integration issues:
-  - TinyFish run status is typed too narrowly.
-  - OpenRouter provider return type leaks private declaration details.
-  - Backend compile depends on generated frontend Convex API output.
-  - AI SDK `maxTokens` option no longer matches the installed SDK type.
+- PR #43 ports the real vendored collection pipeline behind
+  `runCollectionPopulatePipeline(input)`, so the collection benchmark lane now
+  runs the BigSet-wrapped collection runner instead of a fake injected runner.
+- PR #44 keeps TinyFish Agent/browser work opt-in and bounded by a per-run poll
+  timeout. This preserves cheap cron/benchmark reruns as the default path.
+- PR #45 improves collection source targeting for official-source prompts
+  without injecting answer-key URLs at runtime.
+- PR #46 surfaces no-Agent browser/form/detail follow-up as a safe capability
+  diagnostic instead of hiding it as generic bad data or infra failure.
+- `feat/data-collection-agent-v14` is no longer the branch to build on directly.
+  It was the source of the collection pipeline port. New work should branch on
+  top of the current draft stack, not edit Meteor's branch or the dirty main
+  checkout.
 
 ## Target Shape
 
@@ -77,25 +81,30 @@ The current layer now can:
 
 - run an injected collection runner through the same self-healing runtime
   boundary and benchmark harness as Mastra
+- run the real vendored collection pipeline through that same boundary
+- preserve `recipe.runtimeInstructions`, required columns, and benchmark
+  metadata through the collection runner
+- emit a capability diagnostic when no-Agent mode sees pages that need browser,
+  form, or detail-page follow-up
 
 The current layer does not yet:
 
-- run the real vendored collection pipeline as its runtime in this stack
 - generate Playwright scripts as a durable production recipe
 - run a green live Convex canary in this local environment
-- prove quality on a full real benchmark for the collection runtime
+- prove Agent-enabled collection quality on a full real benchmark
+- prove the collection runtime should replace Mastra as the default app runtime
 
 ## Migration Sequence
 
 1. Branch from the top of the self-healing stack.
-   - For any new collection-runner work, base on
-     `codex/collection-self-healing-benchmark` so PR #39, #40, and #41 stay in
-     the path.
-   - Do not edit `main` or `feat/data-collection-agent-v14` directly.
+   - For new collection-runner or benchmark work, base on
+     `codex/collection-capability-diagnostics` unless that PR has been
+     superseded.
+   - Do not edit `main`, the dirty local checkout, or
+     `feat/data-collection-agent-v14` directly.
 
 2. Fix the collection branch as a clean build source.
-   - Port only the needed collection pipeline files into the fresh branch.
-   - Fix the TypeScript/API issues listed above.
+   - Status: done in PR #43 for the BigSet-wrapped collection runner path.
    - Keep vendored code isolated until the adapter is green.
    - Preserve the current backend Convex boundary: do not reintroduce imports
      from `frontend/convex/_generated` into backend compile. Use the existing
@@ -142,6 +151,8 @@ The current layer does not yet:
 6. Run quality gates in increasing cost order.
    - `make verify-self-healing`
    - 2-prompt real benchmark
+   - 1-prompt Agent-enabled capability canary for prompts that need browser or
+     detail follow-up
    - full benchmark only after the 2-prompt run is not obviously broken
    - live `--dataset-id` dry-run only after Convex/env prerequisites are ready
    - `--commit` only on a throwaway dataset first
@@ -177,6 +188,9 @@ Before any merge:
 - benchmark evidence comes from the collection runtime wrapped inside the
   self-healing service, not the direct collection pipeline alone
 - real benchmark artifacts are linked in the PR when runtime quality is claimed
+- capability diagnostics are treated as warnings for healthy rows and as honest
+  benchmark failure messages when no-Agent mode cannot complete browser/form
+  follow-up
 - live dataset commit is tested only on a throwaway dataset
 - backend build does not depend on `frontend/convex/_generated`
 
@@ -205,29 +219,59 @@ node benchmarks/dataset-agent/run-benchmark.mjs \
   --system collection-self-heal='node --import ./backend/node_modules/tsx/dist/esm/index.mjs benchmarks/dataset-agent/adapters/collection-self-healing-adapter.mjs'
 ```
 
+For prompts that likely require browser/detail follow-up, run the same lane with
+Agent explicitly enabled:
+
+```bash
+COLLECTION_AGENT_ENABLE_AGENT=true \
+COLLECTION_AGENT_POLL_TIMEOUT_MS=480000 \
+COLLECTION_AGENT_PIPELINE_MODULE=./backend/BigSet_Data_Collection_Agent/src/orchestrator/pipeline.ts \
+BIGSET_COLLECTION_BENCHMARK_RUNNER_MODULE=./backend/src/pipeline/collection-agent-runner.ts \
+node benchmarks/dataset-agent/run-benchmark.mjs \
+  --prompt-ids mcp-docs-pages \
+  --timeout-ms 900000 \
+  --system collection-self-heal='node --import ./backend/node_modules/tsx/dist/esm/index.mjs benchmarks/dataset-agent/adapters/collection-self-healing-adapter.mjs'
+```
+
+No-Agent `mcp-docs-pages` evidence from PR #46:
+
+- artifact: `benchmark-results/collection-capability-diagnostics-mcp-20260523-001`
+- result: 3 rows, 6 evidence quotes, cost about `$0.007287`
+- status: failed with
+`Capability diagnostic: TinyFish Agent disabled; triage requested browser/form/detail follow-up...`.
+That is not a pass, but it is useful: it tells us the next benchmark should
+turn Agent on and measure whether browser/detail follow-up fixes the source
+evidence miss.
+
+Agent-enabled `mcp-docs-pages` evidence from the stack-handoff branch:
+
+- artifact: `benchmark-results/collection-agent-canary-mcp-20260523-001`
+- result: 3 rows, 12 evidence quotes, 10 source URLs, 3 Agent runs
+- cost: about `$0.053552`
+- status: failed, not blocked
+- score: factual accuracy `0.933`, entity coverage `1.0`, claim support `1.0`,
+  domain accuracy `0.667`
+- conclusion: Agent/browser follow-up runs successfully and improves claim
+  support, but source/domain evidence still misses. The next code target is
+  source coherence: keep each row's docs URL/evidence/source URLs aligned with
+  that entity's official docs domain instead of merging discovery/blog/course
+  evidence across vendors.
+
 ## Next Engineering Move
 
-Create a fresh branch from `codex/collection-self-healing-benchmark` and port the
-real collection runner behind the existing adapter boundary:
+Create a fresh branch from `codex/collection-capability-diagnostics` and fix
+source coherence before running the full benchmark:
 
-1. Add a runner module, likely `backend/src/pipeline/collection-agent-runner.ts`,
-   that exports `runCollectionPopulatePipeline(input)`.
-2. Port only the collection pipeline files needed by that runner from
-   `feat/data-collection-agent-v14`.
-3. Convert `CollectionPopulatePipelineInput` into the collection pipeline's
-   prompt/spec. Include `input.prompt`, `input.recipeInstructions`,
-   `input.requiredColumns`, prompt id/quality, persona, and expected-stress
-   benchmark context when available.
-4. Convert the collection pipeline output into `PopulateRuntimeResult`: rows,
-   source URLs, evidence quotes, usage, metrics, and debug captured sources.
-5. Keep Convex writes, auth, cron scheduling, and durable recipe storage outside
-   the collection runner.
-6. Fix build blockers while porting: TinyFish status typing, OpenRouter provider
-   declaration leak, backend dependency on generated frontend Convex API, and
-   AI SDK `maxTokens`.
-7. Gate in this order: `npm --prefix backend test`, `npm --prefix backend run
-   build`, `make verify-self-healing`, 2-prompt `collection-self-heal`
-   benchmark, then full benchmark only if the 2-prompt run is not obviously
+1. Keep `COLLECTION_AGENT_ENABLE_AGENT=false` as the default.
+2. Add focused tests around record merge/source selection so a row does not gain
+   evidence for a populated field from another record unless the incoming row
+   value supports the existing value.
+3. Tighten docs/official-source selection so docs prompts prefer docs/developers
+   pages over blogs, news, courses, directories, or third-party discovery pages.
+4. Re-run the Agent-enabled `mcp-docs-pages` canary.
+5. If domain accuracy reaches `1.0`, run the 4-prompt focused benchmark from
+   PR #45.
+6. Run the full prompt pack only after the focused benchmark is not obviously
    broken.
 
 When testing the real app or CLI path, set:

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -34,6 +34,9 @@ yarn-error.log*
 .env*
 !.env.example
 
+# Cursor / Convex agent skills cache (skills-lock.json may be committed for reproducibility).
+.agents/
+
 # package manager: this project uses bun (bun.lock is the source of truth).
 # Reject npm/yarn lockfiles so they don't drift from bun's resolution.
 package-lock.json

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -11,3 +11,17 @@ Do not add API routes here. All backend logic lives in `backend/`.
 Auth uses Clerk (`@clerk/nextjs`) with Convex integration (`ConvexProviderWithClerk`). Do not use Better Auth, Next.js server actions, or custom auth middleware. Clerk proxy in `proxy.ts` handles route protection.
 
 After editing any file in `frontend/convex/`, you MUST run `make convex-push` from the project root. Convex is self-hosted and does not hot-reload — without the push, the running instance still has the old code.
+
+<!-- convex-ai-start -->
+
+This project uses [Convex](https://convex.dev) as its backend.
+
+When working on Convex code, **always read
+`convex/_generated/ai/guidelines.md` first** for important guidelines on
+how to correctly use Convex APIs and patterns. The file contains rules that
+override what you may have learned about Convex from training data.
+
+Convex agent skills for common tasks can be installed by running
+`npx convex ai-files install`.
+
+<!-- convex-ai-end -->

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -10,10 +10,24 @@ Use `useConvexAuth()` from `convex/react` (not Clerk's `useAuth()`) to check aut
 
 `lib/backend.ts` — typed fetch wrapper for calling the Fastify backend. Uses `useAuth().getToken()` from `@clerk/nextjs` to get a Bearer token. The backend URL comes from `NEXT_PUBLIC_BACKEND_URL` (defaults to `http://localhost:3501`).
 
-Currently exposes `inferSchema(prompt, token)` which calls `POST /infer-schema` and returns an `InferredSchema`. The frontend maps backend types to UI types (e.g. `string` → `text`, `display_name` → column name, `retrieval_hint` → description) in the dataset wizard (`app/dataset/new/page.tsx`).
+Currently exposes `inferSchema(prompt, token)` which calls `POST /infer-schema` and returns an `InferredSchema`. The frontend maps backend types to UI types (e.g. `string` → `text`, `display_name` → column name) in the dataset wizard (`app/dataset/new/page.tsx`).
 
 ## Convex
 
 Convex functions in `convex/` do NOT hot-reload. After editing any file in `frontend/convex/`, run `make convex-push` from the project root to deploy changes to the self-hosted instance.
 
 @AGENTS.md
+
+<!-- convex-ai-start -->
+
+This project uses [Convex](https://convex.dev) as its backend.
+
+When working on Convex code, **always read
+`convex/_generated/ai/guidelines.md` first** for important guidelines on
+how to correctly use Convex APIs and patterns. The file contains rules that
+override what you may have learned about Convex from training data.
+
+Convex agent skills for common tasks can be installed by running
+`npx convex ai-files install`.
+
+<!-- convex-ai-end -->

--- a/frontend/app/dataset/[id]/page.tsx
+++ b/frontend/app/dataset/[id]/page.tsx
@@ -11,17 +11,19 @@ import { DatasetTable } from "@/components/table";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { StatusBadge } from "@/components/dataset/StatusBadge";
 import { downloadCSV, downloadXLSX } from "@/lib/export";
+import { populate } from "@/lib/backend";
 import { EVENTS, captureException, track } from "@/lib/analytics";
 
 export default function DatasetPage() {
   const params = useParams();
   const { isLoading } = useConvexAuth();
-  const { userId } = useAuth();
+  const { userId, getToken } = useAuth();
   const [exporting, setExporting] = useState<"csv" | "xlsx" | null>(null);
+  const [populating, setPopulating] = useState(false);
 
   const datasetId = params.id as Id<"datasets">;
-  const dataset = useQuery(api.datasets.get, { id: datasetId });
-  const rows = useQuery(api.datasetRows.listByDataset, {
+  const dataset = useQuery(api.datasets.get, isLoading ? "skip" : { id: datasetId });
+  const rows = useQuery(api.datasetRows.listByDataset, isLoading ? "skip" : {
     datasetId,
   });
 
@@ -64,6 +66,35 @@ export default function DatasetPage() {
       });
     } finally {
       setExporting(null);
+    }
+  }
+
+  async function handlePopulate() {
+    if (!dataset || populating) return;
+    setPopulating(true);
+    try {
+      const token = await getToken();
+      if (!token) throw new Error("Not authenticated");
+
+      await populate(
+        dataset._id,
+        dataset.name,
+        dataset.description,
+        dataset.columns,
+        token,
+      );
+      track(EVENTS.DATASET_POPULATED, {
+        datasetId: dataset._id,
+        column_count: dataset.columns.length,
+      });
+    } catch (err) {
+      console.error("[populate] failed", err);
+      captureException(err, {
+        operation: "dataset_populate",
+        datasetId: dataset._id,
+      });
+    } finally {
+      setPopulating(false);
     }
   }
 
@@ -110,6 +141,13 @@ export default function DatasetPage() {
             className="border border-border px-3 py-1.5 text-xs font-medium text-foreground hover:bg-foreground/[0.03] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
           >
             {exporting === "xlsx" ? "Exporting…" : "Export XLSX"}
+          </button>
+          <button
+            onClick={handlePopulate}
+            disabled={populating}
+            className="border border-border px-3 py-1.5 text-xs font-medium text-foreground hover:bg-foreground/[0.03] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {populating ? "Populating…" : "Clear & Populate"}
           </button>
           <div className="w-px h-4 bg-border mx-1" />
           <ThemeToggle />

--- a/frontend/app/dataset/new/page.tsx
+++ b/frontend/app/dataset/new/page.tsx
@@ -60,7 +60,7 @@ function mapBackendColumn(col: InferredColumn, index: number): ProposedColumn {
     id: String(index + 1),
     name: col.display_name,
     type: BACKEND_TYPE_MAP[col.type],
-    description: col.retrieval_hint,
+    description: col.description,
   };
 }
 

--- a/frontend/convex/datasetRows.ts
+++ b/frontend/convex/datasetRows.ts
@@ -1,4 +1,4 @@
-import { query, internalMutation } from "./_generated/server.js";
+import { query, internalMutation, internalQuery } from "./_generated/server.js";
 import { v } from "convex/values";
 import { loadReadableDataset } from "./lib/authz.js";
 
@@ -69,6 +69,34 @@ export const update = internalMutation({
     }
 
     await ctx.db.patch(args.id, { data: newData });
+  },
+});
+
+export const clearByDataset = internalMutation({
+  args: { datasetId: v.id("datasets") },
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("datasetRows")
+      .withIndex("by_dataset", (q) => q.eq("datasetId", args.datasetId))
+      .collect();
+    for (const row of rows) {
+      await ctx.db.delete(row._id);
+    }
+    return rows.length;
+  },
+});
+
+export const get = internalQuery({
+  args: { id: v.id("datasetRows") },
+  handler: async (ctx, args) => {
+    return await ctx.db.get(args.id);
+  },
+});
+
+export const remove = internalMutation({
+  args: { id: v.id("datasetRows") },
+  handler: async (ctx, args) => {
+    await ctx.db.delete(args.id);
   },
 });
 

--- a/frontend/convex/datasetRows.ts
+++ b/frontend/convex/datasetRows.ts
@@ -124,6 +124,11 @@ export const replaceByDataset = internalMutation({
     })),
   },
   handler: async (ctx, args) => {
+    const dataset = await ctx.db.get(args.datasetId);
+    if (!dataset) {
+      throw new Error("Dataset not found");
+    }
+
     const existingRows = await ctx.db
       .query("datasetRows")
       .withIndex("by_dataset", (q) => q.eq("datasetId", args.datasetId))

--- a/frontend/convex/datasetRows.ts
+++ b/frontend/convex/datasetRows.ts
@@ -114,3 +114,35 @@ export const insertBatch = internalMutation({
     }
   },
 });
+
+export const replaceByDataset = internalMutation({
+  args: {
+    datasetId: v.id("datasets"),
+    rows: v.array(v.object({
+      data: v.record(v.string(), v.any()),
+      sources: v.optional(v.array(v.string())),
+    })),
+  },
+  handler: async (ctx, args) => {
+    const existingRows = await ctx.db
+      .query("datasetRows")
+      .withIndex("by_dataset", (q) => q.eq("datasetId", args.datasetId))
+      .collect();
+
+    for (const row of existingRows) {
+      await ctx.db.delete(row._id);
+    }
+    for (const row of args.rows) {
+      await ctx.db.insert("datasetRows", {
+        datasetId: args.datasetId,
+        data: row.data,
+        sources: row.sources,
+      });
+    }
+
+    return {
+      clearedRowCount: existingRows.length,
+      insertedRowCount: args.rows.length,
+    };
+  },
+});

--- a/frontend/convex/datasets.ts
+++ b/frontend/convex/datasets.ts
@@ -1,4 +1,4 @@
-import { query, mutation } from "./_generated/server.js";
+import { query, mutation, internalQuery } from "./_generated/server.js";
 import type { QueryCtx } from "./_generated/server.js";
 import { v } from "convex/values";
 import type { Doc } from "./_generated/dataModel.js";
@@ -79,6 +79,13 @@ export const get = query({
   args: { id: v.id("datasets") },
   handler: async (ctx, args) => {
     return await loadReadableDataset(ctx, args.id);
+  },
+});
+
+export const getForSystemPopulate = internalQuery({
+  args: { id: v.id("datasets") },
+  handler: async (ctx, args) => {
+    return await ctx.db.get(args.id);
   },
 });
 

--- a/frontend/lib/analytics.ts
+++ b/frontend/lib/analytics.ts
@@ -32,6 +32,7 @@ export const EVENTS = {
   // Dataset interaction
   DATASET_OPENED: "dataset_opened",
   DATASET_EXPORTED: "dataset_exported",
+  DATASET_POPULATED: "dataset_populated",
 
   // Creation flow
   DATASET_CREATION_STARTED: "dataset_creation_started",

--- a/frontend/lib/backend.ts
+++ b/frontend/lib/backend.ts
@@ -25,7 +25,7 @@ export interface PopulateColumn {
 
 export interface PopulateResult {
   success: boolean;
-  rows: Record<string, unknown>[];
+  result: unknown;
 }
 
 const BACKEND_URL =

--- a/frontend/lib/backend.ts
+++ b/frontend/lib/backend.ts
@@ -3,8 +3,7 @@ export interface InferredSchema {
   description: string;
   columns: InferredColumn[];
   primary_key: string;
-  retrieval_strategy: "search_fetch" | "browser" | "hybrid";
-  source_hint: string;
+  search_queries?: string[];
 }
 
 export interface InferredColumn {
@@ -13,7 +12,7 @@ export interface InferredColumn {
   type: "string" | "url" | "date" | "number" | "boolean" | "enum";
   is_primary_key: boolean;
   is_enumerable: boolean;
-  retrieval_hint: string;
+  description: string;
   nullable: boolean;
 }
 

--- a/frontend/lib/backend.ts
+++ b/frontend/lib/backend.ts
@@ -17,6 +17,17 @@ export interface InferredColumn {
   nullable: boolean;
 }
 
+export interface PopulateColumn {
+  name: string;
+  type: "text" | "number" | "boolean" | "url" | "date";
+  description?: string;
+}
+
+export interface PopulateResult {
+  success: boolean;
+  rows: Record<string, unknown>[];
+}
+
 const BACKEND_URL =
   process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:3501";
 
@@ -31,6 +42,31 @@ export async function inferSchema(
       Authorization: `Bearer ${token}`,
     },
     body: JSON.stringify({ prompt }),
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    const message = body?.error || `Backend error (${res.status})`;
+    throw new Error(message);
+  }
+
+  return res.json();
+}
+
+export async function populate(
+  datasetId: string,
+  datasetName: string,
+  description: string,
+  columns: PopulateColumn[],
+  token: string,
+): Promise<PopulateResult> {
+  const res = await fetch(`${BACKEND_URL}/populate`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ datasetId, datasetName: datasetName, description, columns }),
   });
 
   if (!res.ok) {

--- a/frontend/skills-lock.json
+++ b/frontend/skills-lock.json
@@ -1,0 +1,41 @@
+{
+  "version": 1,
+  "skills": {
+    "convex": {
+      "source": "get-convex/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/convex/SKILL.md",
+      "computedHash": "c5f3622c64ef550aac27d1dbc041f0c7c40d9119863c9fb8bac180b0498ee8ed"
+    },
+    "convex-create-component": {
+      "source": "get-convex/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/convex-create-component/SKILL.md",
+      "computedHash": "25b6f56cc6afa4237aa191f5bfa5b86f68b70dc7f1195b86d027bd85346cff41"
+    },
+    "convex-migration-helper": {
+      "source": "get-convex/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/convex-migration-helper/SKILL.md",
+      "computedHash": "8da4dee6f36c71b5d899b90ad7bd1d3730cf4dd35118f9ea856075df29809c04"
+    },
+    "convex-performance-audit": {
+      "source": "get-convex/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/convex-performance-audit/SKILL.md",
+      "computedHash": "d4f372ad6bed01b3a83983f5e8386017606e1bf8a97833c016af07f277157f96"
+    },
+    "convex-quickstart": {
+      "source": "get-convex/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/convex-quickstart/SKILL.md",
+      "computedHash": "54e5271d5d613cc4c0068baa250613b5abb6e4533df1e67adc26d2e0c7d68ded"
+    },
+    "convex-setup-auth": {
+      "source": "get-convex/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/convex-setup-auth/SKILL.md",
+      "computedHash": "b1a940758751c5b2fdc6ced105b19927a1655f0c1d4bd2fd5536dc3264202c00"
+    }
+  }
+}

--- a/makefiles/Makefile
+++ b/makefiles/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all dev down clean convex-push convex-env
+.PHONY: all dev down clean convex-push convex-env verify-self-healing
 
 all: dev
 
@@ -32,6 +32,9 @@ convex-push:
 	@cd frontend && npx convex deploy \
 		--url http://127.0.0.1:3210 \
 		--admin-key "$$(grep CONVEX_SELF_HOSTED_ADMIN_KEY .env.local | cut -d= -f2-)"
+
+verify-self-healing:
+	bash scripts/verify-self-healing-stack.sh
 
 down:
 	docker compose -f docker-compose.dev.yml down

--- a/scripts/verify-self-healing-stack.sh
+++ b/scripts/verify-self-healing-stack.sh
@@ -97,7 +97,7 @@ run_blocked_benchmark_smoke() {
 
   mkdir -p "$out_dir"
   printf 'RUN   %s benchmark no-key blocked smoke\n' "$system_name"
-  if ! env -u OPENROUTER_API_KEY -u TINYFISH_API_KEY node benchmarks/dataset-agent/run-benchmark.mjs \
+  if ! env -u OPENROUTER_API_KEY -u TINYFISH_API_KEY BIGSET_BENCHMARK_SKIP_ENV_FILES=1 node benchmarks/dataset-agent/run-benchmark.mjs \
     --prompt-ids latest-ai-blog-posts \
     --timeout-ms 60000 \
     --out "$out_dir" \

--- a/scripts/verify-self-healing-stack.sh
+++ b/scripts/verify-self-healing-stack.sh
@@ -90,18 +90,20 @@ check_convex_ready() {
 }
 
 run_blocked_benchmark_smoke() {
-  local out_dir="benchmark-results/self-healing-blocked-smoke-$(date +%Y%m%d-%H%M%S)"
+  local system_name="$1"
+  local system_command="$2"
+  local out_dir="benchmark-results/${system_name}-blocked-smoke-$(date +%Y%m%d-%H%M%S)"
   local stdout_file="${out_dir}/runner-stdout.json"
 
   mkdir -p "$out_dir"
-  printf 'RUN   mastra benchmark no-key blocked smoke\n'
+  printf 'RUN   %s benchmark no-key blocked smoke\n' "$system_name"
   if ! env -u OPENROUTER_API_KEY -u TINYFISH_API_KEY node benchmarks/dataset-agent/run-benchmark.mjs \
     --prompt-ids latest-ai-blog-posts \
     --timeout-ms 60000 \
     --out "$out_dir" \
-    --system "mastra=node --import ./backend/node_modules/tsx/dist/esm/index.mjs benchmarks/dataset-agent/adapters/mastra-populate-adapter.mjs" \
+    --system "${system_name}=${system_command}" \
     > "$stdout_file"; then
-    mark_fail "mastra benchmark no-key blocked smoke"
+    mark_fail "${system_name} benchmark no-key blocked smoke"
     return
   fi
 
@@ -154,9 +156,9 @@ for (const result of summary.laneResults ?? []) {
   }
 }
 ' "${out_dir}/summary.json"; then
-    mark_pass "mastra benchmark no-key blocked smoke (${out_dir})"
+    mark_pass "${system_name} benchmark no-key blocked smoke (${out_dir})"
   else
-    mark_fail "mastra benchmark no-key blocked smoke"
+    mark_fail "${system_name} benchmark no-key blocked smoke"
   fi
 }
 
@@ -253,10 +255,16 @@ if [[ "$SHOULD_RUN_LOCAL_GATES" -eq 1 ]]; then
   run_required_step "backend tests" npm --prefix backend test
   run_required_step "backend build" npm --prefix backend run build
   run_required_step "mastra adapter syntax" node --check benchmarks/dataset-agent/adapters/mastra-populate-adapter.mjs
+  run_required_step "collection adapter syntax" node --check benchmarks/dataset-agent/adapters/collection-self-healing-adapter.mjs
 fi
 
 if [[ "$SHOULD_RUN_BLOCKED_BENCHMARK_SMOKE" -eq 1 ]]; then
-  run_blocked_benchmark_smoke
+  run_blocked_benchmark_smoke \
+    "mastra" \
+    "node --import ./backend/node_modules/tsx/dist/esm/index.mjs benchmarks/dataset-agent/adapters/mastra-populate-adapter.mjs"
+  run_blocked_benchmark_smoke \
+    "collection-self-heal" \
+    "node --import ./backend/node_modules/tsx/dist/esm/index.mjs benchmarks/dataset-agent/adapters/collection-self-healing-adapter.mjs"
 fi
 
 if [[ "$SHOULD_RUN_CONVEX_PUSH" -eq 1 ]]; then

--- a/scripts/verify-self-healing-stack.sh
+++ b/scripts/verify-self-healing-stack.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR" || exit 1
+
+DATASET_ID=""
+SHOULD_COMMIT_ROWS=0
+SHOULD_RUN_CONVEX_PUSH=0
+SHOULD_RUN_LOCAL_GATES=1
+SHOULD_RUN_BLOCKED_BENCHMARK_SMOKE=1
+SHOULD_RUN_REAL_BENCHMARK=0
+EXIT_STATUS=0
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash scripts/verify-self-healing-stack.sh [options]
+
+Options:
+  --dataset-id <id>     Run a live self-healing populate smoke for one dataset.
+  --commit              Commit rows for --dataset-id instead of dry-run.
+  --convex-push         Deploy Convex functions before the live dataset smoke.
+  --real-benchmark      Run a 2-prompt real Mastra benchmark. May spend API credits.
+  --skip-local          Skip backend test/build/node-check gates.
+  --no-blocked-smoke    Skip the no-key benchmark blocked-contract smoke.
+  -h, --help            Show this help.
+
+Default behavior runs only local checks and a no-key benchmark smoke. It does
+not load secret files and does not spend OpenRouter or TinyFish credits. Live
+dataset and benchmark modes require needed env vars to be exported already.
+USAGE
+}
+
+mark_pass() {
+  printf 'PASS  %s\n' "$1"
+}
+
+mark_fail() {
+  printf 'FAIL  %s\n' "$1"
+  EXIT_STATUS=1
+}
+
+mark_blocked() {
+  printf 'BLOCK %s\n' "$1"
+  if [[ "$EXIT_STATUS" -eq 0 ]]; then
+    EXIT_STATUS=2
+  fi
+}
+
+run_required_step() {
+  local label="$1"
+  shift
+
+  printf 'RUN   %s\n' "$label"
+  if "$@"; then
+    mark_pass "$label"
+  else
+    mark_fail "$label"
+  fi
+}
+
+require_command() {
+  local command_name="$1"
+  if command -v "$command_name" >/dev/null 2>&1; then
+    return 0
+  fi
+  mark_blocked "missing command: ${command_name}"
+  return 1
+}
+
+require_env_var() {
+  local env_name="$1"
+  if [[ -n "${!env_name:-}" ]]; then
+    return 0
+  fi
+  mark_blocked "missing env: ${env_name}"
+  return 1
+}
+
+check_docker_compose_ready() {
+  require_command docker || return 1
+  docker compose -f docker-compose.dev.yml ps >/dev/null 2>&1
+}
+
+check_convex_ready() {
+  local convex_url="$1"
+  require_command curl || return 1
+  curl -sf "${convex_url%/}/version" >/dev/null 2>&1
+}
+
+run_blocked_benchmark_smoke() {
+  local out_dir="benchmark-results/self-healing-blocked-smoke-$(date +%Y%m%d-%H%M%S)"
+  local stdout_file="${out_dir}/runner-stdout.json"
+
+  mkdir -p "$out_dir"
+  printf 'RUN   mastra benchmark no-key blocked smoke\n'
+  if ! env -u OPENROUTER_API_KEY -u TINYFISH_API_KEY node benchmarks/dataset-agent/run-benchmark.mjs \
+    --prompt-ids latest-ai-blog-posts \
+    --timeout-ms 60000 \
+    --out "$out_dir" \
+    --system "mastra=node --import ./backend/node_modules/tsx/dist/esm/index.mjs benchmarks/dataset-agent/adapters/mastra-populate-adapter.mjs" \
+    > "$stdout_file"; then
+    mark_fail "mastra benchmark no-key blocked smoke"
+    return
+  fi
+
+  if node -e '
+const fs = require("fs");
+const summary = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+const group = summary.aggregate?.[0];
+if (!group || group.total !== 1 || group.blocked !== 1 || group.failed !== 0) {
+  console.error("expected exactly one blocked benchmark result");
+  process.exit(1);
+}
+const aggregateSpendFields = [
+  "totalRows",
+  "totalPromptTokens",
+  "totalCompletionTokens",
+  "totalTokens",
+  "searchCallCount",
+  "fetchCallCount",
+  "browserCallCount",
+  "agentRunCount",
+  "agentStepCount",
+  "estimatedTotalCostUsd",
+];
+const nonZeroAggregateFields = aggregateSpendFields.filter(
+  (field) => Number(group[field] ?? 0) !== 0
+);
+if (nonZeroAggregateFields.length > 0) {
+  console.error(`expected zero spend/calls for blocked smoke: ${nonZeroAggregateFields.join(", ")}`);
+  process.exit(1);
+}
+for (const result of summary.laneResults ?? []) {
+  const laneSpendFields = [
+    ["rowCount", result.rowCount],
+    ["promptTokens", result.usage?.promptTokens],
+    ["completionTokens", result.usage?.completionTokens],
+    ["totalTokens", result.usage?.totalTokens],
+    ["searchCallCount", result.searchCallCount],
+    ["fetchCallCount", result.fetchCallCount],
+    ["browserCallCount", result.browserCallCount],
+    ["agentRunCount", result.agentRunCount],
+    ["agentStepCount", result.agentStepCount],
+    ["estimatedTotalCostUsd", result.estimatedTotalCostUsd],
+  ];
+  const nonZeroLaneFields = laneSpendFields
+    .filter(([, value]) => Number(value ?? 0) !== 0)
+    .map(([field]) => field);
+  if (nonZeroLaneFields.length > 0) {
+    console.error(`expected zero spend/calls for blocked lane: ${nonZeroLaneFields.join(", ")}`);
+    process.exit(1);
+  }
+}
+' "${out_dir}/summary.json"; then
+    mark_pass "mastra benchmark no-key blocked smoke (${out_dir})"
+  else
+    mark_fail "mastra benchmark no-key blocked smoke"
+  fi
+}
+
+run_real_benchmark() {
+  require_env_var OPENROUTER_API_KEY || return
+  require_env_var TINYFISH_API_KEY || return
+
+  local out_dir="benchmark-results/self-healing-real-smoke-$(date +%Y%m%d-%H%M%S)"
+  local stdout_file="${out_dir}/runner-stdout.json"
+
+  mkdir -p "$out_dir"
+  printf 'RUN   mastra real benchmark smoke\n'
+  if node benchmarks/dataset-agent/run-benchmark.mjs \
+    --prompt-ids latest-ai-blog-posts,saas-pricing-pages \
+    --timeout-ms 900000 \
+    --out "$out_dir" \
+    --system "mastra=node --import ./backend/node_modules/tsx/dist/esm/index.mjs benchmarks/dataset-agent/adapters/mastra-populate-adapter.mjs" \
+    > "$stdout_file"; then
+    mark_pass "mastra real benchmark smoke (${out_dir})"
+  else
+    mark_fail "mastra real benchmark smoke"
+  fi
+}
+
+run_live_dataset_smoke() {
+  require_env_var CONVEX_URL || return
+  require_env_var CONVEX_SELF_HOSTED_ADMIN_KEY || return
+  require_env_var OPENROUTER_API_KEY || return
+  require_env_var TINYFISH_API_KEY || return
+
+  if ! check_convex_ready "$CONVEX_URL"; then
+    mark_blocked "Convex is not reachable at ${CONVEX_URL%/}/version"
+    return
+  fi
+
+  local populate_args=(--dataset-id "$DATASET_ID" --max-rows 3)
+  local label="self-healing dataset smoke dry-run"
+  if [[ "$SHOULD_COMMIT_ROWS" -eq 1 ]]; then
+    populate_args+=(--commit)
+    label="self-healing dataset smoke commit"
+  fi
+
+  run_required_step "$label" npm --silent --prefix backend run populate:self-heal -- "${populate_args[@]}"
+}
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --dataset-id)
+      DATASET_ID="${2:-}"
+      if [[ -z "$DATASET_ID" ]]; then
+        printf 'Error: --dataset-id requires a value.\n' >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    --commit)
+      SHOULD_COMMIT_ROWS=1
+      shift
+      ;;
+    --convex-push)
+      SHOULD_RUN_CONVEX_PUSH=1
+      shift
+      ;;
+    --real-benchmark)
+      SHOULD_RUN_REAL_BENCHMARK=1
+      shift
+      ;;
+    --skip-local)
+      SHOULD_RUN_LOCAL_GATES=0
+      shift
+      ;;
+    --no-blocked-smoke)
+      SHOULD_RUN_BLOCKED_BENCHMARK_SMOKE=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Error: unknown option: %s\n' "$1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$SHOULD_COMMIT_ROWS" -eq 1 && -z "$DATASET_ID" ]]; then
+  printf 'Error: --commit requires --dataset-id.\n' >&2
+  exit 1
+fi
+
+if [[ "$SHOULD_RUN_LOCAL_GATES" -eq 1 ]]; then
+  run_required_step "backend tests" npm --prefix backend test
+  run_required_step "backend build" npm --prefix backend run build
+  run_required_step "mastra adapter syntax" node --check benchmarks/dataset-agent/adapters/mastra-populate-adapter.mjs
+fi
+
+if [[ "$SHOULD_RUN_BLOCKED_BENCHMARK_SMOKE" -eq 1 ]]; then
+  run_blocked_benchmark_smoke
+fi
+
+if [[ "$SHOULD_RUN_CONVEX_PUSH" -eq 1 ]]; then
+  if [[ ! -f frontend/.env.local ]]; then
+    mark_blocked "frontend/.env.local missing; cannot run make convex-push"
+  elif ! check_docker_compose_ready; then
+    mark_blocked "Docker Compose is not ready; cannot run make convex-push"
+  elif ! check_convex_ready "http://127.0.0.1:3210"; then
+    mark_blocked "Convex is not reachable at http://127.0.0.1:3210/version"
+  else
+    run_required_step "convex push" make convex-push
+  fi
+fi
+
+if [[ "$SHOULD_RUN_REAL_BENCHMARK" -eq 1 ]]; then
+  run_real_benchmark
+fi
+
+if [[ -n "$DATASET_ID" ]]; then
+  run_live_dataset_smoke
+fi
+
+case "$EXIT_STATUS" in
+  0) printf 'DONE  self-healing stack verification passed\n' ;;
+  1) printf 'DONE  self-healing stack verification failed\n' ;;
+  2) printf 'DONE  self-healing stack verification blocked by local prerequisites\n' ;;
+esac
+
+exit "$EXIT_STATUS"


### PR DESCRIPTION
Make performance improvement for the agent by adding in sourceUrl prioritization, extraction agent parallelism, enabling routes for tinyfish agent and playwright agent, and a centralized memory to handle data that should go into the playwright agent. Also made some other changes on benchmark testing to include open ended user prompts that could produce rows capped at 100, or close to it. Made some changes to make sure that the data collection agent can receive input from and make output to the frontend. See the documentation for details.