### PR TITLE
fix: validate dataset name and columns before submission

### DIFF
--- a/frontend/app/dataset/new/page.tsx
+++ b/frontend/app/dataset/new/page.tsx
@@ -183,12 +183,21 @@ export default function NewDatasetPage() {
       );
       return;
     }
+    const trimmedDatasetName = datasetName.trim();
+    if (!trimmedDatasetName) {
+      setError("Dataset name is required.");
+      return;
+    }
+    if (columns.length === 0) {
+      setError("Add at least one column before creating the dataset.");
+      return;
+    }
     setIsCreating(true);
     setError(null);
     let datasetId: string;
     try {
       datasetId = await createDataset({
-        name: datasetName,
+        name: trimmedDatasetName,
         description: prompt,
         refreshCadence,
         maxRowCount,


### PR DESCRIPTION
Submitting with an empty name or zero columns reached the backend and returned a cryptic 'Invalid request' error. Now caught on the client with a clear message before the API call is made.