### PR TITLE
Move createRun() after claim check in /populate route

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -289,7 +289,6 @@ await fastify.register(async (instance) => {
         return reply.code(401).send({ error: "Authentication required" });
       }
 
-      const run = await populateWorkflow.createRun();
       const populateOutcome = await beginDatasetPopulate(
         parsed.data.datasetId,
         auth.userId,
@@ -307,6 +306,8 @@ await fastify.register(async (instance) => {
       if (populateOutcome !== "started") {
         throw new Error(`Unexpected populate claim outcome: ${populateOutcome}`);
       }
+
+      const run = await populateWorkflow.createRun();
 
       void runPopulateWorkflowInBackground({
         input: parsed.data,


### PR DESCRIPTION
Fixup for #85 — addresses the CodeRabbit nitpick.

`populateWorkflow.createRun()` was being called before `beginDatasetPopulate`, meaning a Mastra run got allocated even for requests that would be rejected (not found, forbidden, already building). Moved it to after the claim succeeds.

One-line change, no behavior change for the happy path.