### PR TITLE
Feature/cell expand side sheet

### DIFF
--- a/frontend/app/dataset/[id]/page.tsx
+++ b/frontend/app/dataset/[id]/page.tsx
@@ -9,6 +9,7 @@ import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import { DatasetTable } from "@/components/table";
 import { useSelection } from "@/components/table/use-selection";
+import { SideSheet, CellDetail } from "@/components/SideSheet";
 import { useTheme } from "@/components/ThemeToggle";
 import { StatusBadge } from "@/components/dataset/StatusBadge";
 import { downloadCSV, downloadXLSX } from "@/lib/export";
@@ -34,6 +35,11 @@ export default function DatasetPage() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [confirmPopulate, setConfirmPopulate] = useState(false);
   const [savingRefreshCadence, setSavingRefreshCadence] = useState(false);
+  const [cellDetail, setCellDetail] = useState<{
+    columnName: string;
+    value: unknown;
+    sources?: string[];
+  } | null>(null);
 
   const datasetId = params.id as Id<"datasets">;
   const dataset = useQuery(
@@ -326,7 +332,25 @@ export default function DatasetPage() {
         rows={rows}
         datasetId={datasetId}
         selection={selection}
+        onCellExpand={(columnName, value, rowId) => {
+          const row = rows.find((r) => r._id === rowId);
+          setCellDetail({ columnName, value, sources: row?.sources });
+        }}
       />
+
+      <SideSheet open={cellDetail !== null} onClose={() => setCellDetail(null)}>
+        {cellDetail && (() => {
+          const col = dataset.columns.find((c) => c.name === cellDetail.columnName);
+          if (!col) return null;
+          return (
+            <CellDetail
+              column={col}
+              value={cellDetail.value}
+              sources={cellDetail.sources}
+            />
+          );
+        })()}
+      </SideSheet>
 
       {confirmPopulate && (
         <ConfirmPopulateModal

--- a/frontend/app/dataset/[id]/page.tsx
+++ b/frontend/app/dataset/[id]/page.tsx
@@ -10,6 +10,7 @@ import type { Id } from "@/convex/_generated/dataModel";
 import { DatasetTable } from "@/components/table";
 import { useSelection } from "@/components/table/use-selection";
 import { SideSheet, CellDetail } from "@/components/SideSheet";
+import type { DatasetColumn } from "@/components/table/types";
 import { useTheme } from "@/components/ThemeToggle";
 import { StatusBadge } from "@/components/dataset/StatusBadge";
 import { downloadCSV, downloadXLSX } from "@/lib/export";
@@ -36,7 +37,7 @@ export default function DatasetPage() {
   const [confirmPopulate, setConfirmPopulate] = useState(false);
   const [savingRefreshCadence, setSavingRefreshCadence] = useState(false);
   const [cellDetail, setCellDetail] = useState<{
-    columnName: string;
+    column: DatasetColumn;
     value: unknown;
     sources?: string[];
   } | null>(null);
@@ -85,6 +86,14 @@ export default function DatasetPage() {
       setPopulating(false);
     }
   }, [dataset, populating, getToken]);
+
+  const handleCellExpand = useCallback((columnName: string, value: unknown, rowId: string) => {
+    if (!dataset || !rows) return;
+    const col = dataset.columns.find((c) => c.name === columnName);
+    if (!col) return;
+    const row = rows.find((r) => r._id === rowId);
+    setCellDetail({ column: col, value, sources: row?.sources });
+  }, [dataset, rows]);
 
   const openedFired = useRef<string | null>(null);
   const autoPopulateFired = useRef<string | null>(null);
@@ -332,24 +341,17 @@ export default function DatasetPage() {
         rows={rows}
         datasetId={datasetId}
         selection={selection}
-        onCellExpand={(columnName, value, rowId) => {
-          const row = rows.find((r) => r._id === rowId);
-          setCellDetail({ columnName, value, sources: row?.sources });
-        }}
+        onCellExpand={handleCellExpand}
       />
 
       <SideSheet open={cellDetail !== null} onClose={() => setCellDetail(null)}>
-        {cellDetail && (() => {
-          const col = dataset.columns.find((c) => c.name === cellDetail.columnName);
-          if (!col) return null;
-          return (
-            <CellDetail
-              column={col}
-              value={cellDetail.value}
-              sources={cellDetail.sources}
-            />
-          );
-        })()}
+        {cellDetail && (
+          <CellDetail
+            column={cellDetail.column}
+            value={cellDetail.value}
+            sources={cellDetail.sources}
+          />
+        )}
       </SideSheet>
 
       {confirmPopulate && (

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -103,15 +103,6 @@ body {
   100% { background-position: 200% 0; }
 }
 
-@keyframes slide-in {
-  from { transform: translateX(100%); }
-  to   { transform: translateX(0); }
-}
-
-.animate-slide-in {
-  animation: slide-in 0.2s ease-out;
-}
-
 @keyframes cell-flash {
   0% { background-color: rgba(16, 185, 129, 0.25); }
   100% { background-color: transparent; }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -103,6 +103,15 @@ body {
   100% { background-position: 200% 0; }
 }
 
+@keyframes slide-in {
+  from { transform: translateX(100%); }
+  to   { transform: translateX(0); }
+}
+
+.animate-slide-in {
+  animation: slide-in 0.2s ease-out;
+}
+
 @keyframes cell-flash {
   0% { background-color: rgba(16, 185, 129, 0.25); }
   100% { background-color: transparent; }

--- a/frontend/components/SideSheet.tsx
+++ b/frontend/components/SideSheet.tsx
@@ -82,16 +82,16 @@ export function SideSheet({ open, onClose, children }: SideSheetProps) {
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex justify-end" role="dialog" aria-modal="true">
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4" role="dialog" aria-modal="true">
       {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-foreground/10 backdrop-blur-sm"
+        className="absolute inset-0 bg-foreground/20 backdrop-blur-sm"
         onClick={onClose}
       />
-      {/* Panel */}
+      {/* Modal */}
       <div
         ref={panelRef}
-        className="relative w-full max-w-md h-full bg-surface border-l border-border shadow-2xl flex flex-col animate-slide-in"
+        className="relative w-full max-w-lg max-h-[80vh] bg-surface border border-border rounded-xl shadow-2xl flex flex-col"
       >
         <div className="flex items-center justify-between px-5 py-4 border-b border-border shrink-0">
           <h2 className="text-sm font-semibold text-foreground">Cell Detail</h2>
@@ -144,19 +144,11 @@ export function CellDetail({ column, value, sources }: CellDetailProps) {
         )}
       </div>
 
-      {/* Type */}
-      <div>
-        <p className="text-[11px] font-medium text-muted uppercase tracking-wide mb-1">
-          Type
-        </p>
-        <p className="text-sm text-foreground capitalize">{column.type}</p>
-      </div>
-
       {/* Value */}
       <div>
         <div className="flex items-center justify-between mb-1.5">
           <p className="text-[11px] font-medium text-muted uppercase tracking-wide">
-            Value
+            Value <span className="normal-case">({column.type})</span>
           </p>
           <button
             type="button"

--- a/frontend/components/SideSheet.tsx
+++ b/frontend/components/SideSheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import type { DatasetColumn } from "@/components/table/types";
 
 function IconX() {
@@ -91,10 +91,11 @@ export function SideSheet({ open, onClose, children }: SideSheetProps) {
       {/* Modal */}
       <div
         ref={panelRef}
+        aria-labelledby="cell-detail-title"
         className="relative w-full max-w-lg max-h-[80vh] bg-surface border border-border rounded-xl shadow-2xl flex flex-col"
       >
         <div className="flex items-center justify-between px-5 py-4 border-b border-border shrink-0">
-          <h2 className="text-sm font-semibold text-foreground">Cell Detail</h2>
+          <h2 id="cell-detail-title" className="text-sm font-semibold text-foreground">Cell Detail</h2>
           <button
             onClick={onClose}
             className="inline-flex items-center justify-center h-7 w-7 text-muted hover:text-foreground transition-colors rounded"
@@ -120,19 +121,38 @@ interface CellDetailProps {
   sources?: string[];
 }
 
+function isValidHttpUrl(src: string): boolean {
+  try {
+    const { protocol } = new URL(src);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 export function CellDetail({ column, value, sources }: CellDetailProps) {
   const [copied, setCopied] = useState(false);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const displayValue = value == null || value === "" ? "—" : String(value);
 
-  async function handleCopy() {
+  // Clear any pending timer when the component unmounts to avoid calling
+  // setCopied on an already-gone component.
+  useEffect(() => {
+    return () => {
+      if (copyTimerRef.current != null) clearTimeout(copyTimerRef.current);
+    };
+  }, []);
+
+  const handleCopy = useCallback(async () => {
     try {
       await navigator.clipboard.writeText(value == null ? "" : String(value));
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      if (copyTimerRef.current != null) clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => setCopied(false), 2000);
     } catch {
       // Clipboard API unavailable (e.g. non-HTTPS dev); silently ignore.
     }
-  }
+  }, [value]);
 
   return (
     <div className="space-y-6">
@@ -152,7 +172,7 @@ export function CellDetail({ column, value, sources }: CellDetailProps) {
           </p>
           <button
             type="button"
-            onClick={handleCopy}
+            onClick={() => { void handleCopy(); }}
             className="inline-flex items-center gap-1.5 text-[11px] font-medium text-muted hover:text-foreground transition-colors"
             aria-label="Copy value"
           >
@@ -180,17 +200,24 @@ export function CellDetail({ column, value, sources }: CellDetailProps) {
           </p>
           <ul className="space-y-1.5">
             {sources.map((src, i) => (
-              <li key={i}>
-                <a
-                  href={src}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-start gap-1.5 text-xs text-link hover:underline break-all"
-                  data-ph-mask-text="true"
-                >
-                  <span className="mt-0.5 shrink-0"><IconExternalLink /></span>
-                  {src}
-                </a>
+              <li key={src || i}>
+                {isValidHttpUrl(src) ? (
+                  <a
+                    href={src}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-start gap-1.5 text-xs text-link hover:underline break-all"
+                    data-ph-mask-text="true"
+                  >
+                    <span className="mt-0.5 shrink-0"><IconExternalLink /></span>
+                    {src}
+                  </a>
+                ) : (
+                  <span className="flex items-start gap-1.5 text-xs text-muted break-all" data-ph-mask-text="true">
+                    <span className="mt-0.5 shrink-0"><IconExternalLink /></span>
+                    {src}
+                  </span>
+                )}
               </li>
             ))}
           </ul>

--- a/frontend/components/SideSheet.tsx
+++ b/frontend/components/SideSheet.tsx
@@ -1,8 +1,36 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Copy, Check, ExternalLink, X } from "lucide-react";
 import type { DatasetColumn } from "@/components/table/types";
+
+function IconX() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M18 6 6 18"/><path d="m6 6 12 12"/>
+    </svg>
+  );
+}
+function IconCopy() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>
+    </svg>
+  );
+}
+function IconCheck() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M20 6 9 17l-5-5"/>
+    </svg>
+  );
+}
+function IconExternalLink() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+    </svg>
+  );
+}
 
 /* ------------------------------------------------------------------ */
 /*  Shell                                                               */
@@ -72,7 +100,7 @@ export function SideSheet({ open, onClose, children }: SideSheetProps) {
             className="inline-flex items-center justify-center h-7 w-7 text-muted hover:text-foreground transition-colors rounded"
             aria-label="Close"
           >
-            <X className="size-4" />
+            <IconX />
           </button>
         </div>
         <div className="flex-1 overflow-y-auto p-5">{children}</div>
@@ -137,8 +165,8 @@ export function CellDetail({ column, value, sources }: CellDetailProps) {
             aria-label="Copy value"
           >
             {copied
-              ? <><Check className="size-3 text-green-500" /><span className="text-green-500">Copied</span></>
-              : <><Copy className="size-3" /><span>Copy</span></>
+              ? <><span className="text-green-500"><IconCheck /></span><span className="text-green-500">Copied</span></>
+              : <><IconCopy /><span>Copy</span></>
             }
           </button>
         </div>
@@ -168,7 +196,7 @@ export function CellDetail({ column, value, sources }: CellDetailProps) {
                   className="flex items-start gap-1.5 text-xs text-link hover:underline break-all"
                   data-ph-mask-text="true"
                 >
-                  <ExternalLink className="size-3 mt-0.5 shrink-0" />
+                  <span className="mt-0.5 shrink-0"><IconExternalLink /></span>
                   {src}
                 </a>
               </li>

--- a/frontend/components/SideSheet.tsx
+++ b/frontend/components/SideSheet.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Copy, Check, ExternalLink, X } from "lucide-react";
+import type { DatasetColumn } from "@/components/table/types";
+
+/* ------------------------------------------------------------------ */
+/*  Shell                                                               */
+/* ------------------------------------------------------------------ */
+
+interface SideSheetProps {
+  open: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export function SideSheet({ open, onClose, children }: SideSheetProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Lock body scroll while open.
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = prev; };
+  }, [open]);
+
+  // Keyboard: Escape closes, Tab stays trapped inside.
+  useEffect(() => {
+    if (!open || !panelRef.current) return;
+    const panel = panelRef.current;
+
+    const focusable = panel.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+    focusable[0]?.focus();
+
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") { onClose(); return; }
+      if (e.key !== "Tab" || focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault(); last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault(); first.focus();
+      }
+    }
+
+    panel.addEventListener("keydown", onKey);
+    return () => panel.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end" role="dialog" aria-modal="true">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-foreground/10 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      {/* Panel */}
+      <div
+        ref={panelRef}
+        className="relative w-full max-w-md h-full bg-surface border-l border-border shadow-2xl flex flex-col animate-slide-in"
+      >
+        <div className="flex items-center justify-between px-5 py-4 border-b border-border shrink-0">
+          <h2 className="text-sm font-semibold text-foreground">Cell Detail</h2>
+          <button
+            onClick={onClose}
+            className="inline-flex items-center justify-center h-7 w-7 text-muted hover:text-foreground transition-colors rounded"
+            aria-label="Close"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto p-5">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Content                                                             */
+/* ------------------------------------------------------------------ */
+
+interface CellDetailProps {
+  column: DatasetColumn;
+  value: unknown;
+  /** Row-level sources stored by the populate agent. */
+  sources?: string[];
+}
+
+export function CellDetail({ column, value, sources }: CellDetailProps) {
+  const [copied, setCopied] = useState(false);
+  const displayValue = value == null || value === "" ? "—" : String(value);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(value == null ? "" : String(value));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API unavailable (e.g. non-HTTPS dev); silently ignore.
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Column name + description */}
+      <div>
+        <p className="text-sm font-semibold text-foreground">{column.name}</p>
+        {column.description && (
+          <p className="text-xs text-muted mt-0.5">{column.description}</p>
+        )}
+      </div>
+
+      {/* Type */}
+      <div>
+        <p className="text-[11px] font-medium text-muted uppercase tracking-wide mb-1">
+          Type
+        </p>
+        <p className="text-sm text-foreground capitalize">{column.type}</p>
+      </div>
+
+      {/* Value */}
+      <div>
+        <div className="flex items-center justify-between mb-1.5">
+          <p className="text-[11px] font-medium text-muted uppercase tracking-wide">
+            Value
+          </p>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="inline-flex items-center gap-1.5 text-[11px] font-medium text-muted hover:text-foreground transition-colors"
+            aria-label="Copy value"
+          >
+            {copied
+              ? <><Check className="size-3 text-green-500" /><span className="text-green-500">Copied</span></>
+              : <><Copy className="size-3" /><span>Copy</span></>
+            }
+          </button>
+        </div>
+        <div
+          className="rounded-lg border border-border bg-background px-4 py-3"
+          data-ph-mask-text="true"
+        >
+          <p className="text-sm text-foreground break-all whitespace-pre-wrap">
+            {displayValue}
+          </p>
+        </div>
+      </div>
+
+      {/* Sources */}
+      {sources && sources.length > 0 && (
+        <div>
+          <p className="text-[11px] font-medium text-muted uppercase tracking-wide mb-1.5">
+            Sources
+          </p>
+          <ul className="space-y-1.5">
+            {sources.map((src, i) => (
+              <li key={i}>
+                <a
+                  href={src}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-start gap-1.5 text-xs text-link hover:underline break-all"
+                  data-ph-mask-text="true"
+                >
+                  <ExternalLink className="size-3 mt-0.5 shrink-0" />
+                  {src}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/table/DataRow.tsx
+++ b/frontend/components/table/DataRow.tsx
@@ -5,6 +5,7 @@ import { areEqual } from "react-window";
 import type { Row } from "@tanstack/react-table";
 import type { DatasetRow, DatasetColumn } from "./types";
 import { CellValue } from "./CellValue";
+import { floorWidth } from "./utils";
 
 function IconMaximize2() {
   return (
@@ -13,7 +14,6 @@ function IconMaximize2() {
     </svg>
   );
 }
-import { floorWidth } from "./utils";
 
 export interface DataRowData {
   rows: Row<DatasetRow>[];
@@ -138,7 +138,7 @@ function DataRowImpl({
                 e.stopPropagation();
                 onCellExpand(col.name, value, row.original._id);
               }}
-              className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 p-0.5 rounded bg-foreground/5 hover:bg-foreground/10 text-muted hover:text-foreground transition-all"
+              className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground p-0.5 rounded bg-foreground/5 hover:bg-foreground/10 text-muted hover:text-foreground transition-all"
               aria-label={`Expand ${col.name}`}
             >
               <IconMaximize2 />

--- a/frontend/components/table/DataRow.tsx
+++ b/frontend/components/table/DataRow.tsx
@@ -4,6 +4,7 @@ import { memo, type CSSProperties } from "react";
 import { areEqual } from "react-window";
 import type { Row } from "@tanstack/react-table";
 import type { DatasetRow, DatasetColumn } from "./types";
+import { Maximize2 } from "lucide-react";
 import { CellValue } from "./CellValue";
 import { floorWidth } from "./utils";
 
@@ -13,6 +14,7 @@ export interface DataRowData {
   columnWidths: number[];
   isSelected: (id: string) => boolean;
   toggleRow: (id: string, shiftKey: boolean) => void;
+  onCellExpand: (columnName: string, value: unknown, rowId: string) => void;
   isBuilding: boolean;
   pendingRowIds: Set<string>;
   flashingCells: Set<string>;
@@ -27,7 +29,7 @@ function DataRowImpl({
   index: number;
   style: CSSProperties;
 }) {
-  const { rows, columns, columnWidths, isSelected, toggleRow, isBuilding, pendingRowIds, flashingCells } = data;
+  const { rows, columns, columnWidths, isSelected, toggleRow, onCellExpand, isBuilding, pendingRowIds, flashingCells } = data;
   const row = rows[index];
 
   if (!row) {
@@ -112,7 +114,7 @@ function DataRowImpl({
           <div
             key={col.name}
             data-ph-mask-text="true"
-            className={`relative shrink-0 overflow-hidden text-ellipsis whitespace-nowrap border-r border-border/30 last:border-r-0 ${
+            className={`group relative shrink-0 overflow-hidden text-ellipsis whitespace-nowrap border-r border-border/30 last:border-r-0 ${
               cellIdx === 0
                 ? "font-medium text-foreground"
                 : "text-foreground/70"
@@ -123,6 +125,17 @@ function DataRowImpl({
             }}
           >
             <CellValue value={value} type={col.type} />
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onCellExpand(col.name, value, row.original._id);
+              }}
+              className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 p-0.5 rounded bg-foreground/5 hover:bg-foreground/10 text-muted hover:text-foreground transition-all"
+              aria-label={`Expand ${col.name}`}
+            >
+              <Maximize2 className="size-3" />
+            </button>
             {isPending && <div className="shimmer-overlay absolute inset-0" />}
           </div>
         );

--- a/frontend/components/table/DataRow.tsx
+++ b/frontend/components/table/DataRow.tsx
@@ -4,8 +4,15 @@ import { memo, type CSSProperties } from "react";
 import { areEqual } from "react-window";
 import type { Row } from "@tanstack/react-table";
 import type { DatasetRow, DatasetColumn } from "./types";
-import { Maximize2 } from "lucide-react";
 import { CellValue } from "./CellValue";
+
+function IconMaximize2() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/>
+    </svg>
+  );
+}
 import { floorWidth } from "./utils";
 
 export interface DataRowData {
@@ -134,7 +141,7 @@ function DataRowImpl({
               className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 p-0.5 rounded bg-foreground/5 hover:bg-foreground/10 text-muted hover:text-foreground transition-all"
               aria-label={`Expand ${col.name}`}
             >
-              <Maximize2 className="size-3" />
+              <IconMaximize2 />
             </button>
             {isPending && <div className="shimmer-overlay absolute inset-0" />}
           </div>

--- a/frontend/components/table/DatasetTable.tsx
+++ b/frontend/components/table/DatasetTable.tsx
@@ -85,11 +85,13 @@ export function DatasetTable({
   rows,
   datasetId,
   selection,
+  onCellExpand,
 }: {
   dataset: DatasetMeta;
   rows: DatasetRow[];
   datasetId: string;
   selection: Selection;
+  onCellExpand: (columnName: string, value: unknown, rowId: string) => void;
 }) {
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const previousResizingColumnIdRef = useRef<string | false>(false);
@@ -168,11 +170,12 @@ export function DatasetTable({
       columnWidths,
       isSelected: selection.has,
       toggleRow,
+      onCellExpand,
       isBuilding,
       pendingRowIds,
       flashingCells,
     }),
-    [tableRows, dataset.columns, columnWidths, selection.has, toggleRow, isBuilding, pendingRowIds, flashingCells],
+    [tableRows, dataset.columns, columnWidths, selection.has, toggleRow, onCellExpand, isBuilding, pendingRowIds, flashingCells],
   );
 
   return (

--- a/frontend/components/table/types.ts
+++ b/frontend/components/table/types.ts
@@ -28,5 +28,6 @@ export interface DatasetRow {
   _id: string;
   _creationTime: number;
   data: Record<string, unknown>;
+  sources?: string[];
   updateStatus?: "pending";
 }


### PR DESCRIPTION
This PR is to add a feature for column details window, which surfaces the "sources" information for collected data. Hovering any cell in the dataset table reveals a small expand icon. Clicking it opens a centered popup showing:
- Column name and description
- Full cell value (untruncated, pre-wrapped) with a copy button — label shows the column type inline, e.g. Value (url)
- Sources — the URLs the populate agent used when researching that row, shown as clickable external links. Displayed for all columns in the row since sources are stored at the row level.

Design decisions
- No new dependencies. All icons are inline SVGs matching the existing pattern in ColumnHeader, ColumnIcon, and ThemeToggle. sonner/lucide-react were considered and rejected — lucide-react isn't installed in the Docker container's node_modules, and a toast library would be overkill for a single copy confirmation. Copy feedback is a simple 2-second useState toggle.
- onCellExpand is a useCallback with [dataset, rows] deps, keeping the react-window itemData memo stable across unrelated re-renders.
- State stores the resolved DatasetColumn object, not the column name string, eliminating a render-time find() and the IIFE pattern that would otherwise be needed in JSX.
- Sources are row-level (one list per row, shared across all columns), which matches how the populate agent stores them in Convex.

Special thanks to the PR opened by @MabudAlam , which also included a details side sheet. This is the direction that we decided to go for before the Bigset launch.