### PR TITLE
Add funded startup lead workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,37 @@ Any dataset. Any source. Always fresh. That's the idea.
 5. **You get a structured table**: browse it in the UI, export CSV or XLSX
 6. **Set a refresh cadence** and the agents re-run on schedule, keeping the dataset current automatically
 
+## Example Workflow: Find Funded Leads (and Your Next Job)
+
+Companies that just raised funding usually have budget and urgent problems to solve, which makes them useful sales leads, hiring targets, and market signals. BigSet can turn one sentence into a live dataset of those companies.
+
+### 1. Type one sentence
+
+```text
+Startups that raised funding in the last 30 days, with what they do, funding stage, location, and careers page.
+```
+
+BigSet infers the schema: company, description, funding stage, location, careers page, source links, and any other useful columns it needs.
+
+### 2. Let agents research the live web
+
+The orchestrator discovers recently funded companies, then sub-agents fan out in parallel to research one company each. Rows are deduplicated, and findings are checked against public sources before they land in your table.
+
+### 3. Export and refresh
+
+Export the dataset to CSV or XLSX, then set a refresh cadence: 30 minutes, 6 hours, 12 hours, daily, or weekly. The agents re-run on that schedule so the list keeps pulling in fresh companies as funding news drops.
+
+### Prompts to Steal
+
+| Goal | Prompt |
+|------|--------|
+| Find leads or clients | `Startups that raised funding in the last 30 days, with what they do, funding stage, location, and careers page.` |
+| Apply before jobs are posted | `YC companies currently hiring engineers, with funding stage, location, and number of open roles.` |
+| Spot side-project gaps | `Popular B2B SaaS tools that offer a free tier, with category, free-tier summary, and pricing page URL.` |
+| Pick what to learn next | `AI startups hiring engineers right now, with the specific skills and stack listed in each role.` |
+
+Funded startups are leads. What gets funded is a signal for your next idea. What they hire for is your learning roadmap.
+
 ## Things to Know Before You Start
 
 - **It's experimental.** Expect rough edges; schema inference isn't always perfect, and some topics work better than others.

--- a/frontend/app/dataset/new/page.tsx
+++ b/frontend/app/dataset/new/page.tsx
@@ -43,6 +43,29 @@ const BACKEND_TYPE_MAP: Record<InferredColumn["type"], ColumnType> = {
   boolean: "boolean",
 };
 
+const EXAMPLE_PROMPTS = [
+  {
+    label: "Funded startup leads",
+    prompt:
+      "Startups that raised funding in the last 30 days, with what they do, funding stage, location, and careers page.",
+  },
+  {
+    label: "Engineering hiring targets",
+    prompt:
+      "YC companies currently hiring engineers, with funding stage, location, and number of open roles.",
+  },
+  {
+    label: "Free-tier SaaS gaps",
+    prompt:
+      "Popular B2B SaaS tools that offer a free tier, with category, free-tier summary, and pricing page URL.",
+  },
+  {
+    label: "AI skills roadmap",
+    prompt:
+      "AI startups hiring engineers right now, with the specific skills and stack listed in each role.",
+  },
+];
+
 function mapBackendColumn(col: InferredColumn, index: number): ProposedColumn {
   return {
     id: String(index + 1),
@@ -235,6 +258,29 @@ export default function NewDatasetPage() {
                   rows={4}
                   className="w-full rounded-lg border border-border bg-surface px-4 py-3 text-sm outline-none placeholder:text-muted/50 focus:border-foreground/30 transition-colors resize-none"
                 />
+              </div>
+
+              <div className="space-y-3">
+                <p className="text-xs font-medium uppercase tracking-wider text-muted">
+                  Try an example
+                </p>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {EXAMPLE_PROMPTS.map((example) => (
+                    <button
+                      key={example.label}
+                      type="button"
+                      onClick={() => setPrompt(example.prompt)}
+                      className="rounded-lg border border-border bg-surface px-3 py-2.5 text-left transition-colors hover:border-foreground/30 hover:bg-foreground/[0.03]"
+                    >
+                      <span className="block text-sm font-medium text-foreground">
+                        {example.label}
+                      </span>
+                      <span className="mt-1 block line-clamp-2 text-xs leading-relaxed text-muted">
+                        {example.prompt}
+                      </span>
+                    </button>
+                  ))}
+                </div>
               </div>
 
               {error && (


### PR DESCRIPTION
Adds a funded-startup lead workflow to the README and adds matching example prompts to the New Dataset page.

Validation:
- Targeted static check confirmed the funded-startup example, label, click handler, and render loop exist.
- `npx eslint app/dataset/new/page.tsx` passes with only existing `<img>` warnings.

Notes:
- Full `npm run lint` currently fails on a pre-existing `react-hooks/set-state-in-effect` error in `frontend/components/table/use-row-change-detection.ts`.
- Full `npm run build` currently fails because Convex generated files are missing locally (`frontend/convex/_generated/api`).