### PR TITLE
Add hover tooltips for truncated dataset cell values

### DIFF
--- a/frontend/components/table/CellValue.tsx
+++ b/frontend/components/table/CellValue.tsx
@@ -65,11 +65,14 @@ export function CellValue({
   }
 
   if (type === "number") {
-    return <span className="tabular-nums">{str}</span>;
+    return (
+	 <span className="tabular-nums" title={str} >
+		{str}
+	</span>;
   }
 
   return (
-    <span title={str.length > MAX_CHARS ? str : undefined}>
+    <span title={str}>
       {truncate(str)}
     </span>
   );

--- a/frontend/components/table/CellValue.tsx
+++ b/frontend/components/table/CellValue.tsx
@@ -68,7 +68,8 @@ export function CellValue({
     return (
 	 <span className="tabular-nums" title={str} >
 		{str}
-	</span>;
+	</span>
+    );
   }
 
   return (


### PR DESCRIPTION
**What I changed**

I added hover tooltips for dataset table cells so the full value can be viewed when text is truncated.

**Why**

While testing dataset generation, I noticed that long values, such as URLs, job titles, salary ranges, etc., were getting cut off in the table, making them difficult to read without expanding columns.

**Testing**

- Generated datasets with long text values and URLs
- Confirmed the full value appears on hover
- Verified existing table behavior remains the same