### PR TITLE
Polish dataset-ready email

### DIFF
--- a/backend/src/email/templates/dataset-ready.ts
+++ b/backend/src/email/templates/dataset-ready.ts
@@ -17,9 +17,10 @@ interface DatasetReadyParams {
 export function datasetReadyTemplate(params: DatasetReadyParams): EmailTemplate {
   const safeName = escapeHtml(params.datasetName);
   const safeUrl = escapeAttr(params.datasetUrl);
+  const formattedRowCount = params.rowCount.toLocaleString();
   const rowLabel = params.rowCount === 1 ? "row" : "rows";
 
-  const subject = `Your "${params.datasetName}" dataset is ready`;
+  const subject = `BigSet: "${sanitizeSubjectText(params.datasetName)}" is ready`;
 
   const html = `<!DOCTYPE html>
 <html lang="en">
@@ -29,52 +30,72 @@ export function datasetReadyTemplate(params: DatasetReadyParams): EmailTemplate 
     <meta name="color-scheme" content="light" />
     <title>${escapeHtml(subject)}</title>
   </head>
-  <body style="margin:0;padding:0;background:#f4f4f0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#1d1b16;-webkit-font-smoothing:antialiased;">
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#f4f4f0;">
+  <body style="margin:0;padding:0;background:#f5f3ee;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Arial,sans-serif;color:#1d1b16;-webkit-font-smoothing:antialiased;">
+    <div style="display:none;max-height:0;overflow:hidden;opacity:0;color:transparent;">
+      ${safeName} has ${formattedRowCount} ${rowLabel} ready to inspect and export.
+    </div>
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#f5f3ee;">
       <tr>
-        <td align="center" style="padding:48px 16px;">
-          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:520px;background:#ffffff;border:1px solid #d5d6cf;border-radius:8px;">
+        <td align="center" style="padding:40px 16px;">
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;background:#ffffff;border:1px solid #dedbd2;border-radius:8px;border-top:4px solid #1d1b16;">
             <tr>
-              <td style="padding:24px 28px 0;">
-                <span style="font-size:16px;font-weight:700;letter-spacing:-0.02em;color:#1d1b16;">BigSet</span>
-              </td>
-            </tr>
-            <tr>
-              <td style="padding:24px 28px 4px;">
-                <h1 style="margin:0;font-size:22px;line-height:1.3;font-weight:700;letter-spacing:-0.02em;color:#1d1b16;">
-                  Your dataset is ready
-                </h1>
-              </td>
-            </tr>
-            <tr>
-              <td style="padding:8px 28px;">
-                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#f8f8f4;border:1px solid #e1e2db;border-radius:6px;">
+              <td style="padding:26px 30px 0;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
                   <tr>
-                    <td style="padding:16px 18px;">
-                      <p style="margin:0;color:#1d1b16;font-size:14px;font-weight:600;line-height:1.3;">${safeName}</p>
-                      <p style="margin:6px 0 0;color:#7c7f74;font-size:12px;line-height:1.3;">${params.rowCount.toLocaleString()} ${rowLabel} generated</p>
+                    <td align="left" style="font-size:19px;font-weight:800;color:#1d1b16;">BigSet}</td>
+                    <td align="right">
+                      <span style="display:inline-block;border:1px solid #a9ddc4;background:#eefaf4;color:#04724d;padding:5px 10px;border-radius:999px;font-size:11px;font-weight:700;letter-spacing:0.06em;text-transform:uppercase;">Dataset ready</span>
                     </td>
                   </tr>
                 </table>
               </td>
             </tr>
             <tr>
-              <td style="padding:12px 28px 24px;">
-                <p style="margin:0;color:#7c7f74;font-size:14px;line-height:1.55;">
-                  Your dataset has been populated. Open it to view, query, or export the rows.
+              <td style="padding:28px 30px 8px;">
+                <h1 style="margin:0;font-size:26px;line-height:1.22;font-weight:800;color:#1d1b16;">
+                  Fresh rows are ready
+                </h1>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:0 30px 18px;">
+                <p style="margin:0;color:#6f7169;font-size:15px;line-height:1.55;">
+                  BigSet finished populating your dataset. Open it to review the table, spot-check sources, or export the rows.
                 </p>
               </td>
             </tr>
             <tr>
-              <td style="padding:0 28px 32px;">
-                <a href="${safeUrl}" style="display:inline-block;padding:12px 24px;background:#1d1b16;color:#f4f4f0;text-decoration:none;font-size:14px;font-weight:600;border-radius:6px;letter-spacing:-0.01em;">
-                  Open Dataset
+              <td style="padding:0 30px 24px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#faf9f5;border:1px solid #e5e2d8;border-radius:8px;">
+                  <tr>
+                    <td style="padding:18px 20px;border-bottom:1px solid #e5e2d8;">
+                      <p style="margin:0;color:#8a877d;font-size:11px;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;line-height:1.3;">Dataset</p>
+                      <p style="margin:6px 0 0;color:#1d1b16;font-size:16px;font-weight:700;line-height:1.35;">${safeName}</p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding:18px 20px;">
+                      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                        <tr>
+                          <td align="left" style="color:#8a877d;font-size:12px;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;">Rows generated</td>
+                          <td align="right" style="color:#1d1b16;font-size:22px;font-weight:800;line-height:1;">${formattedRowCount}</td>
+                        </tr>
+                      </table>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:0 30px 34px;">
+                <a href="${safeUrl}" style="display:inline-block;padding:13px 22px;background:#1d1b16;color:#ffffff;text-decoration:none;font-size:14px;font-weight:700;border-radius:6px;">
+                  Open dataset
                 </a>
               </td>
             </tr>
             <tr>
-              <td style="padding:18px 28px;border-top:1px solid #e8e9e3;color:#7c7f74;font-size:11px;line-height:1.5;">
-                BigSet · Live, queryable datasets by TinyFish
+              <td style="padding:18px 30px;border-top:1px solid #ece9df;color:#7c7f74;font-size:12px;line-height:1.5;">
+                BigSet by TinyFish - live, queryable datasets from the web.
               </td>
             </tr>
           </table>
@@ -85,15 +106,16 @@ export function datasetReadyTemplate(params: DatasetReadyParams): EmailTemplate 
 </html>`;
 
   const text = [
-    "Your dataset is ready",
+    "BigSet dataset ready",
     "",
     `${params.datasetName}`,
-    `${params.rowCount.toLocaleString()} ${rowLabel} generated`,
+    `${formattedRowCount} ${rowLabel} generated`,
+    "",
+    "Open it to review the table, spot-check sources, or export the rows.",
     "",
     `Open dataset: ${params.datasetUrl}`,
     "",
-    "—",
-    "BigSet · Live, queryable datasets by TinyFish",
+    "BigSet by TinyFish",
   ].join("\n");
 
   return { subject, html, text };
@@ -115,4 +137,8 @@ function escapeAttr(s: string): string {
   // Same set for href attributes — Resend won't accept javascript:
   // URIs and we control the URL anyway, but be defensive.
   return s.replace(/[&<>"']/g, (c) => HTML_ESCAPES[c]);
+}
+
+function sanitizeSubjectText(s: string): string {
+  return s.replace(/[\r\n]+/g, " ").trim();
 }


### PR DESCRIPTION
## Summary
- refresh the dataset-ready email with clearer BigSet branding, stronger status summary, and cleaner CTA
- keep the template email-client safe: inline styles, table layout, no external CSS or images
- sanitize dataset names before using them in the email subject

Rebased onto main after #84 merged.
Not stacked on #85.

Fixes #82.

## Verification
- `npm run build` in `backend`
- generated compiled HTML preview from `dist/email/templates/dataset-ready.js`
- rendered preview in Chromium and confirmed brand, CTA, row count, no external stylesheet, and no images
- `git diff --check`

## Notes
- This PR only touches the backend dataset-ready email template.
- Not stacked on #85.