### PR TITLE
Release dataset claim if createRun() throws

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -307,7 +307,14 @@ await fastify.register(async (instance) => {
         throw new Error(`Unexpected populate claim outcome: ${populateOutcome}`);
       }
 
-      const run = await populateWorkflow.createRun();
+      let run: Awaited<ReturnType<typeof populateWorkflow.createRun>>;
+      try {
+        run = await populateWorkflow.createRun();
+      } catch (runErr) {
+        req.log.error(runErr, "Failed to create workflow run; releasing dataset claim");
+        await setDatasetPopulateStatus(parsed.data.datasetId, "failed", statusErrorMessage(runErr));
+        return reply.code(502).send({ error: "Failed to populate dataset. Please try again." });
+      }
 
       void runPopulateWorkflowInBackground({
         input: parsed.data,


### PR DESCRIPTION
Fixup for #85 — addresses CodeRabbit's actionable comment.

If `populateWorkflow.createRun()` throws after the claim has already succeeded, the dataset gets stuck in `"building"` forever. This wraps `createRun()` in its own try/catch: on failure it calls `setDatasetPopulateStatus(..., "failed", ...)` to release the claim before returning 502.

Uses the existing `statusErrorMessage()` and `setDatasetPopulateStatus()` helpers already in the file.