### PR TITLE
Sort user's datasets newest-first on dashboard

### DIFF
--- a/frontend/convex/datasets.ts
+++ b/frontend/convex/datasets.ts
@@ -66,6 +66,7 @@ export const listMine = query({
     const datasets = await ctx.db
       .query("datasets")
       .withIndex("by_owner", (q) => q.eq("ownerId", identity.subject))
+      .order("desc")
       .collect();
 
     return Promise.all(datasets.map((ds) => attachPreview(ctx, ds)));


### PR DESCRIPTION
listMine was using the default ascending order of the by_owner index, showing oldest datasets at the top. Adding .order("desc") mirrors the existing behaviour of listPublic and shows the most recently created dataset first.