### PR TITLE
Allow resizing the final dataset table column

### DIFF
--- a/frontend/components/table/DatasetTable.tsx
+++ b/frontend/components/table/DatasetTable.tsx
@@ -21,6 +21,7 @@ const DEFAULT_COL_WIDTH = 180;
 const MIN_COL_WIDTH = 80;
 const ROW_HEIGHT = 34;
 const GHOST_ROW_COUNT = 50;
+const LAST_COLUMN_RESIZE_GUTTER = 160;
 
 const columnHelper = createColumnHelper<DatasetRow>();
 
@@ -68,6 +69,7 @@ export function DatasetTable({
   selection: Selection;
 }) {
   const tableContainerRef = useRef<HTMLDivElement>(null);
+  const previousResizingColumnIdRef = useRef<string | false>(false);
   const [containerHeight, setContainerHeight] = useState(600);
 
   useEffect(() => {
@@ -112,7 +114,15 @@ export function DatasetTable({
   const isBuilding = dataset.status === "building";
   const displayCount = isBuilding ? Math.max(tableRows.length, GHOST_ROW_COUNT) : tableRows.length;
   const totalWidth = columnWidths.reduce((sum, w) => sum + w, 0);
+  const tableContentWidth = totalWidth + LAST_COLUMN_RESIZE_GUTTER;
   const resizingColumnId = table.getState().columnSizingInfo.isResizingColumn;
+
+  useEffect(() => {
+    if (previousResizingColumnIdRef.current && !resizingColumnId) {
+      persistWidths();
+    }
+    previousResizingColumnIdRef.current = resizingColumnId;
+  }, [resizingColumnId, persistWidths]);
 
   const toggleRow = useCallback(
     (id: string, shiftKey: boolean) => {
@@ -143,7 +153,7 @@ export function DatasetTable({
         if (resizingColumnId) persistWidths();
       }}
     >
-      <div style={{ minWidth: totalWidth }}>
+      <div style={{ minWidth: tableContentWidth }}>
         <TableHeader
           headers={headers}
           columns={dataset.columns}

--- a/frontend/components/table/DatasetTable.tsx
+++ b/frontend/components/table/DatasetTable.tsx
@@ -149,9 +149,6 @@ export function DatasetTable({
       ref={tableContainerRef}
       className="flex-1 overflow-auto relative"
       style={{ fontSize: "13px" }}
-      onMouseUp={() => {
-        if (resizingColumnId) persistWidths();
-      }}
     >
       <div style={{ minWidth: tableContentWidth }}>
         <TableHeader


### PR DESCRIPTION
## Summary
- add right-side table gutter so the final dataset column has room to resize
- persist column widths when resizing ends, including mouseup outside the table

Rebased onto main after #84 merged.
Not stacked on #85.

Fixes #80.

## Verification
- `npm run lint -- --quiet` in `frontend`
- `NEXT_PUBLIC_CONVEX_URL=http://127.0.0.1:3210 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_dGVzdC5jbGVyay5hY2NvdW50cy5kZXYk npm run build` in `frontend`
- browser QA with real `DatasetTable` static harness: dragged final `Availability` column from 180px to 310px, confirmed localStorage persisted `Availability: 310`, reloaded and confirmed width restored at 310px
- `git diff --check`

## Notes
- This PR only touches frontend table resize behavior.
- Not stacked on #85.