### PR TITLE
fix: correct stale .env.example references to the make dev auto-create flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Frontend on :3500, backend on :3501, Mastra Studio on :4111, Convex dashboard on
 
 ## Setup
 
-1. Copy `.env.example` to `.env` and fill in your keys:
+1. `make dev` auto-creates a local `.env` on first run (no template to copy). Fill in your keys there:
    - `TINYFISH_API_KEY` — from https://agent.tinyfish.ai/api-keys?utm_source=github&utm_medium=organic&utm_campaign=bigset-developer-2026q2
    - `OPENROUTER_API_KEY` — from https://openrouter.ai/settings/keys
    - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` — from Clerk API Keys

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -44,7 +44,7 @@ Writes to Convex via `ConvexHttpClient` in `src/convex.ts`. Import `{ convex, ap
 
 ## Environment
 
-Required env vars (see `.env.example`):
+Required env vars (loaded from the root `.env`; see `src/env.ts`):
 - `CONVEX_URL` — Convex instance URL
 - `CONVEX_SELF_HOSTED_ADMIN_KEY` — for system-level Convex writes (internal mutations)
 - `CLERK_SECRET_KEY`, `CLERK_PUBLISHABLE_KEY` — for JWT verification

--- a/backend/README.md
+++ b/backend/README.md
@@ -5,9 +5,8 @@ Fastify server that handles auth, database, and talks to TinyFish APIs.
 ## Running
 
 ```bash
-# From the repo root:
-cp .env.example .env
-# Fill in the root .env file.
+# From the repo root: `make dev` auto-creates a local .env on first run.
+# Fill in the root .env file (no template to copy).
 cd backend
 npm install
 npm run dev

--- a/makefiles/Makefile
+++ b/makefiles/Makefile
@@ -188,7 +188,7 @@ ensure-admin-key:
 	fi
 
 convex-env:
-	@test -f .env || { echo "Error: .env not found. Run: cp .env.example .env"; exit 1; }
+	@test -f .env || { echo "Error: .env not found. Run: make dev (it auto-creates a local .env)"; exit 1; }
 	@prod="$$(grep '^PROD=' .env | cut -d= -f2-)"; \
 	admin_key="$$(grep '^CONVEX_SELF_HOSTED_ADMIN_KEY=' .env | cut -d= -f2-)"; \
 	if [[ -z "$$admin_key" ]]; then \
@@ -212,7 +212,7 @@ convex-env:
 	'npx convex env set CLERK_JWT_ISSUER_DOMAIN "$$CLERK_JWT_ISSUER_DOMAIN" --url $(CONVEX_CLI_URL) --admin-key "$$CONVEX_SELF_HOSTED_ADMIN_KEY"'
 
 convex-push:
-	@test -f .env || { echo "Error: .env not found. Run: cp .env.example .env"; exit 1; }
+	@test -f .env || { echo "Error: .env not found. Run: make dev (it auto-creates a local .env)"; exit 1; }
 	@admin_key="$$(grep '^CONVEX_SELF_HOSTED_ADMIN_KEY=' .env | cut -d= -f2-)"; \
 	if [[ -z "$$admin_key" ]]; then \
 		echo "Error: CONVEX_SELF_HOSTED_ADMIN_KEY is missing in root .env"; \
@@ -223,7 +223,7 @@ convex-push:
 	'npx convex deploy --url $(CONVEX_CLI_URL) --admin-key "$$CONVEX_SELF_HOSTED_ADMIN_KEY"'
 
 seed-public-datasets:
-	@test -f .env || { echo "Error: .env not found. Run: cp .env.example .env"; exit 1; }
+	@test -f .env || { echo "Error: .env not found. Run: make dev (it auto-creates a local .env)"; exit 1; }
 	@cd frontend && node ../scripts/with-root-env.mjs npx convex run publicSeed:seedPublicDatasets
 
 down: stop-local-keychain


### PR DESCRIPTION
## What

The repo references a `.env.example` file that doesn't exist anywhere in the tree (`git ls-files` / `find` confirm it's not tracked or present). The README was refactored so `make dev` auto-creates a local `.env` (the `validate-dev-env` target in `makefiles/Makefile`), and the top-level README no longer mentions a template to copy — but six stale references were left behind:

- `CLAUDE.md` — Setup step 1: "Copy `.env.example` to `.env`"
- `backend/CLAUDE.md` — "Required env vars (see `.env.example`)"
- `backend/README.md` — `cp .env.example .env`
- `makefiles/Makefile` — three error messages (`convex-env`, `convex-push`, `seed-public-datasets`): `Error: .env not found. Run: cp .env.example .env`

## Why

A new contributor following the setup instructions, or running `make convex-push` / `make seed-public-datasets` standalone before `make dev`, hits an instruction telling them to copy a file that doesn't exist.

## Change

Point every reference at the actual flow: `make dev` auto-creates a local `.env`. Docs-and-strings only — no behavior change.

## Verification

- `grep -rn "env.example"` over the tree returns no matches after the change.
- `make -n` parses the Makefile cleanly.