### PR TITLE
Harden PK validation: reject empty primary_keys, dedupe declared PKs

### DIFF
--- a/backend/src/mastra/tools/investigate-tool.ts
+++ b/backend/src/mastra/tools/investigate-tool.ts
@@ -12,6 +12,9 @@ const investigateInputSchema = z.object({
     ),
   primary_keys: z
     .record(z.string(), z.string())
+    .refine((v) => Object.keys(v).length > 0, {
+      message: "primary_keys must include at least one primary-key value",
+    })
     .describe(
       "REQUIRED: the primary key column value(s) for this entity. e.g. {\"Company Name\": \"Stripe\"} or {\"First Name\": \"John\", \"Last Name\": \"Doe\"}. You MUST provide at least the primary key values you have found.",
     ),

--- a/backend/src/pipeline/types.ts
+++ b/backend/src/pipeline/types.ts
@@ -61,10 +61,12 @@ export const datasetSchemaSchema = z
     }
 
     const pkNames = pkCols.map((c) => c.name);
-    const declaredPk = Array.isArray(data.primary_key)
+    const declaredPkRaw = Array.isArray(data.primary_key)
       ? data.primary_key
       : [data.primary_key];
+    const declaredPk = [...new Set(declaredPkRaw)];
     if (
+      declaredPk.length !== declaredPkRaw.length ||
       declaredPk.length !== pkNames.length ||
       !declaredPk.every((n) => pkNames.includes(n))
     ) {


### PR DESCRIPTION
## Summary

Follow-up to #97 per CodeRabbit review. Mengzhe's merge picked up the case-insensitive duplicate check but these two fixes didn't make it in time:

- **Reject empty `primary_keys`**: `run_subagent` schema now validates that at least one PK value is provided, preventing silent dispatch of subagents with no entity identity
- **Dedupe declared `primary_key` array**: Schema inference validation now dedupes the LLM's `primary_key` output before membership checks, catching duplicates like `["name", "name"]`

## Test plan

- [ ] Trigger a populate run — orchestrator should still dispatch subagents normally with PK values
- [ ] Schema inference with multiple PK columns should still validate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)