### PR TITLE
Add cost tracking for populate workflow runs

### DIFF
--- a/backend/src/mastra/agents/populate.ts
+++ b/backend/src/mastra/agents/populate.ts
@@ -4,6 +4,7 @@ import { buildSubagentTool } from "../tools/investigate-tool.js";
 import { searchWebTool, fetchPageTool } from "../tools/web-tools.js";
 import type { AuthContext } from "../workflows/populate.js";
 import type { PopulateColumn } from "../../pipeline/populate.js";
+import type { RunMetrics } from "../run-metrics.js";
 
 const openrouter = createOpenRouter({
   apiKey: process.env.OPENROUTER_API_KEY!,
@@ -41,12 +42,13 @@ export function buildPopulateAgent(
   authorizedDatasetId: string,
   authContext: AuthContext,
   columns: PopulateColumn[],
+  metrics?: RunMetrics,
 ): Agent {
   return new Agent({
     id: "populate-agent",
     name: "Dataset Populate Orchestrator",
     instructions: INSTRUCTIONS,
-    model: openrouter("qwen/qwen3.7-max"),
+    model: openrouter("deepseek/deepseek-v4-pro"),
     tools: {
       search_web: searchWebTool,
       fetch_page: fetchPageTool,
@@ -54,6 +56,7 @@ export function buildPopulateAgent(
         authorizedDatasetId,
         authContext,
         columns,
+        metrics,
       ),
     },
   });

--- a/backend/src/mastra/agents/populate.ts
+++ b/backend/src/mastra/agents/populate.ts
@@ -48,7 +48,7 @@ export function buildPopulateAgent(
     id: "populate-agent",
     name: "Dataset Populate Orchestrator",
     instructions: INSTRUCTIONS,
-    model: openrouter("deepseek/deepseek-v4-pro"),
+    model: openrouter("qwen/qwen3.7-max"),
     tools: {
       search_web: searchWebTool,
       fetch_page: fetchPageTool,

--- a/backend/src/mastra/run-metrics.ts
+++ b/backend/src/mastra/run-metrics.ts
@@ -3,7 +3,7 @@
  *
  * A single RunMetrics instance is created at the start of each agentStep,
  * passed by reference into every tool factory and agent builder, and read
- * once at the end to write the populateRuns Convex record.
+ * once at the end to write the runStats Convex record.
  *
  * All operations are synchronous integer increments or field reads — zero
  * I/O, zero meaningful overhead on the hot path.

--- a/backend/src/mastra/run-metrics.ts
+++ b/backend/src/mastra/run-metrics.ts
@@ -10,14 +10,25 @@
  */
 
 interface AgentResult {
+  // Mastra FullOutput: totalUsage sums across all steps; usage is last-step only.
+  // Prefer totalUsage for accurate multi-step accounting.
+  totalUsage?: { inputTokens?: number; outputTokens?: number };
   usage?: { inputTokens?: number; outputTokens?: number };
   steps?: unknown[];
+}
+
+function tokens(result: AgentResult): { input: number; output: number } {
+  const src = result.totalUsage ?? result.usage;
+  return {
+    input: src?.inputTokens ?? 0,
+    output: src?.outputTokens ?? 0,
+  };
 }
 
 export class RunMetrics {
   searchCalls = 0;
   fetchCalls = 0;
-  /** investigate_row tool calls dispatched by the orchestrator. */
+  /** run_subagent tool calls dispatched by the orchestrator. */
   investigateCalls = 0;
   /** Rows successfully inserted across all investigate subagents. */
   rowsInserted = 0;
@@ -31,14 +42,16 @@ export class RunMetrics {
   };
 
   addOrchestratorResult(result: AgentResult): void {
-    this.orchestrator.inputTokens += result.usage?.inputTokens ?? 0;
-    this.orchestrator.outputTokens += result.usage?.outputTokens ?? 0;
+    const { input, output } = tokens(result);
+    this.orchestrator.inputTokens += input;
+    this.orchestrator.outputTokens += output;
     this.orchestrator.steps += result.steps?.length ?? 0;
   }
 
   addInvestigateResult(result: AgentResult): void {
-    this.investigate.inputTokens += result.usage?.inputTokens ?? 0;
-    this.investigate.outputTokens += result.usage?.outputTokens ?? 0;
+    const { input, output } = tokens(result);
+    this.investigate.inputTokens += input;
+    this.investigate.outputTokens += output;
     this.investigate.steps += result.steps?.length ?? 0;
     this.investigate.runs += 1;
   }

--- a/backend/src/mastra/run-metrics.ts
+++ b/backend/src/mastra/run-metrics.ts
@@ -1,12 +1,16 @@
 /**
- * Per-run metrics collector for the populate workflow.
+ * Per-run metrics collector for the populate and update workflows.
  *
- * A single RunMetrics instance is created at the start of each agentStep,
+ * A single RunMetrics instance is created at the start of each workflow run,
  * passed by reference into every tool factory and agent builder, and read
  * once at the end to write the runStats Convex record.
  *
  * All operations are synchronous integer increments or field reads — zero
  * I/O, zero meaningful overhead on the hot path.
+ *
+ * Tier mapping:
+ *   populate workflow  → orchestrator = populate agent, investigate = investigate subagents
+ *   update workflow    → orchestrator = (unused, stays 0),  investigate = refresh agents
  */
 
 interface AgentResult {
@@ -28,12 +32,19 @@ function tokens(result: AgentResult): { input: number; output: number } {
 export class RunMetrics {
   searchCalls = 0;
   fetchCalls = 0;
-  /** run_subagent tool calls dispatched by the orchestrator. */
+  /** run_subagent tool calls dispatched by the orchestrator (populate only). */
   investigateCalls = 0;
-  /** Rows successfully inserted across all investigate subagents. */
+  /** Rows successfully inserted across all investigate subagents (populate only). */
   rowsInserted = 0;
+  /** Rows successfully updated by refresh agents (update workflow only). */
+  rowsUpdated = 0;
 
   readonly orchestrator = { inputTokens: 0, outputTokens: 0, steps: 0 };
+  /**
+   * Accumulates tokens for investigate subagents (populate) or refresh agents
+   * (update workflow). The `runs` field equals the number of subagent invocations
+   * in either workflow.
+   */
   readonly investigate = {
     inputTokens: 0,
     outputTokens: 0,
@@ -54,6 +65,14 @@ export class RunMetrics {
     this.investigate.outputTokens += output;
     this.investigate.steps += result.steps?.length ?? 0;
     this.investigate.runs += 1;
+  }
+
+  /**
+   * Accumulate tokens for one refresh agent run (update workflow).
+   * Stored in the `investigate` tier so the runStats schema needs no new columns.
+   */
+  addRefreshResult(result: AgentResult): void {
+    this.addInvestigateResult(result);
   }
 
   totals(): { inputTokens: number; outputTokens: number } {

--- a/backend/src/mastra/run-metrics.ts
+++ b/backend/src/mastra/run-metrics.ts
@@ -1,0 +1,53 @@
+/**
+ * Per-run metrics collector for the populate workflow.
+ *
+ * A single RunMetrics instance is created at the start of each agentStep,
+ * passed by reference into every tool factory and agent builder, and read
+ * once at the end to write the populateRuns Convex record.
+ *
+ * All operations are synchronous integer increments or field reads — zero
+ * I/O, zero meaningful overhead on the hot path.
+ */
+
+interface AgentResult {
+  usage?: { inputTokens?: number; outputTokens?: number };
+  steps?: unknown[];
+}
+
+export class RunMetrics {
+  searchCalls = 0;
+  fetchCalls = 0;
+  /** investigate_row tool calls dispatched by the orchestrator. */
+  investigateCalls = 0;
+  /** Rows successfully inserted across all investigate subagents. */
+  rowsInserted = 0;
+
+  readonly orchestrator = { inputTokens: 0, outputTokens: 0, steps: 0 };
+  readonly investigate = {
+    inputTokens: 0,
+    outputTokens: 0,
+    steps: 0,
+    runs: 0,
+  };
+
+  addOrchestratorResult(result: AgentResult): void {
+    this.orchestrator.inputTokens += result.usage?.inputTokens ?? 0;
+    this.orchestrator.outputTokens += result.usage?.outputTokens ?? 0;
+    this.orchestrator.steps += result.steps?.length ?? 0;
+  }
+
+  addInvestigateResult(result: AgentResult): void {
+    this.investigate.inputTokens += result.usage?.inputTokens ?? 0;
+    this.investigate.outputTokens += result.usage?.outputTokens ?? 0;
+    this.investigate.steps += result.steps?.length ?? 0;
+    this.investigate.runs += 1;
+  }
+
+  totals(): { inputTokens: number; outputTokens: number } {
+    return {
+      inputTokens: this.orchestrator.inputTokens + this.investigate.inputTokens,
+      outputTokens:
+        this.orchestrator.outputTokens + this.investigate.outputTokens,
+    };
+  }
+}

--- a/backend/src/mastra/run-metrics.ts
+++ b/backend/src/mastra/run-metrics.ts
@@ -75,6 +75,19 @@ export class RunMetrics {
     this.addInvestigateResult(result);
   }
 
+  /**
+   * Tally tool calls from a flat result.toolCalls array into searchCalls /
+   * fetchCalls. Centralised here so callers don't duplicate the loop and
+   * tool-name strings.
+   */
+  countToolCalls(toolCalls: unknown[]): void {
+    for (const tc of toolCalls as any[]) {
+      const name = tc.payload?.toolName ?? tc.toolName;
+      if (name === "search_web") this.searchCalls++;
+      else if (name === "fetch_page") this.fetchCalls++;
+    }
+  }
+
   totals(): { inputTokens: number; outputTokens: number } {
     return {
       inputTokens: this.orchestrator.inputTokens + this.investigate.inputTokens,

--- a/backend/src/mastra/save-run-metrics.ts
+++ b/backend/src/mastra/save-run-metrics.ts
@@ -11,6 +11,7 @@ export interface SaveRunMetricsInput {
   status: "success" | "error";
   error?: string;
   isBenchmark?: boolean;
+  workflowType?: "populate" | "update";
 }
 
 /**
@@ -48,5 +49,7 @@ export async function saveRunMetrics(input: SaveRunMetricsInput): Promise<void> 
     status: input.status,
     error: input.error,
     isBenchmark: input.isBenchmark,
+    workflowType: input.workflowType,
+    rowsUpdated: input.metrics.rowsUpdated > 0 ? input.metrics.rowsUpdated : undefined,
   });
 }

--- a/backend/src/mastra/save-run-metrics.ts
+++ b/backend/src/mastra/save-run-metrics.ts
@@ -14,14 +14,14 @@ export interface SaveRunMetricsInput {
 }
 
 /**
- * Persist a completed run's metrics to the populateRuns Convex table.
+ * Persist a completed run's metrics to the runStats Convex table.
  *
  * Called from the agentStep finally-block as a fire-and-forget operation —
  * any error here is logged but must never propagate to the populate workflow.
  */
 export async function saveRunMetrics(input: SaveRunMetricsInput): Promise<void> {
   const totals = input.metrics.totals();
-  await convex.mutation(internal.populateRuns.insert, {
+  await convex.mutation(internal.runStats.insert, {
     workflowRunId: input.workflowRunId,
     datasetId: input.datasetId,
     userId: input.userId,

--- a/backend/src/mastra/save-run-metrics.ts
+++ b/backend/src/mastra/save-run-metrics.ts
@@ -1,0 +1,52 @@
+import { convex, internal } from "../convex.js";
+import type { RunMetrics } from "./run-metrics.js";
+
+export interface SaveRunMetricsInput {
+  workflowRunId: string;
+  datasetId: string;
+  userId: string;
+  startedAt: number;
+  finishedAt: number;
+  metrics: RunMetrics;
+  status: "success" | "error";
+  error?: string;
+  isBenchmark?: boolean;
+}
+
+/**
+ * Persist a completed run's metrics to the populateRuns Convex table.
+ *
+ * Called from the agentStep finally-block as a fire-and-forget operation —
+ * any error here is logged but must never propagate to the populate workflow.
+ */
+export async function saveRunMetrics(input: SaveRunMetricsInput): Promise<void> {
+  const totals = input.metrics.totals();
+  await convex.mutation(internal.populateRuns.insert, {
+    workflowRunId: input.workflowRunId,
+    datasetId: input.datasetId,
+    userId: input.userId,
+    startedAt: input.startedAt,
+    finishedAt: input.finishedAt,
+    durationMs: input.finishedAt - input.startedAt,
+
+    searchCalls: input.metrics.searchCalls,
+    fetchCalls: input.metrics.fetchCalls,
+    investigateCalls: input.metrics.investigateCalls,
+    rowsInserted: input.metrics.rowsInserted,
+
+    tokensInput: totals.inputTokens,
+    tokensOutput: totals.outputTokens,
+
+    orchestratorTokensInput: input.metrics.orchestrator.inputTokens,
+    orchestratorTokensOutput: input.metrics.orchestrator.outputTokens,
+    orchestratorSteps: input.metrics.orchestrator.steps,
+    investigateTokensInput: input.metrics.investigate.inputTokens,
+    investigateTokensOutput: input.metrics.investigate.outputTokens,
+    investigateSteps: input.metrics.investigate.steps,
+    investigateRuns: input.metrics.investigate.runs,
+
+    status: input.status,
+    error: input.error,
+    isBenchmark: input.isBenchmark,
+  });
+}

--- a/backend/src/mastra/tools/investigate-tool.ts
+++ b/backend/src/mastra/tools/investigate-tool.ts
@@ -114,12 +114,16 @@ ${context}${urlsBlock}${notesBlock}`;
 
         const result = await agent.generate(prompt, { maxSteps: 10 });
         if (metrics) {
-          for (const step of (result.steps ?? []) as any[]) {
-            for (const tc of (step.toolCalls ?? []) as any[]) {
-              const name = tc.payload?.toolName ?? tc.toolName;
-              if (name === "search_web") metrics.searchCalls++;
-              else if (name === "fetch_page") metrics.fetchCalls++;
-            }
+          // Use result.toolCalls (the flat accumulated list across all steps) rather
+          // than iterating result.steps[n].toolCalls. The per-step arrays are snapshots
+          // captured at step-finish time; tool-call chunks that arrive after their
+          // step-finish event end up attributed to the wrong step, causing systematic
+          // miscounts. result.toolCalls is the authoritative list maintained by Mastra's
+          // stream processor as chunks arrive.
+          for (const tc of (result.toolCalls ?? []) as any[]) {
+            const name = tc.payload?.toolName ?? tc.toolName;
+            if (name === "search_web") metrics.searchCalls++;
+            else if (name === "fetch_page") metrics.fetchCalls++;
           }
           metrics.addInvestigateResult(result);
         }
@@ -128,7 +132,7 @@ ${context}${urlsBlock}${notesBlock}`;
         if (metrics && parsed.inserted) metrics.rowsInserted++;
 
         console.log(
-          `[run_subagent] done entity="${entity_hint}" inserted=${parsed.inserted} steps=${result.steps?.length ?? "?"}` +
+          `[run_subagent] done entity="${entity_hint}" inserted=${parsed.inserted} steps=${result.steps?.length ?? "?"} toolCalls=${result.toolCalls?.length ?? "?"}` +
             (parsed.row_summary ? `\n  summary: ${parsed.row_summary}` : "") +
             (parsed.reason ? `\n  reason:  ${parsed.reason}` : "") +
             (parsed.clues ? `\n  clues:   ${parsed.clues}` : ""),

--- a/backend/src/mastra/tools/investigate-tool.ts
+++ b/backend/src/mastra/tools/investigate-tool.ts
@@ -120,11 +120,7 @@ ${context}${urlsBlock}${notesBlock}`;
           // step-finish event end up attributed to the wrong step, causing systematic
           // miscounts. result.toolCalls is the authoritative list maintained by Mastra's
           // stream processor as chunks arrive.
-          for (const tc of (result.toolCalls ?? []) as any[]) {
-            const name = tc.payload?.toolName ?? tc.toolName;
-            if (name === "search_web") metrics.searchCalls++;
-            else if (name === "fetch_page") metrics.fetchCalls++;
-          }
+          metrics.countToolCalls(result.toolCalls ?? []);
           metrics.addInvestigateResult(result);
         }
 

--- a/backend/src/mastra/tools/investigate-tool.ts
+++ b/backend/src/mastra/tools/investigate-tool.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { buildInvestigateAgent } from "../agents/investigate.js";
 import type { AuthContext } from "../workflows/populate.js";
 import type { PopulateColumn } from "../../pipeline/populate.js";
+import type { RunMetrics } from "../run-metrics.js";
 
 const investigateInputSchema = z.object({
   entity_hint: z
@@ -72,6 +73,7 @@ export function buildSubagentTool(
   authorizedDatasetId: string,
   authContext: AuthContext,
   columns: PopulateColumn[],
+  metrics?: RunMetrics,
 ) {
   return createTool({
     id: "run_subagent",
@@ -80,6 +82,7 @@ export function buildSubagentTool(
     inputSchema: investigateInputSchema,
     outputSchema: investigateOutputSchema,
     execute: async ({ entity_hint, primary_keys, context, urls, notes }) => {
+      if (metrics) metrics.investigateCalls++;
       console.log(
         `[run_subagent] spawning subagent user=${authContext.authorizedUserId} run=${authContext.workflowRunId} dataset=${authorizedDatasetId} entity="${entity_hint}" pk=${JSON.stringify(primary_keys)}`,
       );
@@ -110,7 +113,19 @@ Context (partial data already found):
 ${context}${urlsBlock}${notesBlock}`;
 
         const result = await agent.generate(prompt, { maxSteps: 10 });
+        if (metrics) {
+          for (const step of (result.steps ?? []) as any[]) {
+            for (const tc of (step.toolCalls ?? []) as any[]) {
+              if (tc.toolName === "search_web") metrics.searchCalls++;
+              else if (tc.toolName === "fetch_page") metrics.fetchCalls++;
+            }
+          }
+          metrics.addInvestigateResult(result);
+        }
+
         const parsed = parseInvestigateResult(result.text);
+        if (metrics && parsed.inserted) metrics.rowsInserted++;
+
         console.log(
           `[run_subagent] done entity="${entity_hint}" inserted=${parsed.inserted} steps=${result.steps?.length ?? "?"}` +
             (parsed.row_summary ? `\n  summary: ${parsed.row_summary}` : "") +

--- a/backend/src/mastra/tools/investigate-tool.ts
+++ b/backend/src/mastra/tools/investigate-tool.ts
@@ -116,8 +116,9 @@ ${context}${urlsBlock}${notesBlock}`;
         if (metrics) {
           for (const step of (result.steps ?? []) as any[]) {
             for (const tc of (step.toolCalls ?? []) as any[]) {
-              if (tc.toolName === "search_web") metrics.searchCalls++;
-              else if (tc.toolName === "fetch_page") metrics.fetchCalls++;
+              const name = tc.payload?.toolName ?? tc.toolName;
+              if (name === "search_web") metrics.searchCalls++;
+              else if (name === "fetch_page") metrics.fetchCalls++;
             }
           }
           metrics.addInvestigateResult(result);

--- a/backend/src/mastra/workflows/populate.ts
+++ b/backend/src/mastra/workflows/populate.ts
@@ -235,12 +235,11 @@ const agentStep = createStep({
       );
       const result = await agent.generate(inputData.prompt, { maxSteps: 80 });
       metrics.addOrchestratorResult(result);
-      for (const step of (result.steps ?? []) as any[]) {
-        for (const tc of (step.toolCalls ?? []) as any[]) {
-          const name = tc.payload?.toolName ?? tc.toolName;
-          if (name === "search_web") metrics.searchCalls++;
-          else if (name === "fetch_page") metrics.fetchCalls++;
-        }
+      // Use result.toolCalls (flat accumulated list) — same reasoning as investigate-tool.ts.
+      for (const tc of (result.toolCalls ?? []) as any[]) {
+        const name = tc.payload?.toolName ?? tc.toolName;
+        if (name === "search_web") metrics.searchCalls++;
+        else if (name === "fetch_page") metrics.fetchCalls++;
       }
       return { text: result.text };
     } catch (err) {

--- a/backend/src/mastra/workflows/populate.ts
+++ b/backend/src/mastra/workflows/populate.ts
@@ -236,11 +236,7 @@ const agentStep = createStep({
       const result = await agent.generate(inputData.prompt, { maxSteps: 80 });
       metrics.addOrchestratorResult(result);
       // Use result.toolCalls (flat accumulated list) — same reasoning as investigate-tool.ts.
-      for (const tc of (result.toolCalls ?? []) as any[]) {
-        const name = tc.payload?.toolName ?? tc.toolName;
-        if (name === "search_web") metrics.searchCalls++;
-        else if (name === "fetch_page") metrics.fetchCalls++;
-      }
+      metrics.countToolCalls(result.toolCalls ?? []);
       return { text: result.text };
     } catch (err) {
       status = "error";

--- a/backend/src/mastra/workflows/populate.ts
+++ b/backend/src/mastra/workflows/populate.ts
@@ -237,8 +237,9 @@ const agentStep = createStep({
       metrics.addOrchestratorResult(result);
       for (const step of (result.steps ?? []) as any[]) {
         for (const tc of (step.toolCalls ?? []) as any[]) {
-          if (tc.toolName === "search_web") metrics.searchCalls++;
-          else if (tc.toolName === "fetch_page") metrics.fetchCalls++;
+          const name = tc.payload?.toolName ?? tc.toolName;
+          if (name === "search_web") metrics.searchCalls++;
+          else if (name === "fetch_page") metrics.fetchCalls++;
         }
       }
       return { text: result.text };

--- a/backend/src/mastra/workflows/populate.ts
+++ b/backend/src/mastra/workflows/populate.ts
@@ -226,14 +226,13 @@ const agentStep = createStep({
     let status: "success" | "error" = "success";
     let errorMsg: string | undefined;
 
-    const agent = buildPopulateAgent(
-      inputData.authorizedDatasetId,
-      inputData.authContext,
-      inputData.columns,
-      metrics,
-    );
-
     try {
+      const agent = buildPopulateAgent(
+        inputData.authorizedDatasetId,
+        inputData.authContext,
+        inputData.columns,
+        metrics,
+      );
       const result = await agent.generate(inputData.prompt, { maxSteps: 80 });
       metrics.addOrchestratorResult(result);
       for (const step of (result.steps ?? []) as any[]) {

--- a/backend/src/mastra/workflows/populate.ts
+++ b/backend/src/mastra/workflows/populate.ts
@@ -5,6 +5,8 @@ import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { datasetContextSchema, populateColumnSchema } from "../../pipeline/populate.js";
 import { convex, internal } from "../../convex.js";
 import { buildPopulateAgent } from "../agents/populate.js";
+import { RunMetrics } from "../run-metrics.js";
+import { saveRunMetrics } from "../save-run-metrics.js";
 
 /**
  * Server-set auth/run context threaded through every step.
@@ -28,6 +30,7 @@ import { buildPopulateAgent } from "../agents/populate.js";
 export const authContextSchema = z.object({
   authorizedUserId: z.string().min(1),
   workflowRunId: z.string().min(1),
+  isBenchmark: z.boolean().optional(),
 });
 export type AuthContext = z.infer<typeof authContextSchema>;
 
@@ -208,24 +211,61 @@ For each lead you find, call run_subagent with the primary key values and any co
  * capability scope; see tools/dataset-tools.ts). So this step does what
  * Mastra's agent-as-step adapter would do internally: build the agent,
  * call `.generate(prompt, { maxSteps })`, return the text.
+ *
+ * A RunMetrics instance is created here, threaded into every tool factory
+ * and agent builder, and saved to Convex in the finally block. The save is
+ * fire-and-forget — errors are logged but never propagate to the workflow.
  */
 const agentStep = createStep({
   id: "populate-agent",
   inputSchema: buildPromptOutputSchema,
   outputSchema: z.object({ text: z.string() }),
   execute: async ({ inputData }) => {
+    const metrics = new RunMetrics();
+    const startedAt = Date.now();
+    let status: "success" | "error" = "success";
+    let errorMsg: string | undefined;
+
     const agent = buildPopulateAgent(
       inputData.authorizedDatasetId,
       inputData.authContext,
       inputData.columns,
+      metrics,
     );
+
     try {
       const result = await agent.generate(inputData.prompt, { maxSteps: 80 });
+      metrics.addOrchestratorResult(result);
+      for (const step of (result.steps ?? []) as any[]) {
+        for (const tc of (step.toolCalls ?? []) as any[]) {
+          if (tc.toolName === "search_web") metrics.searchCalls++;
+          else if (tc.toolName === "fetch_page") metrics.fetchCalls++;
+        }
+      }
       return { text: result.text };
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.error(`[populate-agent] agent.generate failed: ${msg}`);
+      status = "error";
+      errorMsg = err instanceof Error ? err.message : String(err);
+      console.error(`[populate-agent] agent.generate failed: ${errorMsg}`);
       throw err;
+    } finally {
+      const finishedAt = Date.now();
+      void saveRunMetrics({
+        workflowRunId: inputData.authContext.workflowRunId,
+        datasetId: inputData.authorizedDatasetId,
+        userId: inputData.authContext.authorizedUserId,
+        startedAt,
+        finishedAt,
+        metrics,
+        status,
+        error: errorMsg,
+        isBenchmark: inputData.authContext.isBenchmark,
+      }).catch((err) =>
+        console.error(
+          `[populate-agent] metrics save failed run=${inputData.authContext.workflowRunId}:`,
+          err,
+        ),
+      );
     }
   },
 });

--- a/backend/src/mastra/workflows/update.ts
+++ b/backend/src/mastra/workflows/update.ts
@@ -4,6 +4,8 @@ import { datasetContextSchema, populateColumnSchema } from "../../pipeline/popul
 import { convex, internal } from "../../convex.js";
 import { buildRefreshAgent } from "../agents/refresh.js";
 import { authContextSchema } from "./populate.js";
+import { RunMetrics } from "../run-metrics.js";
+import { saveRunMetrics } from "../save-run-metrics.js";
 
 export const updateInputSchema = datasetContextSchema.extend({
   authContext: authContextSchema,
@@ -94,6 +96,9 @@ const refreshRowsStep = createStep({
     let updatedCount = 0;
     let errors = 0;
 
+    const metrics = new RunMetrics();
+    const startedAt = Date.now();
+
     const pkColumns = columns.filter((c) => c.isPrimaryKey);
 
     async function processRow(row: z.infer<typeof rowSchema>) {
@@ -128,10 +133,29 @@ ${row.rowSummary ? `\nPrevious summary: ${row.rowSummary}` : ""}
 ${row.howFound ? `\nPreviously found via: ${row.howFound}` : ""}`;
 
         const result = await agent.generate(prompt, { maxSteps: 10 });
+
+        // Accumulate token usage into the investigate tier (refresh agents map
+        // to the investigate tier so the runStats schema needs no new columns).
+        metrics.addRefreshResult(result);
+
+        // Use result.toolCalls (flat accumulated list) — same reasoning as
+        // investigate-tool.ts. Per-step arrays are step-finish snapshots and
+        // can misattribute chunks that arrive after the step-finish event.
+        for (const tc of (result.toolCalls ?? []) as any[]) {
+          const name = tc.payload?.toolName ?? tc.toolName;
+          if (name === "search_web") metrics.searchCalls++;
+          else if (name === "fetch_page") metrics.fetchCalls++;
+        }
+
         const text = result.text.toLowerCase();
         if (text.includes("updated: true")) {
           updatedCount++;
+          metrics.rowsUpdated++;
         }
+
+        console.log(
+          `[refresh-rows] Row ${row._id}: updated=${text.includes("updated: true")} steps=${result.steps?.length ?? "?"} toolCalls=${(result.toolCalls as any[])?.length ?? "?"}`,
+        );
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error(
@@ -158,9 +182,32 @@ ${row.howFound ? `\nPreviously found via: ${row.howFound}` : ""}`;
       `[refresh-rows] Processing ${rows.length} rows (max ${MAX_CONCURRENT} concurrent)`,
     );
     await processWithConcurrency(rows, processRow, MAX_CONCURRENT);
+    const finishedAt = Date.now();
     console.log(
       `[refresh-rows] Done: ${updatedCount} updated, ${errors} errors, ${rows.length - updatedCount - errors} unchanged`,
     );
+
+    // Persist metrics — fire-and-forget; never propagate errors to the workflow.
+    try {
+      await saveRunMetrics({
+        workflowRunId: authContext.workflowRunId,
+        datasetId,
+        userId: authContext.authorizedUserId,
+        startedAt,
+        finishedAt,
+        metrics,
+        status: errors > 0 && updatedCount === 0 && rows.length === errors ? "error" : "success",
+        error:
+          errors > 0 && updatedCount === 0 && rows.length === errors
+            ? `All ${errors} row(s) failed to refresh`
+            : undefined,
+        workflowType: "update",
+      });
+    } catch (metricsErr) {
+      console.error(
+        `[refresh-rows] Failed to save run metrics: ${metricsErr instanceof Error ? metricsErr.message : String(metricsErr)}`,
+      );
+    }
 
     return { updatedCount, totalCount: rows.length, errors };
   },

--- a/backend/src/mastra/workflows/update.ts
+++ b/backend/src/mastra/workflows/update.ts
@@ -143,14 +143,17 @@ ${row.howFound ? `\nPreviously found via: ${row.howFound}` : ""}`;
         // can misattribute chunks that arrive after the step-finish event.
         metrics.countToolCalls(result.toolCalls ?? []);
 
-        const text = result.text.toLowerCase();
-        if (text.includes("updated: true")) {
+        // Use a tolerant regex so variants like `"updated":true` or
+        // `updated : true` are all caught, not just the exact string
+        // "updated: true" that the agent is instructed to produce.
+        const updated = /\bupdated"?\s*:\s*true\b/i.test(result.text);
+        if (updated) {
           updatedCount++;
           metrics.rowsUpdated++;
         }
 
         console.log(
-          `[refresh-rows] Row ${row._id}: updated=${text.includes("updated: true")} steps=${result.steps?.length ?? "?"} toolCalls=${(result.toolCalls as any[])?.length ?? "?"}`,
+          `[refresh-rows] Row ${row._id}: updated=${updated} steps=${result.steps?.length ?? "?"} toolCalls=${(result.toolCalls as any[])?.length ?? "?"}`,
         );
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/backend/src/mastra/workflows/update.ts
+++ b/backend/src/mastra/workflows/update.ts
@@ -141,11 +141,7 @@ ${row.howFound ? `\nPreviously found via: ${row.howFound}` : ""}`;
         // Use result.toolCalls (flat accumulated list) — same reasoning as
         // investigate-tool.ts. Per-step arrays are step-finish snapshots and
         // can misattribute chunks that arrive after the step-finish event.
-        for (const tc of (result.toolCalls ?? []) as any[]) {
-          const name = tc.payload?.toolName ?? tc.toolName;
-          if (name === "search_web") metrics.searchCalls++;
-          else if (name === "fetch_page") metrics.fetchCalls++;
-        }
+        metrics.countToolCalls(result.toolCalls ?? []);
 
         const text = result.text.toLowerCase();
         if (text.includes("updated: true")) {
@@ -187,27 +183,28 @@ ${row.howFound ? `\nPreviously found via: ${row.howFound}` : ""}`;
       `[refresh-rows] Done: ${updatedCount} updated, ${errors} errors, ${rows.length - updatedCount - errors} unchanged`,
     );
 
-    // Persist metrics — fire-and-forget; never propagate errors to the workflow.
-    try {
-      await saveRunMetrics({
-        workflowRunId: authContext.workflowRunId,
-        datasetId,
-        userId: authContext.authorizedUserId,
-        startedAt,
-        finishedAt,
-        metrics,
-        status: errors > 0 && updatedCount === 0 && rows.length === errors ? "error" : "success",
-        error:
-          errors > 0 && updatedCount === 0 && rows.length === errors
-            ? `All ${errors} row(s) failed to refresh`
-            : undefined,
-        workflowType: "update",
-      });
-    } catch (metricsErr) {
+    // Persist metrics — fire-and-forget; never block the workflow return.
+    void saveRunMetrics({
+      workflowRunId: authContext.workflowRunId,
+      datasetId,
+      userId: authContext.authorizedUserId,
+      startedAt,
+      finishedAt,
+      metrics,
+      // Total failure: every row errored. Partial failure: some rows errored
+      // but at least one succeeded — still "success" overall, but the error
+      // field records how many failed so partial issues are visible in the data.
+      status: errors > 0 && updatedCount === 0 ? "error" : "success",
+      error: errors > 0
+        ? `${errors} of ${rows.length} row(s) failed to refresh`
+        : undefined,
+      workflowType: "update",
+    }).catch((err) =>
       console.error(
-        `[refresh-rows] Failed to save run metrics: ${metricsErr instanceof Error ? metricsErr.message : String(metricsErr)}`,
-      );
-    }
+        `[refresh-rows] metrics save failed run=${authContext.workflowRunId}:`,
+        err,
+      ),
+    );
 
     return { updatedCount, totalCount: rows.length, errors };
   },

--- a/frontend/convex/populateRuns.ts
+++ b/frontend/convex/populateRuns.ts
@@ -37,6 +37,12 @@ export const insert = internalMutation({
     isBenchmark: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
+    if (args.status === "success" && args.error) {
+      throw new Error("populateRuns.insert: error must be absent on a successful run");
+    }
+    if (args.status === "error" && !args.error) {
+      throw new Error("populateRuns.insert: error message is required on a failed run");
+    }
     await ctx.db.insert("populateRuns", args);
   },
 });

--- a/frontend/convex/populateRuns.ts
+++ b/frontend/convex/populateRuns.ts
@@ -1,0 +1,86 @@
+import { internalMutation, internalQuery } from "./_generated/server.js";
+import { v } from "convex/values";
+
+/**
+ * Insert a populate-run metrics record.
+ *
+ * Called by the backend agent runner at the end of every populate workflow
+ * run (success or error). Never called from the browser.
+ */
+export const insert = internalMutation({
+  args: {
+    workflowRunId: v.string(),
+    datasetId: v.string(),
+    userId: v.string(),
+    startedAt: v.number(),
+    finishedAt: v.number(),
+    durationMs: v.number(),
+
+    searchCalls: v.number(),
+    fetchCalls: v.number(),
+    investigateCalls: v.number(),
+    rowsInserted: v.number(),
+
+    tokensInput: v.number(),
+    tokensOutput: v.number(),
+
+    orchestratorTokensInput: v.number(),
+    orchestratorTokensOutput: v.number(),
+    orchestratorSteps: v.number(),
+    investigateTokensInput: v.number(),
+    investigateTokensOutput: v.number(),
+    investigateSteps: v.number(),
+    investigateRuns: v.number(),
+
+    status: v.union(v.literal("success"), v.literal("error")),
+    error: v.optional(v.string()),
+    isBenchmark: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.insert("populateRuns", args);
+  },
+});
+
+/**
+ * Fetch a single run by its workflowRunId. Used by the benchmark runner to
+ * retrieve metrics after a workflow completes.
+ */
+export const getByWorkflowRunId = internalQuery({
+  args: { workflowRunId: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("populateRuns")
+      .withIndex("by_workflow_run", (q) =>
+        q.eq("workflowRunId", args.workflowRunId),
+      )
+      .first();
+  },
+});
+
+/**
+ * List all runs for a dataset, newest first.
+ */
+export const listByDataset = internalQuery({
+  args: { datasetId: v.string() },
+  handler: async (ctx, args) => {
+    const runs = await ctx.db
+      .query("populateRuns")
+      .withIndex("by_dataset", (q) => q.eq("datasetId", args.datasetId))
+      .collect();
+    return runs.sort((a, b) => b.startedAt - a.startedAt);
+  },
+});
+
+/**
+ * List all runs for a user, newest first.
+ */
+export const listByUser = internalQuery({
+  args: { userId: v.string() },
+  handler: async (ctx, args) => {
+    const runs = await ctx.db
+      .query("populateRuns")
+      .withIndex("by_user", (q) => q.eq("userId", args.userId))
+      .collect();
+    return runs.sort((a, b) => b.startedAt - a.startedAt);
+  },
+});

--- a/frontend/convex/runStats.ts
+++ b/frontend/convex/runStats.ts
@@ -35,6 +35,10 @@ export const insert = internalMutation({
     status: v.union(v.literal("success"), v.literal("error")),
     error: v.optional(v.string()),
     isBenchmark: v.optional(v.boolean()),
+    workflowType: v.optional(
+      v.union(v.literal("populate"), v.literal("update"))
+    ),
+    rowsUpdated: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     if (args.status === "success" && args.error) {

--- a/frontend/convex/runStats.ts
+++ b/frontend/convex/runStats.ts
@@ -38,12 +38,12 @@ export const insert = internalMutation({
   },
   handler: async (ctx, args) => {
     if (args.status === "success" && args.error) {
-      throw new Error("populateRuns.insert: error must be absent on a successful run");
+      throw new Error("runStats.insert: error must be absent on a successful run");
     }
     if (args.status === "error" && !args.error) {
-      throw new Error("populateRuns.insert: error message is required on a failed run");
+      throw new Error("runStats.insert: error message is required on a failed run");
     }
-    await ctx.db.insert("populateRuns", args);
+    await ctx.db.insert("runStats", args);
   },
 });
 
@@ -55,7 +55,7 @@ export const getByWorkflowRunId = internalQuery({
   args: { workflowRunId: v.string() },
   handler: async (ctx, args) => {
     return await ctx.db
-      .query("populateRuns")
+      .query("runStats")
       .withIndex("by_workflow_run", (q) =>
         q.eq("workflowRunId", args.workflowRunId),
       )
@@ -70,7 +70,7 @@ export const listByDataset = internalQuery({
   args: { datasetId: v.string() },
   handler: async (ctx, args) => {
     const runs = await ctx.db
-      .query("populateRuns")
+      .query("runStats")
       .withIndex("by_dataset", (q) => q.eq("datasetId", args.datasetId))
       .collect();
     return runs.sort((a, b) => b.startedAt - a.startedAt);
@@ -84,7 +84,7 @@ export const listByUser = internalQuery({
   args: { userId: v.string() },
   handler: async (ctx, args) => {
     const runs = await ctx.db
-      .query("populateRuns")
+      .query("runStats")
       .withIndex("by_user", (q) => q.eq("userId", args.userId))
       .collect();
     return runs.sort((a, b) => b.startedAt - a.startedAt);

--- a/frontend/convex/runStats.ts
+++ b/frontend/convex/runStats.ts
@@ -69,6 +69,9 @@ export const getByWorkflowRunId = internalQuery({
 
 /**
  * List all runs for a dataset, newest first.
+ * TODO: paginate — .collect() loads all docs into memory and will degrade
+ * as run history grows. Add cursor-based pagination when this is exposed
+ * to the frontend or run counts become large.
  */
 export const listByDataset = internalQuery({
   args: { datasetId: v.string() },
@@ -83,6 +86,7 @@ export const listByDataset = internalQuery({
 
 /**
  * List all runs for a user, newest first.
+ * TODO: paginate — same concern as listByDataset above.
  */
 export const listByUser = internalQuery({
   args: { userId: v.string() },

--- a/frontend/convex/schema.ts
+++ b/frontend/convex/schema.ts
@@ -142,6 +142,15 @@ export default defineSchema({
 
     // True when written by the benchmark runner rather than a real user session.
     isBenchmark: v.optional(v.boolean()),
+
+    // "populate" = initial fill workflow; "update" = refresh/update workflow.
+    // Optional for backward compat with rows written before this field existed
+    // (treat missing as "populate").
+    workflowType: v.optional(
+      v.union(v.literal("populate"), v.literal("update"))
+    ),
+    // Rows successfully updated by the refresh agent (update workflow only).
+    rowsUpdated: v.optional(v.number()),
   })
     .index("by_dataset", ["datasetId"])
     .index("by_user", ["userId"])

--- a/frontend/convex/schema.ts
+++ b/frontend/convex/schema.ts
@@ -104,7 +104,7 @@ export default defineSchema({
   // (success or error) by the backend agent runner — never by the frontend.
   // Tracks tool-call counts, token usage, and timing so runs can be
   // compared across datasets, users, and benchmark sessions.
-  populateRuns: defineTable({
+  runStats: defineTable({
     workflowRunId: v.string(),
     // v.string() (not v.id) so benchmark runs can use synthetic dataset ids
     // without needing a real Convex dataset document.

--- a/frontend/convex/schema.ts
+++ b/frontend/convex/schema.ts
@@ -99,4 +99,47 @@ export default defineSchema({
     // "before current period", which forces a reset on next write.
     periodStart: v.optional(v.number()),
   }).index("by_user", ["userId"]),
+
+  // One row per populate workflow run. Written once at the end of each run
+  // (success or error) by the backend agent runner — never by the frontend.
+  // Tracks tool-call counts, token usage, and timing so runs can be
+  // compared across datasets, users, and benchmark sessions.
+  populateRuns: defineTable({
+    workflowRunId: v.string(),
+    // v.string() (not v.id) so benchmark runs can use synthetic dataset ids
+    // without needing a real Convex dataset document.
+    datasetId: v.string(),
+    userId: v.string(),
+    startedAt: v.number(),
+    finishedAt: v.number(),
+    durationMs: v.number(),
+
+    // Tool-call counts
+    searchCalls: v.number(),
+    fetchCalls: v.number(),
+    investigateCalls: v.number(),
+    rowsInserted: v.number(),
+
+    // Token usage — totals across all agent invocations in this run
+    tokensInput: v.number(),
+    tokensOutput: v.number(),
+
+    // Breakdown by agent tier
+    orchestratorTokensInput: v.number(),
+    orchestratorTokensOutput: v.number(),
+    orchestratorSteps: v.number(),
+    investigateTokensInput: v.number(),
+    investigateTokensOutput: v.number(),
+    investigateSteps: v.number(),
+    investigateRuns: v.number(),
+
+    status: v.union(v.literal("success"), v.literal("error")),
+    error: v.optional(v.string()),
+
+    // True when written by the benchmark runner rather than a real user session.
+    isBenchmark: v.optional(v.boolean()),
+  })
+    .index("by_dataset", ["datasetId"])
+    .index("by_user", ["userId"])
+    .index("by_workflow_run", ["workflowRunId"]),
 });


### PR DESCRIPTION
## Summary

- Adds a `populateRuns` Convex table that records one metrics record per populate workflow run (both real user sessions and future benchmark runs)
- Instruments the agent pipeline with a `RunMetrics` object threaded through all tool factories — tracks search/fetch/investigate call counts, LLM token usage (split by orchestrator vs investigate tier), rows inserted, and wall-clock duration
- The Convex write fires after `agent.generate()` returns in a `finally` block as a fire-and-forget — zero impact on agent performance or user-facing latency
- Switches both agents from `moonshotai/kimi-k2-0905` to `deepseek/deepseek-v4-pro`
- Fixes token tracking to use AI SDK v6 field names (`inputTokens`/`outputTokens`) instead of the old v3 names (`promptTokens`/`completionTokens`)

## New files

- `backend/src/mastra/run-metrics.ts` — `RunMetrics` class (counters + token aggregation helpers)
- `backend/src/mastra/save-run-metrics.ts` — writes a completed run record to Convex
- `frontend/convex/populateRuns.ts` — `insert` mutation + `getByWorkflowRunId`, `listByDataset`, `listByUser` queries

## Schema change

Adds `populateRuns` table to `frontend/convex/schema.ts`. Requires `make convex-push` after merging (or `make dev` on first startup).

## Test plan

- [ ] Run `make dev` after merging to deploy the schema change
- [ ] Trigger a populate run from the app UI
- [ ] Confirm a record appears in Convex dashboard → Data → `populateRuns` with non-zero `tokensInput`, `tokensOutput`, `searchCalls`, `fetchCalls`
- [ ] Confirm `status` is `"success"` and `rowsInserted` matches the actual row count

🤖 Generated with [Claude Code](https://claude.com/claude-code)