### PR TITLE
Add dataset refresh cadence scheduling

### DIFF
--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -11,10 +11,17 @@ function required(name: string): string {
   return value;
 }
 
+function numberFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
 export const env = {
   CLIENT_ORIGIN: process.env.CLIENT_ORIGIN || "http://localhost:3500",
   CONVEX_URL: required("CONVEX_URL"),
-  PORT: Number(process.env.PORT || "3501"),
+  PORT: numberFromEnv("PORT", 3501),
 
   // Used by ./convex.ts to call internal Convex functions (e.g. agent-driven
   // row inserts). Optional today because no scheduled jobs run yet; required
@@ -59,13 +66,16 @@ export const env = {
 
   REFRESH_SCHEDULER_ENABLED:
     process.env.REFRESH_SCHEDULER_ENABLED !== "false",
-  REFRESH_SCHEDULER_POLL_MS: Number(
-    process.env.REFRESH_SCHEDULER_POLL_MS || 60_000,
+  REFRESH_SCHEDULER_POLL_MS: numberFromEnv(
+    "REFRESH_SCHEDULER_POLL_MS",
+    60_000,
   ),
-  REFRESH_SCHEDULER_BATCH_SIZE: Number(
-    process.env.REFRESH_SCHEDULER_BATCH_SIZE || 5,
+  REFRESH_SCHEDULER_BATCH_SIZE: numberFromEnv(
+    "REFRESH_SCHEDULER_BATCH_SIZE",
+    5,
   ),
-  REFRESH_SCHEDULER_STALE_AFTER_MS: Number(
-    process.env.REFRESH_SCHEDULER_STALE_AFTER_MS || 6 * 60 * 60 * 1000,
+  REFRESH_SCHEDULER_STALE_AFTER_MS: numberFromEnv(
+    "REFRESH_SCHEDULER_STALE_AFTER_MS",
+    6 * 60 * 60 * 1000,
   ),
 };

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -56,4 +56,16 @@ export const env = {
     process.env.POSTHOG_HOST ||
     process.env.NEXT_PUBLIC_POSTHOG_HOST ||
     "https://us.i.posthog.com",
+
+  REFRESH_SCHEDULER_ENABLED:
+    process.env.REFRESH_SCHEDULER_ENABLED !== "false",
+  REFRESH_SCHEDULER_POLL_MS: Number(
+    process.env.REFRESH_SCHEDULER_POLL_MS || 60_000,
+  ),
+  REFRESH_SCHEDULER_BATCH_SIZE: Number(
+    process.env.REFRESH_SCHEDULER_BATCH_SIZE || 5,
+  ),
+  REFRESH_SCHEDULER_STALE_AFTER_MS: Number(
+    process.env.REFRESH_SCHEDULER_STALE_AFTER_MS || 6 * 60 * 60 * 1000,
+  ),
 };

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -248,6 +248,73 @@ async function runUpdateWorkflowInBackground({
   }
 }
 
+async function runScheduledUpdateWorkflowInBackground({
+  input,
+  run,
+  authorizedUserId,
+  logger,
+  modelConfig,
+}: {
+  input: DatasetContext;
+  run: UpdateWorkflowRun;
+  authorizedUserId: string;
+  logger: FastifyBaseLogger;
+  modelConfig: {
+    schemaInference: string;
+    populateOrchestrator: string;
+    investigateSubagent: string;
+  };
+}): Promise<void> {
+  const datasetId = input.datasetId;
+
+  try {
+    const result = await run.start({
+      inputData: {
+        ...input,
+        authContext: {
+          authorizedUserId,
+          workflowRunId: run.runId,
+          modelConfig,
+        },
+      },
+    });
+
+    logger.info(
+      {
+        datasetId,
+        workflowStatus: result.status,
+        steps: JSON.stringify(result.steps).slice(0, 2000),
+      },
+      "Scheduled update workflow completed",
+    );
+
+    if (result.status !== "success") {
+      throw new Error(`Workflow ended with status: ${result.status}`);
+    }
+
+    await convex.mutation(internal.datasets.completeScheduledRefreshInternal, {
+      id: datasetId,
+      now: Date.now(),
+    });
+  } catch (err) {
+    const lastStatusError = statusErrorMessage(err);
+    logger.error({ err, datasetId }, "Scheduled update workflow failed");
+
+    try {
+      await convex.mutation(internal.datasets.failScheduledRefreshInternal, {
+        id: datasetId,
+        now: Date.now(),
+        lastStatusError,
+      });
+    } catch (statusErr) {
+      logger.error(
+        { err: statusErr, datasetId },
+        "Failed to record scheduled refresh failure",
+      );
+    }
+  }
+}
+
 async function runPopulateWorkflowInBackground({
   input,
   run,
@@ -350,6 +417,110 @@ async function runPopulateWorkflowInBackground({
   }
 }
 
+async function backfillDatasetRefreshSettings(
+  logger: FastifyBaseLogger,
+): Promise<void> {
+  try {
+    const result = await convex.mutation(
+      internal.datasets.backfillRefreshSettings,
+      { defaultCadence: "daily" },
+    );
+    logger.info(result, "Dataset refresh settings backfill complete");
+  } catch (err) {
+    logger.error({ err }, "Dataset refresh settings backfill failed");
+  }
+}
+
+function startLocalRefreshScheduler(
+  logger: FastifyBaseLogger,
+): ReturnType<typeof setInterval> | null {
+  if (!env.REFRESH_SCHEDULER_ENABLED) {
+    logger.info("Dataset refresh scheduler disabled");
+    return null;
+  }
+
+  let ticking = false;
+
+  async function tick(): Promise<void> {
+    if (ticking) return;
+    ticking = true;
+
+    try {
+      const now = Date.now();
+      const dueDatasets = await convex.query(
+        internal.datasets.listDueForRefreshInternal,
+        {
+          now,
+          limit: env.REFRESH_SCHEDULER_BATCH_SIZE,
+        },
+      );
+
+      for (const dueDataset of dueDatasets as Array<{ _id: string }>) {
+        let run: UpdateWorkflowRun;
+        try {
+          run = await updateWorkflow.createRun();
+        } catch (runErr) {
+          logger.error(runErr, "Failed to create scheduled update workflow run");
+          continue;
+        }
+
+        const claim = await convex.mutation(
+          internal.datasets.claimScheduledRefreshInternal,
+          {
+            id: dueDataset._id,
+            now: Date.now(),
+            runId: run.runId,
+            staleAfterMs: env.REFRESH_SCHEDULER_STALE_AFTER_MS,
+          },
+        );
+
+        if (claim.outcome !== "started") {
+          logger.debug(
+            { datasetId: dueDataset._id, outcome: claim.outcome },
+            "Skipped scheduled refresh claim",
+          );
+          continue;
+        }
+
+        const dataset = claim.dataset;
+        const { getModelConfig } = await import("./config/models.js");
+        const modelConfig = await getModelConfig(dataset.ownerId);
+
+        void runScheduledUpdateWorkflowInBackground({
+          input: {
+            datasetId: dataset.datasetId,
+            datasetName: dataset.datasetName,
+            description: dataset.description,
+            columns: dataset.columns,
+          },
+          run,
+          authorizedUserId: dataset.ownerId,
+          logger,
+          modelConfig,
+        });
+      }
+    } catch (err) {
+      logger.error({ err }, "Dataset refresh scheduler tick failed");
+    } finally {
+      ticking = false;
+    }
+  }
+
+  void tick();
+  const interval = setInterval(() => {
+    void tick();
+  }, env.REFRESH_SCHEDULER_POLL_MS);
+  logger.info(
+    {
+      pollMs: env.REFRESH_SCHEDULER_POLL_MS,
+      batchSize: env.REFRESH_SCHEDULER_BATCH_SIZE,
+      staleAfterMs: env.REFRESH_SCHEDULER_STALE_AFTER_MS,
+    },
+    "Dataset refresh scheduler started",
+  );
+  return interval;
+}
+
 const fastify = Fastify({ logger: true });
 
 await fastify.register(fastifyCors, {
@@ -365,9 +536,13 @@ await fastify.register(fastifyCors, {
 // protected routes — see the example block below.
 await fastify.register(clerkAuthPlugin);
 
+void backfillDatasetRefreshSettings(fastify.log);
+const refreshScheduler = startLocalRefreshScheduler(fastify.log);
+
 // Flush queued PostHog events on graceful shutdown so a SIGTERM mid-flight
 // doesn't drop the dataset_ready_email_sent capture from the last request.
 fastify.addHook("onClose", async () => {
+  if (refreshScheduler) clearInterval(refreshScheduler);
   await shutdownAnalytics();
 });
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -428,6 +428,7 @@ async function backfillDatasetRefreshSettings(
     logger.info(result, "Dataset refresh settings backfill complete");
   } catch (err) {
     logger.error({ err }, "Dataset refresh settings backfill failed");
+    throw err;
   }
 }
 
@@ -536,7 +537,7 @@ await fastify.register(fastifyCors, {
 // protected routes — see the example block below.
 await fastify.register(clerkAuthPlugin);
 
-void backfillDatasetRefreshSettings(fastify.log);
+await backfillDatasetRefreshSettings(fastify.log);
 const refreshScheduler = startLocalRefreshScheduler(fastify.log);
 
 // Flush queued PostHog events on graceful shutdown so a SIGTERM mid-flight

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -43,6 +43,10 @@ services:
       # When unset, backend analytics module no-ops.
       POSTHOG_KEY: ${NEXT_PUBLIC_POSTHOG_KEY:-}
       POSTHOG_HOST: ${NEXT_PUBLIC_POSTHOG_HOST:-https://us.i.posthog.com}
+      REFRESH_SCHEDULER_ENABLED: ${REFRESH_SCHEDULER_ENABLED:-true}
+      REFRESH_SCHEDULER_POLL_MS: ${REFRESH_SCHEDULER_POLL_MS:-60000}
+      REFRESH_SCHEDULER_BATCH_SIZE: ${REFRESH_SCHEDULER_BATCH_SIZE:-5}
+      REFRESH_SCHEDULER_STALE_AFTER_MS: ${REFRESH_SCHEDULER_STALE_AFTER_MS:-21600000}
     depends_on:
       convex:
         condition: service_healthy

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -6,7 +6,6 @@ import { useRouter } from "next/navigation";
 import { useQuery, useConvexAuth } from "convex/react";
 import { useUser, useClerk } from "@clerk/nextjs";
 import { api } from "@/convex/_generated/api";
-import type { UserResource } from "@clerk/types";
 import {
   DatasetCard,
   type DatasetCardData,
@@ -14,6 +13,13 @@ import {
 import { useTheme } from "@/components/ThemeToggle";
 import { QuotaBadge } from "@/components/QuotaBadge";
 import { EVENTS, track } from "@/lib/analytics";
+
+type ProfileUser = {
+  fullName?: string | null;
+  firstName?: string | null;
+  primaryEmailAddress?: { emailAddress?: string | null } | null;
+  imageUrl?: string | null;
+};
 
 export default function DashboardPage() {
   const { isAuthenticated, isLoading } = useConvexAuth();
@@ -252,7 +258,7 @@ function ProfileMenu({
   user,
   onSignOut,
 }: {
-  user: UserResource | null | undefined;
+  user: ProfileUser | null | undefined;
   onSignOut: () => void;
 }) {
   const [open, setOpen] = useState(false);

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -13,13 +13,7 @@ import {
 import { useTheme } from "@/components/ThemeToggle";
 import { QuotaBadge } from "@/components/QuotaBadge";
 import { EVENTS, track } from "@/lib/analytics";
-
-type ProfileUser = {
-  fullName?: string | null;
-  firstName?: string | null;
-  primaryEmailAddress?: { emailAddress?: string | null } | null;
-  imageUrl?: string | null;
-};
+import type { ProfileUser } from "@/lib/profile-user";
 
 export default function DashboardPage() {
   const { isAuthenticated, isLoading } = useConvexAuth();

--- a/frontend/app/dataset/[id]/page.tsx
+++ b/frontend/app/dataset/[id]/page.tsx
@@ -3,9 +3,8 @@
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useQuery, useConvexAuth } from "convex/react";
+import { useMutation, useQuery, useConvexAuth } from "convex/react";
 import { useAuth, useUser, useClerk } from "@clerk/nextjs";
-import type { UserResource } from "@clerk/types";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import { DatasetTable } from "@/components/table";
@@ -15,6 +14,18 @@ import { StatusBadge } from "@/components/dataset/StatusBadge";
 import { downloadCSV, downloadXLSX } from "@/lib/export";
 import { populate, update } from "@/lib/backend";
 import { EVENTS, captureException, track } from "@/lib/analytics";
+import {
+  REFRESH_CADENCE_OPTIONS,
+  refreshCadenceLabel,
+  type RefreshCadence,
+} from "@/lib/refresh-cadence";
+
+type ProfileUser = {
+  fullName?: string | null;
+  firstName?: string | null;
+  primaryEmailAddress?: { emailAddress?: string | null } | null;
+  imageUrl?: string | null;
+};
 
 export default function DatasetPage() {
   const params = useParams();
@@ -28,6 +39,7 @@ export default function DatasetPage() {
   const [exportOpen, setExportOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [confirmPopulate, setConfirmPopulate] = useState(false);
+  const [savingRefreshCadence, setSavingRefreshCadence] = useState(false);
 
   const datasetId = params.id as Id<"datasets">;
   const dataset = useQuery(
@@ -38,6 +50,7 @@ export default function DatasetPage() {
     api.datasetRows.listByDataset,
     authLoading ? "skip" : { datasetId },
   );
+  const updateRefreshSettings = useMutation(api.datasets.updateRefreshSettings);
 
   const rowIds = useMemo(() => (rows ?? []).map((r) => r._id), [rows]);
   const selection = useSelection(rowIds);
@@ -154,7 +167,7 @@ export default function DatasetPage() {
       track(EVENTS.DATASET_UPDATE_STARTED, {
         datasetId: dataset._id,
         column_count: dataset.columns.length,
-        row_count: selectedRowIds?.length ?? rows.length,
+        row_count: selectedRowIds?.length ?? rows?.length ?? 0,
         selective: selectedCount > 0,
         runId: result.runId,
       });
@@ -166,6 +179,25 @@ export default function DatasetPage() {
       });
     } finally {
       setUpdating(false);
+    }
+  }
+
+  async function handleRefreshCadenceChange(refreshCadence: RefreshCadence) {
+    if (!dataset || savingRefreshCadence || userId !== dataset.ownerId) return;
+    setSavingRefreshCadence(true);
+    try {
+      await updateRefreshSettings({
+        id: dataset._id,
+        refreshCadence,
+      });
+    } catch (err) {
+      console.error("[refresh cadence] failed", err);
+      captureException(err, {
+        operation: "dataset_refresh_cadence_update",
+        datasetId: dataset._id,
+      });
+    } finally {
+      setSavingRefreshCadence(false);
     }
   }
 
@@ -183,6 +215,12 @@ export default function DatasetPage() {
 
   const exportDisabled = exporting !== null || rows.length === 0;
   const isDatasetBusy = dataset.status === "building" || dataset.status === "updating";
+  const isOwner = userId === dataset.ownerId;
+  const displayDataset = {
+    ...dataset,
+    refreshCadence: dataset.refreshCadence ?? "daily",
+    refreshEnabled: dataset.refreshEnabled ?? true,
+  };
   const updateDisabled = updating || isDatasetBusy;
   const populateDisabled = populating || isDatasetBusy;
   const updateLabel = dataset.status === "updating"
@@ -239,11 +277,13 @@ export default function DatasetPage() {
             open={settingsOpen}
             onToggle={() => setSettingsOpen((o) => !o)}
             onClose={() => setSettingsOpen(false)}
-            cadence={dataset.cadence}
+            refreshCadence={displayDataset.refreshCadence}
+            refreshCadenceDisabled={!isOwner || savingRefreshCadence}
             updateLabel={updateLabel}
             updateDisabled={updateDisabled}
             populateLabel={populateLabel}
             populateDisabled={populateDisabled}
+            onRefreshCadenceChange={handleRefreshCadenceChange}
             onUpdate={() => { setSettingsOpen(false); handleUpdate(); }}
             onPopulate={() => {
               setSettingsOpen(false);
@@ -288,7 +328,7 @@ export default function DatasetPage() {
       </div>
 
       <DatasetTable
-        dataset={dataset}
+        dataset={displayDataset}
         rows={rows}
         datasetId={datasetId}
         selection={selection}
@@ -395,22 +435,26 @@ function SettingsDropdown({
   open,
   onToggle,
   onClose,
-  cadence,
+  refreshCadence,
+  refreshCadenceDisabled,
   updateLabel,
   updateDisabled,
   populateLabel,
   populateDisabled,
+  onRefreshCadenceChange,
   onUpdate,
   onPopulate,
 }: {
   open: boolean;
   onToggle: () => void;
   onClose: () => void;
-  cadence: string;
+  refreshCadence: RefreshCadence;
+  refreshCadenceDisabled: boolean;
   updateLabel: string;
   updateDisabled: boolean;
   populateLabel: string;
   populateDisabled: boolean;
+  onRefreshCadenceChange: (refreshCadence: RefreshCadence) => void;
   onUpdate: () => void;
   onPopulate: () => void;
 }) {
@@ -437,7 +481,7 @@ function SettingsDropdown({
       </button>
 
       {open && (
-        <div className="absolute right-0 top-full mt-1.5 w-48 rounded-xl border border-border bg-surface shadow-xl ring-1 ring-black/[0.04] z-50 overflow-hidden">
+        <div className="absolute right-0 top-full mt-1.5 w-56 rounded-xl border border-border bg-surface shadow-xl ring-1 ring-black/[0.04] z-50 overflow-hidden">
           <div className="p-1">
             <button
               onClick={onUpdate}
@@ -456,8 +500,29 @@ function SettingsDropdown({
               {populateLabel}
             </button>
           </div>
-          <div className="border-t border-border px-3 py-1.5">
-            <span className="text-[11px] italic text-muted">{cadence}</span>
+          <div className="border-t border-border p-1">
+            <div className="px-2 py-1 text-[11px] font-medium text-muted">
+              Refresh cadence
+            </div>
+            {REFRESH_CADENCE_OPTIONS.map((option) => {
+              const selected = refreshCadence === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => onRefreshCadenceChange(option.value)}
+                  disabled={refreshCadenceDisabled || selected}
+                  className="w-full flex items-center justify-between gap-2 px-2 py-1.5 rounded-lg text-xs text-foreground hover:bg-foreground/[0.05] transition-colors disabled:cursor-default disabled:opacity-60"
+                >
+                  <span>{refreshCadenceLabel(option.value)}</span>
+                  {selected && (
+                    <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                      <polyline points="20 6 9 17 4 12" />
+                    </svg>
+                  )}
+                </button>
+              );
+            })}
           </div>
         </div>
       )}
@@ -473,7 +538,7 @@ function DatasetProfileMenu({
   user,
   onSignOut,
 }: {
-  user: UserResource | null | undefined;
+  user: ProfileUser | null | undefined;
   onSignOut: () => void;
 }) {
   const [open, setOpen] = useState(false);

--- a/frontend/app/dataset/[id]/page.tsx
+++ b/frontend/app/dataset/[id]/page.tsx
@@ -19,13 +19,7 @@ import {
   refreshCadenceLabel,
   type RefreshCadence,
 } from "@/lib/refresh-cadence";
-
-type ProfileUser = {
-  fullName?: string | null;
-  firstName?: string | null;
-  primaryEmailAddress?: { emailAddress?: string | null } | null;
-  imageUrl?: string | null;
-};
+import type { ProfileUser } from "@/lib/profile-user";
 
 export default function DatasetPage() {
   const params = useParams();

--- a/frontend/app/dataset/new/page.tsx
+++ b/frontend/app/dataset/new/page.tsx
@@ -8,6 +8,10 @@ import { useMutation, useConvexAuth } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { EVENTS, track } from "@/lib/analytics";
 import { inferSchema, type InferredColumn } from "@/lib/backend";
+import {
+  REFRESH_CADENCE_OPTIONS,
+  type RefreshCadence,
+} from "@/lib/refresh-cadence";
 
 
 type ColumnType = "text" | "number" | "boolean" | "url" | "date";
@@ -20,24 +24,7 @@ interface ProposedColumn {
   isPrimaryKey: boolean;
 }
 
-type Cadence = "30m" | "6h" | "12h" | "daily" | "weekly";
 type Step = "describe" | "generating" | "review";
-
-const CADENCE_OPTIONS: { value: Cadence; label: string }[] = [
-  { value: "30m", label: "Every 30 min" },
-  { value: "6h", label: "Every 6 hours" },
-  { value: "12h", label: "Every 12 hours" },
-  { value: "daily", label: "Daily" },
-  { value: "weekly", label: "Weekly" },
-];
-
-const CADENCE_LABELS: Record<Cadence, string> = {
-  "30m": "Every 30 min",
-  "6h": "Every 6 hours",
-  "12h": "Every 12 hours",
-  daily: "Daily",
-  weekly: "Weekly",
-};
 
 const COLUMN_TYPES: { value: ColumnType; label: string; icon: string }[] = [
   { value: "text", label: "Text", icon: "≡" },
@@ -93,7 +80,7 @@ export default function NewDatasetPage() {
 
   const [step, setStep] = useState<Step>("describe");
   const [prompt, setPrompt] = useState("");
-  const [cadence, setCadence] = useState<Cadence>("daily");
+  const [refreshCadence, setRefreshCadence] = useState<RefreshCadence>("daily");
   const [columns, setColumns] = useState<ProposedColumn[]>([]);
   const [datasetName, setDatasetName] = useState("");
   const [isCreating, setIsCreating] = useState(false);
@@ -183,7 +170,7 @@ export default function NewDatasetPage() {
       datasetId = await createDataset({
         name: datasetName,
         description: prompt,
-        cadence: CADENCE_LABELS[cadence],
+        refreshCadence,
         columns: columns.map((c) => ({
           name: c.name,
           type: c.type,
@@ -203,7 +190,13 @@ export default function NewDatasetPage() {
       setIsCreating(false);
       return;
     }
-    try { track(EVENTS.DATASET_CREATED, { datasetId, column_count: columns.length, cadence: CADENCE_LABELS[cadence] }); } catch {}
+    try {
+      track(EVENTS.DATASET_CREATED, {
+        datasetId,
+        column_count: columns.length,
+        refreshCadence,
+      });
+    } catch {}
     router.push(`/dataset/${datasetId}`);
   }
 
@@ -312,12 +305,12 @@ export default function NewDatasetPage() {
                 <div className="space-y-2">
                   <label className="block text-sm font-medium">Update frequency</label>
                   <div className="flex flex-wrap gap-2">
-                    {CADENCE_OPTIONS.map((opt) => (
+                    {REFRESH_CADENCE_OPTIONS.map((opt) => (
                       <button
                         key={opt.value}
-                        onClick={() => setCadence(opt.value)}
+                        onClick={() => setRefreshCadence(opt.value)}
                         className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${
-                          cadence === opt.value
+                          refreshCadence === opt.value
                             ? "border-foreground bg-foreground text-accent-text"
                             : "border-border bg-surface text-foreground hover:border-foreground/30"
                         }`}

--- a/frontend/components/dataset/DatasetCard.tsx
+++ b/frontend/components/dataset/DatasetCard.tsx
@@ -1,13 +1,14 @@
 import Link from "next/link";
 import { StatusBadge, type DatasetStatus } from "./StatusBadge";
 import { MiniTable } from "./MiniTable";
+import { refreshCadenceLabel, type RefreshCadence } from "@/lib/refresh-cadence";
 
 export interface DatasetCardData {
   _id: string;
   name: string;
   description: string;
   status: DatasetStatus;
-  cadence: string;
+  refreshCadence: RefreshCadence;
   columns: { name: string; type: string }[];
   // Preview is capped at 5 rows for the mini-table. The total row count
   // is on `rowCount` (denormalized counter maintained by the row write
@@ -51,7 +52,9 @@ export function DatasetCard({ dataset }: { dataset: DatasetCardData }) {
           <div className="px-5 py-3 border-t border-border flex items-center justify-between">
             <div className="flex items-center gap-3">
               <StatusBadge status={dataset.status} />
-              <span className="text-[11px] text-muted">{dataset.cadence}</span>
+              <span className="text-[11px] text-muted">
+                {refreshCadenceLabel(dataset.refreshCadence)}
+              </span>
             </div>
             <span className="text-[11px] text-muted">
               {dataset.rowCount ?? 0} rows

--- a/frontend/components/table/types.ts
+++ b/frontend/components/table/types.ts
@@ -1,3 +1,5 @@
+import type { RefreshCadence } from "@/lib/refresh-cadence";
+
 export type ColumnType = "text" | "number" | "boolean" | "url" | "date";
 
 export interface DatasetColumn {
@@ -13,7 +15,12 @@ export interface DatasetMeta {
   description: string;
   status: "live" | "paused" | "building" | "updating" | "failed";
   lastStatusError?: string;
-  cadence: string;
+  refreshCadence: RefreshCadence;
+  refreshEnabled: boolean;
+  nextRefreshAt?: number;
+  lastRefreshAt?: number;
+  lastRefreshStartedAt?: number;
+  lastRefreshRunId?: string;
   columns: DatasetColumn[];
 }
 

--- a/frontend/convex/datasets.ts
+++ b/frontend/convex/datasets.ts
@@ -14,6 +14,11 @@ import {
   requireIdentity,
 } from "./lib/authz.js";
 import { requireQuotaRemaining } from "./lib/quota.js";
+import {
+  nextRefreshAtFor,
+  refreshCadenceValidator,
+  type RefreshCadence,
+} from "./lib/refreshScheduling.js";
 
 const columnValidator = v.object({
   name: v.string(),
@@ -27,30 +32,6 @@ const columnValidator = v.object({
   description: v.optional(v.string()),
   isPrimaryKey: v.optional(v.boolean()),
 });
-
-const refreshCadenceValidator = v.union(
-  v.literal("manual"),
-  v.literal("30m"),
-  v.literal("6h"),
-  v.literal("12h"),
-  v.literal("daily"),
-  v.literal("weekly"),
-);
-
-type RefreshCadence = "manual" | "30m" | "6h" | "12h" | "daily" | "weekly";
-
-const REFRESH_INTERVAL_MS: Record<Exclude<RefreshCadence, "manual">, number> = {
-  "30m": 30 * 60 * 1000,
-  "6h": 6 * 60 * 60 * 1000,
-  "12h": 12 * 60 * 60 * 1000,
-  daily: 24 * 60 * 60 * 1000,
-  weekly: 7 * 24 * 60 * 60 * 1000,
-};
-
-function nextRefreshAtFor(cadence: RefreshCadence, from: number): number | undefined {
-  if (cadence === "manual") return undefined;
-  return from + REFRESH_INTERVAL_MS[cadence];
-}
 
 function refreshCadenceFromLegacyLabel(
   legacyCadence: string | undefined,

--- a/frontend/convex/datasets.ts
+++ b/frontend/convex/datasets.ts
@@ -28,6 +28,58 @@ const columnValidator = v.object({
   isPrimaryKey: v.optional(v.boolean()),
 });
 
+const refreshCadenceValidator = v.union(
+  v.literal("manual"),
+  v.literal("30m"),
+  v.literal("6h"),
+  v.literal("12h"),
+  v.literal("daily"),
+  v.literal("weekly"),
+);
+
+type RefreshCadence = "manual" | "30m" | "6h" | "12h" | "daily" | "weekly";
+
+const REFRESH_INTERVAL_MS: Record<Exclude<RefreshCadence, "manual">, number> = {
+  "30m": 30 * 60 * 1000,
+  "6h": 6 * 60 * 60 * 1000,
+  "12h": 12 * 60 * 60 * 1000,
+  daily: 24 * 60 * 60 * 1000,
+  weekly: 7 * 24 * 60 * 60 * 1000,
+};
+
+function nextRefreshAtFor(cadence: RefreshCadence, from: number): number | undefined {
+  if (cadence === "manual") return undefined;
+  return from + REFRESH_INTERVAL_MS[cadence];
+}
+
+function refreshCadenceFromLegacyLabel(
+  legacyCadence: string | undefined,
+  fallback: RefreshCadence,
+): RefreshCadence {
+  const normalized = legacyCadence?.trim().toLowerCase();
+  switch (normalized) {
+    case "every 30 min":
+    case "every 30 mins":
+    case "every 30 minute":
+    case "every 30 minutes":
+      return "30m";
+    case "every 6 hour":
+    case "every 6 hours":
+      return "6h";
+    case "every 12 hour":
+    case "every 12 hours":
+      return "12h";
+    case "daily":
+      return "daily";
+    case "weekly":
+      return "weekly";
+    case "manual":
+      return "manual";
+    default:
+      return fallback;
+  }
+}
+
 const PREVIEW_ROW_COUNT = 5;
 
 async function attachPreview(ctx: QueryCtx, dataset: Doc<"datasets">) {
@@ -179,6 +231,111 @@ export const beginUpdateInternal = internalMutation({
   },
 });
 
+export const listDueForRefreshInternal = internalQuery({
+  args: {
+    now: v.number(),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("datasets")
+      .withIndex("by_refresh_due", (q) =>
+        q.eq("refreshEnabled", true).lte("nextRefreshAt", args.now),
+      )
+      .take(Math.min(args.limit ?? 10, 50));
+  },
+});
+
+export const claimScheduledRefreshInternal = internalMutation({
+  args: {
+    id: v.id("datasets"),
+    now: v.number(),
+    runId: v.string(),
+    staleAfterMs: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const dataset = await ctx.db.get(args.id);
+    if (!dataset) return { outcome: "not_found" as const };
+    if (!dataset.refreshEnabled || !dataset.refreshCadence || dataset.refreshCadence === "manual") {
+      return { outcome: "disabled" as const };
+    }
+    if (!dataset.nextRefreshAt || dataset.nextRefreshAt > args.now) {
+      return { outcome: "not_due" as const };
+    }
+    if (dataset.status === "building") {
+      return { outcome: "already_building" as const };
+    }
+    if (dataset.status === "updating") {
+      const staleScheduledRun =
+        dataset.lastRefreshStartedAt !== undefined &&
+        dataset.lastRefreshStartedAt + args.staleAfterMs <= args.now;
+      if (!staleScheduledRun) {
+        return { outcome: "already_updating" as const };
+      }
+    }
+
+    await ctx.db.patch(dataset._id, {
+      status: "updating",
+      lastStatusError: undefined,
+      lastRefreshStartedAt: args.now,
+      lastRefreshRunId: args.runId,
+    });
+
+    return {
+      outcome: "started" as const,
+      dataset: {
+        datasetId: dataset._id,
+        datasetName: dataset.name,
+        description: dataset.description,
+        columns: dataset.columns,
+        ownerId: dataset.ownerId,
+      },
+    };
+  },
+});
+
+export const completeScheduledRefreshInternal = internalMutation({
+  args: {
+    id: v.id("datasets"),
+    now: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const dataset = await ctx.db.get(args.id);
+    if (!dataset) return { outcome: "not_found" as const };
+
+    const refreshCadence = dataset.refreshCadence ?? "manual";
+    await ctx.db.patch(dataset._id, {
+      status: "live",
+      lastStatusError: undefined,
+      lastRefreshAt: args.now,
+      lastRefreshStartedAt: undefined,
+      nextRefreshAt: nextRefreshAtFor(refreshCadence, args.now),
+    });
+    return { outcome: "completed" as const };
+  },
+});
+
+export const failScheduledRefreshInternal = internalMutation({
+  args: {
+    id: v.id("datasets"),
+    now: v.number(),
+    lastStatusError: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const dataset = await ctx.db.get(args.id);
+    if (!dataset) return { outcome: "not_found" as const };
+
+    const refreshCadence = dataset.refreshCadence ?? "manual";
+    await ctx.db.patch(dataset._id, {
+      status: "failed",
+      lastStatusError: args.lastStatusError,
+      lastRefreshStartedAt: undefined,
+      nextRefreshAt: nextRefreshAtFor(refreshCadence, args.now),
+    });
+    return { outcome: "failed" as const };
+  },
+});
+
 /**
  * Admin-only status transition. Used by the backend orchestration layer
  * to move a dataset between lifecycle states after a workflow completes.
@@ -221,7 +378,7 @@ export const create = mutation({
   args: {
     name: v.string(),
     description: v.string(),
-    cadence: v.string(),
+    refreshCadence: refreshCadenceValidator,
     columns: v.array(columnValidator),
     retrievalStrategy: v.optional(
       v.union(
@@ -246,7 +403,60 @@ export const create = mutation({
       status: "paused",
       visibility: "private",
       rowCount: 0,
+      refreshEnabled: args.refreshCadence !== "manual",
+      nextRefreshAt: nextRefreshAtFor(args.refreshCadence, Date.now()),
     });
+  },
+});
+
+export const updateRefreshSettings = mutation({
+  args: {
+    id: v.id("datasets"),
+    refreshCadence: refreshCadenceValidator,
+  },
+  handler: async (ctx, args) => {
+    const dataset = await loadOwnedDataset(ctx, args.id);
+    const refreshEnabled = args.refreshCadence !== "manual";
+    await ctx.db.patch(dataset._id, {
+      refreshCadence: args.refreshCadence,
+      refreshEnabled,
+      nextRefreshAt: refreshEnabled
+        ? nextRefreshAtFor(args.refreshCadence, Date.now())
+        : undefined,
+    });
+  },
+});
+
+export const backfillRefreshSettings = internalMutation({
+  args: {
+    defaultCadence: v.optional(refreshCadenceValidator),
+  },
+  handler: async (ctx, args) => {
+    const defaultCadence = args.defaultCadence ?? "daily";
+    const now = Date.now();
+    const datasets = await ctx.db.query("datasets").collect();
+    let patched = 0;
+    let alreadyCurrent = 0;
+
+    for (const dataset of datasets) {
+      if (dataset.refreshCadence) {
+        alreadyCurrent++;
+        continue;
+      }
+
+      const refreshCadence = refreshCadenceFromLegacyLabel(
+        dataset.cadence,
+        defaultCadence,
+      );
+      await ctx.db.patch(dataset._id, {
+        refreshCadence,
+        refreshEnabled: refreshCadence !== "manual",
+        nextRefreshAt: nextRefreshAtFor(refreshCadence, now),
+      });
+      patched++;
+    }
+
+    return { patched, alreadyCurrent, total: datasets.length };
   },
 });
 

--- a/frontend/convex/lib/refreshScheduling.ts
+++ b/frontend/convex/lib/refreshScheduling.ts
@@ -1,0 +1,28 @@
+import { v } from "convex/values";
+
+export const refreshCadenceValidator = v.union(
+  v.literal("manual"),
+  v.literal("30m"),
+  v.literal("6h"),
+  v.literal("12h"),
+  v.literal("daily"),
+  v.literal("weekly"),
+);
+
+export type RefreshCadence = "manual" | "30m" | "6h" | "12h" | "daily" | "weekly";
+
+export const REFRESH_INTERVAL_MS: Record<Exclude<RefreshCadence, "manual">, number> = {
+  "30m": 30 * 60 * 1000,
+  "6h": 6 * 60 * 60 * 1000,
+  "12h": 12 * 60 * 60 * 1000,
+  daily: 24 * 60 * 60 * 1000,
+  weekly: 7 * 24 * 60 * 60 * 1000,
+};
+
+export function nextRefreshAtFor(
+  cadence: RefreshCadence,
+  from: number,
+): number | undefined {
+  if (cadence === "manual") return undefined;
+  return from + REFRESH_INTERVAL_MS[cadence];
+}

--- a/frontend/convex/modelConfig.ts
+++ b/frontend/convex/modelConfig.ts
@@ -51,7 +51,12 @@ export const upsert = mutation({
     } else {
       // First-time save — build insert object from provided fields only.
       // userId is always required and comes from the authenticated identity.
-      const insert: Record<string, string> = { userId: identity.subject };
+      const insert: {
+        userId: string;
+        schemaInference?: string;
+        populateOrchestrator?: string;
+        investigateSubagent?: string;
+      } = { userId: identity.subject };
       if (args.schemaInference !== undefined) insert.schemaInference = args.schemaInference;
       if (args.populateOrchestrator !== undefined) insert.populateOrchestrator = args.populateOrchestrator;
       if (args.investigateSubagent !== undefined) insert.investigateSubagent = args.investigateSubagent;

--- a/frontend/convex/publicSeed.ts
+++ b/frontend/convex/publicSeed.ts
@@ -1,5 +1,9 @@
 import { internalMutation } from "./_generated/server.js";
 import { v } from "convex/values";
+import {
+  nextRefreshAtFor,
+  type RefreshCadence,
+} from "./lib/refreshScheduling.js";
 
 /**
  * Idempotent loader for the curated public datasets that appear on the
@@ -43,20 +47,6 @@ import { v } from "convex/values";
 export const SYSTEM_OWNER_ID = "system";
 
 type ColType = "text" | "number" | "boolean" | "url" | "date";
-type RefreshCadence = "manual" | "30m" | "6h" | "12h" | "daily" | "weekly";
-
-const REFRESH_INTERVAL_MS: Record<Exclude<RefreshCadence, "manual">, number> = {
-  "30m": 30 * 60 * 1000,
-  "6h": 6 * 60 * 60 * 1000,
-  "12h": 12 * 60 * 60 * 1000,
-  daily: 24 * 60 * 60 * 1000,
-  weekly: 7 * 24 * 60 * 60 * 1000,
-};
-
-function nextRefreshAtFor(cadence: RefreshCadence, from: number): number | undefined {
-  if (cadence === "manual") return undefined;
-  return from + REFRESH_INTERVAL_MS[cadence];
-}
 
 interface PublicDatasetDef {
   /**

--- a/frontend/convex/publicSeed.ts
+++ b/frontend/convex/publicSeed.ts
@@ -17,7 +17,7 @@ import { v } from "convex/values";
  *   - Existing datasets are matched by `seedKey` (a stable, immutable
  *     identifier carried on each entry). If a dataset with the same
  *     seedKey already exists under `ownerId: system`, it is skipped.
- *   - `name`, `description`, `cadence`, and other fields can change
+ *   - `name`, `description`, `refreshCadence`, and other fields can change
  *     freely on subsequent runs without creating duplicates. They are
  *     NOT re-synced to the live row — patches in place are a deliberate
  *     future enhancement (see `backfilled` path below for the pattern).
@@ -43,6 +43,20 @@ import { v } from "convex/values";
 export const SYSTEM_OWNER_ID = "system";
 
 type ColType = "text" | "number" | "boolean" | "url" | "date";
+type RefreshCadence = "manual" | "30m" | "6h" | "12h" | "daily" | "weekly";
+
+const REFRESH_INTERVAL_MS: Record<Exclude<RefreshCadence, "manual">, number> = {
+  "30m": 30 * 60 * 1000,
+  "6h": 6 * 60 * 60 * 1000,
+  "12h": 12 * 60 * 60 * 1000,
+  daily: 24 * 60 * 60 * 1000,
+  weekly: 7 * 24 * 60 * 60 * 1000,
+};
+
+function nextRefreshAtFor(cadence: RefreshCadence, from: number): number | undefined {
+  if (cadence === "manual") return undefined;
+  return from + REFRESH_INTERVAL_MS[cadence];
+}
 
 interface PublicDatasetDef {
   /**
@@ -54,7 +68,7 @@ interface PublicDatasetDef {
   seedKey: string;
   name: string;
   description: string;
-  cadence: string;
+  refreshCadence: RefreshCadence;
   columns: { name: string; type: ColType; description?: string }[];
   rows: Record<string, string>[];
 }
@@ -70,7 +84,7 @@ const PUBLIC_DATASETS: PublicDatasetDef[] = [
     name: "AI-Native Companies Hiring Engineers",
     description:
       "Engineering hiring across the AI tooling, dev-tools, and agent ecosystem. Companies and stages reflect publicly known facts; role counts are approximate.",
-    cadence: "Daily",
+    refreshCadence: "daily",
     columns: [
       { name: "Company", type: "text" },
       { name: "Product", type: "text" },
@@ -99,7 +113,7 @@ const PUBLIC_DATASETS: PublicDatasetDef[] = [
     name: "NVIDIA Consumer GPU Retail Prices",
     description:
       "Retail prices for current-generation NVIDIA Founders Edition cards across major US retailers, reflecting public MSRPs and observed street prices.",
-    cadence: "Every 30 minutes",
+    refreshCadence: "30m",
     columns: [
       { name: "Model", type: "text" },
       { name: "MSRP", type: "number" },
@@ -125,7 +139,7 @@ const PUBLIC_DATASETS: PublicDatasetDef[] = [
     name: "Top Open-Source AI Repositories",
     description:
       "Most-starred AI/ML repositories on GitHub. Star counts are rounded approximations sourced from public GitHub metadata at curation time.",
-    cadence: "Daily",
+    refreshCadence: "daily",
     columns: [
       { name: "Repo", type: "text" },
       { name: "Stars", type: "number" },
@@ -153,7 +167,7 @@ const PUBLIC_DATASETS: PublicDatasetDef[] = [
     name: "Frontier AI Model Pricing",
     description:
       "Per-million-token API pricing and context windows for production AI models. Values reflect published rates on each provider's pricing page.",
-    cadence: "Weekly",
+    refreshCadence: "weekly",
     columns: [
       { name: "Provider", type: "text" },
       { name: "Model", type: "text" },
@@ -180,7 +194,7 @@ const PUBLIC_DATASETS: PublicDatasetDef[] = [
     name: "Browser Automation & Web Agent Companies",
     description:
       "Companies building browser-control APIs, headless browser infrastructure, and agentic web scraping. Funding totals are public disclosures.",
-    cadence: "Weekly",
+    refreshCadence: "weekly",
     columns: [
       { name: "Company", type: "text" },
       { name: "Product", type: "text" },
@@ -206,7 +220,7 @@ const PUBLIC_DATASETS: PublicDatasetDef[] = [
     name: "H100 Cloud GPU Pricing",
     description:
       "Per-GPU per-hour pricing for NVIDIA H100 80GB across hyperscalers and specialty cloud providers. AWS/GCP/Azure prices are full-node rates normalized to 1× H100.",
-    cadence: "Daily",
+    refreshCadence: "daily",
     columns: [
       { name: "Provider", type: "text" },
       { name: "Per-GPU $ / hr", type: "number" },
@@ -231,7 +245,7 @@ const PUBLIC_DATASETS: PublicDatasetDef[] = [
     name: "Notable AI Company Funding Rounds",
     description:
       "Significant venture rounds raised by AI companies. Round names, amounts, and lead investors are drawn from public funding announcements.",
-    cadence: "Daily",
+    refreshCadence: "daily",
     columns: [
       { name: "Company", type: "text" },
       { name: "Round", type: "text" },
@@ -260,7 +274,7 @@ const PUBLIC_DATASETS: PublicDatasetDef[] = [
     name: "AI Coding Tools Landscape",
     description:
       "Editors, CLIs, and extensions that ship with AI-powered coding. Pricing and underlying-model fields reflect each tool's public docs.",
-    cadence: "Weekly",
+    refreshCadence: "weekly",
     columns: [
       { name: "Product", type: "text" },
       { name: "Type", type: "text" },
@@ -288,7 +302,7 @@ const PUBLIC_DATASETS: PublicDatasetDef[] = [
     name: "Observability SaaS Pricing Comparison",
     description:
       "Starting price, log-ingest rate, and free-tier limits for the leading observability platforms. Values reflect each vendor's published pricing page.",
-    cadence: "Weekly",
+    refreshCadence: "weekly",
     columns: [
       { name: "Vendor", type: "text" },
       { name: "Starter $ / mo", type: "number" },
@@ -337,7 +351,7 @@ function assertUniqueSeedKeys(defs: PublicDatasetDef[]): void {
  *
  *   npx convex run publicSeed:seedPublicDatasets '{"force":true}'
  *     → ALSO updates existing curated datasets in place: patches metadata
- *       (name, description, cadence, columns) and replaces all their rows
+ *       (name, description, refreshCadence, columns) and replaces all their rows
  *       with the current PUBLIC_DATASETS content. Use this when you've
  *       edited curated content and want it reflected live.
  *
@@ -349,6 +363,7 @@ export const seedPublicDatasets = internalMutation({
   args: { force: v.optional(v.boolean()) },
   handler: async (ctx, { force }) => {
     assertUniqueSeedKeys(PUBLIC_DATASETS);
+    const now = Date.now();
 
     const existing = await ctx.db
       .query("datasets")
@@ -383,7 +398,9 @@ export const seedPublicDatasets = internalMutation({
         await ctx.db.patch(tracked._id, {
           name: ds.name,
           description: ds.description,
-          cadence: ds.cadence,
+          refreshCadence: ds.refreshCadence,
+          refreshEnabled: ds.refreshCadence !== "manual",
+          nextRefreshAt: nextRefreshAtFor(ds.refreshCadence, now),
           columns: ds.columns,
           status: "live",
           visibility: "public",
@@ -413,6 +430,9 @@ export const seedPublicDatasets = internalMutation({
       if (legacy) {
         await ctx.db.patch(legacy._id, {
           seedKey: ds.seedKey,
+          refreshCadence: ds.refreshCadence,
+          refreshEnabled: ds.refreshCadence !== "manual",
+          nextRefreshAt: nextRefreshAtFor(ds.refreshCadence, now),
           visibility: "public",
         });
         backfilled++;
@@ -425,7 +445,9 @@ export const seedPublicDatasets = internalMutation({
         description: ds.description,
         ownerId: SYSTEM_OWNER_ID,
         status: "live",
-        cadence: ds.cadence,
+        refreshCadence: ds.refreshCadence,
+        refreshEnabled: ds.refreshCadence !== "manual",
+        nextRefreshAt: nextRefreshAtFor(ds.refreshCadence, now),
         visibility: "public",
         columns: ds.columns,
         rowCount: ds.rows.length,

--- a/frontend/convex/schema.ts
+++ b/frontend/convex/schema.ts
@@ -14,7 +14,24 @@ export default defineSchema({
       v.literal("failed")
     ),
     lastStatusError: v.optional(v.string()),
-    cadence: v.string(),
+    // Legacy rollout field. Existing documents may still contain this
+    // display-only label; new code reads/writes refreshCadence instead.
+    cadence: v.optional(v.string()),
+    refreshCadence: v.optional(
+      v.union(
+        v.literal("manual"),
+        v.literal("30m"),
+        v.literal("6h"),
+        v.literal("12h"),
+        v.literal("daily"),
+        v.literal("weekly")
+      )
+    ),
+    refreshEnabled: v.optional(v.boolean()),
+    nextRefreshAt: v.optional(v.number()),
+    lastRefreshAt: v.optional(v.number()),
+    lastRefreshStartedAt: v.optional(v.number()),
+    lastRefreshRunId: v.optional(v.string()),
     // Optional for backward compat with rows seeded before this field existed.
     // Treat undefined as "private" in authorization helpers.
     visibility: v.optional(
@@ -58,7 +75,8 @@ export default defineSchema({
   })
     .index("by_owner", ["ownerId"])
     .index("by_visibility", ["visibility"])
-    .index("by_seed_key", ["seedKey"]),
+    .index("by_seed_key", ["seedKey"])
+    .index("by_refresh_due", ["refreshEnabled", "nextRefreshAt"]),
 
   datasetRows: defineTable({
     datasetId: v.id("datasets"),

--- a/frontend/lib/profile-user.ts
+++ b/frontend/lib/profile-user.ts
@@ -1,0 +1,6 @@
+export type ProfileUser = {
+  fullName?: string | null;
+  firstName?: string | null;
+  primaryEmailAddress?: { emailAddress?: string | null } | null;
+  imageUrl?: string | null;
+};

--- a/frontend/lib/refresh-cadence.ts
+++ b/frontend/lib/refresh-cadence.ts
@@ -9,14 +9,9 @@ export const REFRESH_CADENCE_OPTIONS: { value: RefreshCadence; label: string }[]
   { value: "weekly", label: "Weekly" },
 ];
 
-export const REFRESH_CADENCE_LABELS: Record<RefreshCadence, string> = {
-  manual: "Manual",
-  "30m": "Every 30 min",
-  "6h": "Every 6 hours",
-  "12h": "Every 12 hours",
-  daily: "Daily",
-  weekly: "Weekly",
-};
+export const REFRESH_CADENCE_LABELS = Object.fromEntries(
+  REFRESH_CADENCE_OPTIONS.map((option) => [option.value, option.label]),
+) as Record<RefreshCadence, string>;
 
 export function refreshCadenceLabel(cadence: RefreshCadence): string {
   return REFRESH_CADENCE_LABELS[cadence];

--- a/frontend/lib/refresh-cadence.ts
+++ b/frontend/lib/refresh-cadence.ts
@@ -1,0 +1,23 @@
+export type RefreshCadence = "manual" | "30m" | "6h" | "12h" | "daily" | "weekly";
+
+export const REFRESH_CADENCE_OPTIONS: { value: RefreshCadence; label: string }[] = [
+  { value: "manual", label: "Manual" },
+  { value: "30m", label: "Every 30 min" },
+  { value: "6h", label: "Every 6 hours" },
+  { value: "12h", label: "Every 12 hours" },
+  { value: "daily", label: "Daily" },
+  { value: "weekly", label: "Weekly" },
+];
+
+export const REFRESH_CADENCE_LABELS: Record<RefreshCadence, string> = {
+  manual: "Manual",
+  "30m": "Every 30 min",
+  "6h": "Every 6 hours",
+  "12h": "Every 12 hours",
+  daily: "Daily",
+  weekly: "Weekly",
+};
+
+export function refreshCadenceLabel(cadence: RefreshCadence): string {
+  return REFRESH_CADENCE_LABELS[cadence];
+}


### PR DESCRIPTION
## Summary
- Add per-dataset refresh cadence settings and Settings dropdown controls
- Add local backend scheduler for due dataset refreshes
- Add Convex claim/complete/fail mutations plus legacy cadence backfill

## Verification
- npm run build in backend
- npm run build in frontend
- make convex-push