### PR TITLE
feat: send X-TF-Request-Origin header for BigSet tracking

### DIFF
--- a/backend/src/mastra/tools/web-tools.ts
+++ b/backend/src/mastra/tools/web-tools.ts
@@ -35,7 +35,7 @@ export const searchWebTool = createTool({
     const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
     try {
       const res = await fetch(url, {
-        headers: { "X-API-Key": apiKey },
+        headers: { "X-API-Key": apiKey, "X-TF-Request-Origin": "bigset" },
         signal: controller.signal,
       });
       clearTimeout(timeout);
@@ -104,6 +104,7 @@ export const fetchPageTool = createTool({
         headers: {
           "Content-Type": "application/json",
           "X-API-Key": apiKey,
+          "X-TF-Request-Origin": "bigset",
         },
         body: JSON.stringify({ urls: [targetUrl], format: "markdown" }),
         signal: controller.signal,


### PR DESCRIPTION
## Summary

- Add `X-TF-Request-Origin: bigset` header to both TinyFish API calls (search and fetch) in `backend/src/mastra/tools/web-tools.ts`
- Allows UX Labs to distinguish BigSet traffic from other API consumers in usage tracking

**Depends on:** https://github.com/tinyfish-io/ux-labs/pull/3167 (adds `bigset` to the origin enums and forwards the header through the API gateway)

## Test plan

- [ ] Run a populate workflow and verify search/fetch requests include the `X-TF-Request-Origin: bigset` header
- [ ] Confirm `request_origin = 'bigset'` appears in UX Labs `search_usage` and `fetch_requests` tables after the UX Labs PR is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)