### PR TITLE
feat: paginate runStats, fix verification script on Windows, and clean up react-hooks warning

### DIFF
--- a/frontend/components/table/use-row-change-detection.ts
+++ b/frontend/components/table/use-row-change-detection.ts
@@ -53,11 +53,15 @@ export function useRowChangeDetection(rows: DatasetRow[]) {
     prevRowsRef.current = nextMap;
 
     if (newFlashes.size > 0) {
-      setFlashingCells((prev) => {
-        const merged = new Set(prev);
-        for (const key of newFlashes) merged.add(key);
-        return merged;
-      });
+      const updateTimer = setTimeout(() => {
+        setFlashingCells((prev) => {
+          const merged = new Set(prev);
+          for (const key of newFlashes) merged.add(key);
+          return merged;
+        });
+        flashTimersRef.current.delete(updateTimer);
+      }, 0);
+      flashTimersRef.current.add(updateTimer);
 
       const timer = setTimeout(() => {
         setFlashingCells((prev) => {

--- a/frontend/convex/runStats.ts
+++ b/frontend/convex/runStats.ts
@@ -1,6 +1,9 @@
 import { internalMutation, internalQuery } from "./_generated/server.js";
 import { v } from "convex/values";
 
+const DEFAULT_PAGE_SIZE = 50;
+const MAX_PAGE_SIZE = 200;
+
 /**
  * Insert a populate-run metrics record.
  *
@@ -68,33 +71,52 @@ export const getByWorkflowRunId = internalQuery({
 });
 
 /**
- * List all runs for a dataset, newest first.
- * TODO: paginate — .collect() loads all docs into memory and will degrade
- * as run history grows. Add cursor-based pagination when this is exposed
- * to the frontend or run counts become large.
+ * List runs for a dataset, newest first.
+ * Cursor-based pagination keeps memory bounded as run history grows.
  */
 export const listByDataset = internalQuery({
-  args: { datasetId: v.string() },
+  args: {
+    datasetId: v.string(),
+    cursor: v.optional(v.string()),
+    limit: v.optional(v.number()),
+  },
   handler: async (ctx, args) => {
-    const runs = await ctx.db
+    const limit = Math.min(args.limit ?? DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE);
+    const { page, isDone, continueCursor } = await ctx.db
       .query("runStats")
-      .withIndex("by_dataset", (q) => q.eq("datasetId", args.datasetId))
-      .collect();
-    return runs.sort((a, b) => b.startedAt - a.startedAt);
+      .withIndex("by_dataset_started_at", (q) =>
+        q.eq("datasetId", args.datasetId),
+      )
+      .order("desc")
+      .paginate({
+        cursor: args.cursor ?? null,
+        numItems: limit,
+      });
+
+    return { runs: page, isDone, continueCursor };
   },
 });
 
 /**
- * List all runs for a user, newest first.
- * TODO: paginate — same concern as listByDataset above.
+ * List runs for a user, newest first.
  */
 export const listByUser = internalQuery({
-  args: { userId: v.string() },
+  args: {
+    userId: v.string(),
+    cursor: v.optional(v.string()),
+    limit: v.optional(v.number()),
+  },
   handler: async (ctx, args) => {
-    const runs = await ctx.db
+    const limit = Math.min(args.limit ?? DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE);
+    const { page, isDone, continueCursor } = await ctx.db
       .query("runStats")
-      .withIndex("by_user", (q) => q.eq("userId", args.userId))
-      .collect();
-    return runs.sort((a, b) => b.startedAt - a.startedAt);
+      .withIndex("by_user_started_at", (q) => q.eq("userId", args.userId))
+      .order("desc")
+      .paginate({
+        cursor: args.cursor ?? null,
+        numItems: limit,
+      });
+
+    return { runs: page, isDone, continueCursor };
   },
 });

--- a/frontend/convex/schema.ts
+++ b/frontend/convex/schema.ts
@@ -170,6 +170,8 @@ export default defineSchema({
     rowsUpdated: v.optional(v.number()),
   })
     .index("by_dataset", ["datasetId"])
+    .index("by_dataset_started_at", ["datasetId", "startedAt"])
     .index("by_user", ["userId"])
+    .index("by_user_started_at", ["userId", "startedAt"])
     .index("by_workflow_run", ["workflowRunId"]),
 });

--- a/scripts/verify-authz.sh
+++ b/scripts/verify-authz.sh
@@ -6,6 +6,17 @@
 #   bash scripts/verify-authz.sh
 set -u
 
+# Use python3 if available, fallback to python (common on Windows)
+PYTHON="python3"
+if ! command -v python3 &>/dev/null; then
+  if command -v python &>/dev/null; then
+    PYTHON="python"
+  else
+    echo "Error: python3 or python is required to run this script."
+    exit 1
+  fi
+fi
+
 CONVEX="${CONVEX_URL:-http://localhost:3210}"
 FRONTEND="${FRONTEND_URL:-http://localhost:3500}"
 FAIL=0
@@ -34,11 +45,11 @@ mutation() {
 }
 
 assert_success() {
-  python3 -c "import json,sys; d=json.load(sys.stdin); print('PASS' if d.get('status')=='success' else 'FAIL: '+d.get('errorMessage','?')[:60])"
+  $PYTHON -c "import json,sys; d=json.load(sys.stdin); print('PASS' if d.get('status')=='success' else 'FAIL: '+d.get('errorMessage','?')[:60])"
 }
 assert_error_contains() {
   local needle="$1"
-  python3 -c "import json,sys; d=json.load(sys.stdin); print('PASS' if '$needle' in d.get('errorMessage','') else 'FAIL: '+d.get('errorMessage','?')[:80])"
+  $PYTHON -c "import json,sys; d=json.load(sys.stdin); print('PASS' if '$needle' in d.get('errorMessage','') else 'FAIL: '+d.get('errorMessage','?')[:80])"
 }
 
 echo "════════════════════════════════════════════════════════════════"
@@ -47,7 +58,7 @@ echo "  convex=$CONVEX  frontend=$FRONTEND"
 echo "════════════════════════════════════════════════════════════════"
 
 PUB_ID=$(query '{"path":"datasets:listPublic","args":{},"format":"json"}' \
-  | python3 -c "import json,sys; print(json.load(sys.stdin)['value'][0]['_id'])")
+  | $PYTHON -c "import json,sys; print(json.load(sys.stdin)['value'][0]['_id'])")
 if [ -z "${PUB_ID:-}" ]; then
   echo "No public dataset found. Seed curated data first (publicSeed:seedPublicDatasets)."
   exit 1
@@ -65,7 +76,7 @@ section "Anonymous WRITES — must all be rejected"
 run_test "anon datasets.listMine -> Not authenticated" \
   "$(query '{"path":"datasets:listMine","args":{},"format":"json"}' | assert_error_contains 'Not authenticated')"
 run_test "anon datasets.create -> Not authenticated" \
-  "$(mutation '{"path":"datasets:create","args":{"name":"x","description":"x","cadence":"daily","columns":[]},"format":"json"}' | assert_error_contains 'Not authenticated')"
+  "$(mutation '{"path":"datasets:create","args":{"name":"x","description":"x","refreshCadence":"daily","columns":[]},"format":"json"}' | assert_error_contains 'Not authenticated')"
 run_test "anon datasets.updateStatus -> Not authenticated" \
   "$(mutation "{\"path\":\"datasets:updateStatus\",\"args\":{\"id\":\"$PUB_ID\",\"status\":\"paused\"},\"format\":\"json\"}" | assert_error_contains 'Not authenticated')"
 run_test "anon datasets.remove -> Not authenticated" \


### PR DESCRIPTION
## Description
This PR addresses three key areas to improve scalability, cross-platform local development, and clean up frontend compilation/linting:

1. **Query Pagination**: Optimized the `listByDataset` and `listByUser` queries on the `runStats` table in Convex to use cursor-based pagination (`.paginate()`) instead of loading all historic records into memory (`.collect()`). This bounds memory usage and improves database performance.
2. **Cross-Platform Verification Script**: Enhanced `scripts/verify-authz.sh` to check for `python3` and fallback to `python` (which is standard on Windows hosts).
3. **Aligned Schema Payload in Tests**: Corrected a legacy `cadence` payload argument inside the verification script to `refreshCadence` for `datasets:create`. This fixed a schema validation exception on Convex that was previously masking auth checks.
4. **React Linter Fix**: Resolved a `react-hooks/set-state-in-effect` rule violation in `use-row-change-detection.ts` by wrapping `setFlashingCells` inside `setTimeout(..., 0)` to align with the repository's established code patterns.

## Changes Made
* **Database Schema**: Added compound indexes `by_dataset_started_at` (`["datasetId", "startedAt"]`) and `by_user_started_at` (`["userId", "startedAt"]`) in `frontend/convex/schema.ts`.
* **Database Queries**: Changed `listByDataset` and `listByUser` to cursor-based paginated queries in `frontend/convex/runStats.ts`.
* **Authorization script**: Updated `scripts/verify-authz.sh` with the Python binary checker and updated testing arguments.
* **Component table hook**: Wrapped synchronous state setters in `frontend/components/table/use-row-change-detection.ts` in deferred callbacks.

## Verification
* Deployed updated schema successfully to local Convex backend.
* Ran verification scripts successfully:
  ```bash
  bash scripts/verify-authz.sh
