### PR TITLE
feat: add delete dataset option to Settings dropdown

### DIFF
--- a/frontend/app/dataset/[id]/page.tsx
+++ b/frontend/app/dataset/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useConvexAuth } from "convex/react";
@@ -25,6 +25,7 @@ import type { ProfileUser } from "@/lib/profile-user";
 
 export default function DatasetPage() {
   const params = useParams();
+  const router = useRouter();
   const { isLoading: authLoading } = useConvexAuth();
   const { userId, getToken } = useAuth();
   const { user } = useUser();
@@ -36,6 +37,7 @@ export default function DatasetPage() {
   const [exportOpen, setExportOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [confirmPopulate, setConfirmPopulate] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const [savingRefreshCadence, setSavingRefreshCadence] = useState(false);
   const [cellDetail, setCellDetail] = useState<{
     column: DatasetColumn;
@@ -53,6 +55,7 @@ export default function DatasetPage() {
     authLoading ? "skip" : { datasetId },
   );
   const updateRefreshSettings = useMutation(api.datasets.updateRefreshSettings);
+  const removeDataset = useMutation(api.datasets.remove);
 
   const rowIds = useMemo(() => (rows ?? []).map((r) => r._id), [rows]);
   const selection = useSelection(rowIds);
@@ -241,6 +244,17 @@ export default function DatasetPage() {
     }
   }
 
+  async function handleDelete() {
+    if (!dataset) return;
+    try {
+      await removeDataset({ id: dataset._id });
+      router.push("/dashboard");
+    } catch (err) {
+      console.error("[delete] failed", err);
+      captureException(err, { operation: "dataset_delete", datasetId: dataset._id });
+    }
+  }
+
   // Computed before the loading guard so the useEffect below can depend on it
   // without hitting the TDZ. Optional chaining handles the pre-load undefined state.
   const isDatasetBusy = dataset?.status === "building" || dataset?.status === "updating";
@@ -255,7 +269,6 @@ export default function DatasetPage() {
       return () => clearTimeout(id);
     }
   }, [isDatasetBusy]);
-
   if (authLoading || dataset === undefined || rows === undefined) {
     return (
       <div className="flex flex-1 items-center justify-center">
@@ -361,6 +374,7 @@ export default function DatasetPage() {
                 handlePopulate();
               }
             }}
+            onDelete={isOwner ? () => { setSettingsOpen(false); setConfirmDelete(true); } : undefined}
           />
 
           <div className="w-px h-4 bg-border mx-0.5" />
@@ -421,6 +435,17 @@ export default function DatasetPage() {
             handlePopulate();
           }}
           onCancel={() => setConfirmPopulate(false)}
+        />
+      )}
+
+      {confirmDelete && (
+        <ConfirmDeleteModal
+          datasetName={dataset.name}
+          onConfirm={() => {
+            setConfirmDelete(false);
+            handleDelete();
+          }}
+          onCancel={() => setConfirmDelete(false)}
         />
       )}
     </div>
@@ -523,6 +548,7 @@ function SettingsDropdown({
   onRefreshCadenceChange,
   onUpdate,
   onPopulate,
+  onDelete,
 }: {
   open: boolean;
   onToggle: () => void;
@@ -536,6 +562,7 @@ function SettingsDropdown({
   onRefreshCadenceChange: (refreshCadence: RefreshCadence) => void;
   onUpdate: () => void;
   onPopulate: () => void;
+  onDelete?: () => void;
 }) {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -589,6 +616,7 @@ function SettingsDropdown({
                 <button
                   key={option.value}
                   type="button"
+
                   onClick={() => onRefreshCadenceChange(option.value)}
                   disabled={refreshCadenceDisabled || selected}
                   className="w-full flex items-center justify-between gap-2 px-2 py-1.5 rounded-lg text-xs text-foreground hover:bg-foreground/[0.05] transition-colors disabled:cursor-default disabled:opacity-60"
@@ -603,6 +631,17 @@ function SettingsDropdown({
               );
             })}
           </div>
+          {onDelete && (
+            <div className="border-t border-border p-1">
+              <button
+                onClick={onDelete}
+                className="w-full flex items-center gap-2 px-2 py-1.5 rounded-lg text-xs text-red-500 hover:bg-red-500/[0.08] transition-colors"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/></svg>
+                Delete dataset
+              </button>
+            </div>
+          )}
         </div>
       )}
     </div>
@@ -729,6 +768,57 @@ function ConfirmPopulateModal({
             className="flex-1 rounded-lg bg-red-600 py-1.5 text-xs font-medium text-white hover:bg-red-700 transition-colors"
           >
             Delete &amp; populate
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Confirm delete modal                                               */
+/* ------------------------------------------------------------------ */
+
+function ConfirmDeleteModal({
+  datasetName,
+  onConfirm,
+  onCancel,
+}: {
+  datasetName: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onCancel();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onCancel]);
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/40"
+      onClick={(e) => { if (e.target === e.currentTarget) onCancel(); }}
+      role="presentation"
+    >
+      <div role="dialog" aria-modal="true" aria-labelledby="confirm-delete-title" className="w-full max-w-xs rounded-xl border border-border bg-surface shadow-2xl p-4 text-center">
+        <p id="confirm-delete-title" className="text-sm font-semibold text-foreground">
+          Delete &ldquo;{datasetName}&rdquo;?
+        </p>
+        <p className="mt-1 text-xs text-muted">All rows will be permanently deleted. This can&apos;t be undone.</p>
+        <div className="mt-4 flex gap-2">
+          <button
+            onClick={onCancel}
+            className="flex-1 rounded-lg bg-foreground/[0.06] py-1.5 text-xs font-medium text-foreground hover:bg-foreground/[0.1] transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className="flex-1 rounded-lg bg-red-600 py-1.5 text-xs font-medium text-white hover:bg-red-700 transition-colors"
+          >
+            Delete dataset
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Added a **Delete dataset** button to the Settings dropdown on the dataset page
- Wires up the existing pi.datasets.remove Convex mutation which was never called from the UI
- Shows a confirmation modal before deleting to prevent accidental data loss
- Redirects to the dashboard after successful deletion

## Problem

There was no way to delete a dataset from the UI. If a dataset ended up in a broken state (e.g. created with 0 columns), the user was stuck — the page showed a blank table with no recovery path and no way to clean it up.

## Test plan

- [x] Open a dataset, click Settings, confirm Delete dataset appears at the bottom
- [ ] Click Delete dataset, confirm the modal appears
- [ ] Confirm deletion, verify dataset is removed and user is redirected to dashboard
- [ ] Verify cancel dismisses the modal without deleting
- [ ] Verify Delete option only appears for the dataset owner

🤖 Generated with [Claude Code](https://claude.com/claude-code)